### PR TITLE
@ClassRule support in WireMockRule

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -112,6 +112,10 @@ public class WireMockServer {
 			throw new RuntimeException(e);
 		}
 	}
+	
+    public boolean isRunning() {
+        return jettyServer != null && jettyServer.isRunning();
+    }
 
     @SuppressWarnings({"rawtypes", "unchecked" })
     private void addMockServiceContext() {

--- a/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
@@ -16,41 +16,57 @@
 package com.github.tomakehurst.wiremock.junit;
 
 import org.junit.rules.MethodRule;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
-public class WireMockRule implements MethodRule {
-	
-	private int port;
-	
-	public WireMockRule(int port) {
-		this.port = port;
-	}
-	
-	public WireMockRule() {
-		this(WireMockServer.DEFAULT_PORT);
-	}
+public class WireMockRule implements MethodRule, TestRule {
 
-	@Override
-	public Statement apply(final Statement base, FrameworkMethod method, Object target) {
-		return new Statement() {
+    private int port;
+    private final WireMockServer wireMockServer;
 
-			@Override
-			public void evaluate() throws Throwable {
-				WireMockServer wireMockServer = new WireMockServer(port);
-				wireMockServer.start();
-				WireMock.configureFor("localhost", port);
-				try {
-                    base.evaluate();
-                } finally {
-                    wireMockServer.stop();
+    public WireMockRule(int port) {
+        this.port = port;
+        this.wireMockServer = new WireMockServer(port);
+    }
+
+    public WireMockRule() {
+        this(WireMockServer.DEFAULT_PORT);
+    }
+
+    @Override
+    public Statement apply(final Statement base, FrameworkMethod method, Object target) {
+        return apply(base, null);
+    }
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                if (wireMockServer.isRunning()) {
+                    try {
+                        base.evaluate();
+                    } finally {
+                        WireMock.reset();
+                    }
+                } else {
+                    wireMockServer.start();
+                    WireMock.configureFor("localhost", port);
+                    try {
+                        base.evaluate();
+                    } finally {
+                        wireMockServer.stop();
+                    }
                 }
-			}
-			
-		};
-	}
+            }
+
+        };
+    }
 
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
@@ -15,43 +15,77 @@
  */
 package com.github.tomakehurst.wiremock;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 
+@RunWith(Enclosed.class)
 public class WireMockJUnitRuleTest {
 
-	@Rule
-	public WireMockRule wireMockRule = new WireMockRule(8089);
+    public static class BasicWireMockRule {
+    
+    	@Rule
+    	public WireMockRule wireMockRule = new WireMockRule(8089);
 	
-	@Test
-	public void canRegisterStubAndFetchOnCorrectPort() {
-		givenThat(get(urlEqualTo("/rule/test")).willReturn(aResponse().withBody("Rule test body")));
-		
-		WireMockTestClient testClient = new WireMockTestClient(8089);
-		
-		assertThat(testClient.get("/rule/test").content(), is("Rule test body"));
-	}
-
-    @Ignore("Generates a failure to illustrate a Rule bug whereby a failed test would cause BindExceptions on subsequent (otherwise passing) tests")
-    @Test
-    public void fail() {
-        assertTrue(false);
+    	@Test
+    	public void canRegisterStubAndFetchOnCorrectPort() {
+    		givenThat(get(urlEqualTo("/rule/test")).willReturn(aResponse().withBody("Rule test body")));
+    		
+    		WireMockTestClient testClient = new WireMockTestClient(8089);
+    		
+    		assertThat(testClient.get("/rule/test").content(), is("Rule test body"));
+    	}
+    	
     }
+    
+    public static class WireMockRuleFailThenPass {
+        
+        @Ignore("Generates a failure to illustrate a Rule bug whereby a failed test would cause BindExceptions on subsequent (otherwise passing) tests")
+        @Test
+        public void fail() {
+            assertTrue(false);
+        }
+    
+        @Test
+        public void succeed() {
+            assertTrue(true);
+        }
+        
+    }
+    
+    public static class WireMockRuleAsClassRule {
+        
+        @ClassRule
+        @Rule
+        public static WireMockRule wireMockRule = new WireMockRule(8089);
+        
+        @Test
+        public void testStubAndFetchOnce() {
+            assertCanRegisterStubAndFetchOnCorrectPort();
+        }
+        
+        @Test
+        public void testStubAndFetchAgain() {
+            assertCanRegisterStubAndFetchOnCorrectPort();
+        }
+    
+        public void assertCanRegisterStubAndFetchOnCorrectPort() {
+            givenThat(get(urlEqualTo("/rule/test")).willReturn(aResponse().withBody("Rule test body")));
+            
+            WireMockTestClient testClient = new WireMockTestClient(8089);
+            
+            assertThat(testClient.get("/rule/test").content(), is("Rule test body"));
+        }
 
-    @Test
-    public void succeed() {
-        assertTrue(true);
     }
 }


### PR DESCRIPTION
As of version 4.9, JUnit has `@ClassRule`, in addition to `@Rule`, allowing you to create rules that run once per class. WireMockStaticRule basically simulates this at the moment, but requires you to manually add an `@AfterClass` method that stops the server, since it can't understand the actual test class context to know when all tests are completed. WireMockStaticRule also has to do that start and WireMock.configure() in its constructor, rather than on application, which seemed a bit nasty.

With this patch, you can instead just write:

```
@ClassRule 
@Rule 
public static WireMockRule rule = new WireMockRule();
```

And it'll start and stop a wiremock once only per test class, and reset the wiremock between tests. In addition the current main use case:

```
@Rule 
public WireMockRule rule = new WireMockRule();
```

Still works as it does now; creating, starting & stopping a fresh wiremock for each test.

Hopefully all fairly straight-forward, and this made my life a little tidier, so I thought I'd push it back. 

The tests are a little ropey, in that they're really only checking it doesn't explode, not that it's only using one instance or that it's correctly stopping the wiremock, but I can't think of any sensible way of doing otherwise. Suggestions welcomed! Meanwhile I've also slightly tidied up that test class into inner classes, to make the rules independent between tests.

Another note: WireMockRule now implements TestRule, in addition to MethodRule. These are both basically the same, but MethodRule is deprecated (replaced by TestRule), and rules are required to implement TestRule instead if they want to support, for example, @ClassRule. If you're happy dropping support for rules in JUnit < 4.9 you can trivially switch over to just using the TestRule interface, but for now I've left both in.
