### PR TITLE
Jackson upgrade to 2.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,9 @@ configurations {
 dependencies {
 	compile "org.mortbay.jetty:jetty:6.1.26"
 	compile "com.google.guava:guava:13.0.1"
-	compile "org.codehaus.jackson:jackson-core-asl:1.9.12", "org.codehaus.jackson:jackson-mapper-asl:1.9.12"
+	compile "com.fasterxml.jackson.core:jackson-core:2.1.2", 
+        	"com.fasterxml.jackson.core:jackson-annotations:2.1.2", 
+        	"com.fasterxml.jackson.core:jackson-databind:2.1.2"
 	compile "org.apache.httpcomponents:httpclient:4.1.2"
 	compile "log4j:log4j:1.2.16"
 	compile "net.sf.jopt-simple:jopt-simple:4.3"

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
@@ -15,10 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.map.ObjectMapper;
-
 import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public final class Json {
 	
@@ -37,7 +37,7 @@ public final class Json {
 	public static <T> String write(T object) {
 		try {
 			ObjectMapper mapper = new ObjectMapper();
-			return mapper.defaultPrettyPrintingWriter().writeValueAsString(object);
+			return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
 		} catch (IOException ioe) {
 			throw new RuntimeException("Unable to generate JSON from object. Reason: " + ioe.getMessage(), ioe);
 		}

--- a/src/main/java/com/github/tomakehurst/wiremock/global/GlobalSettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/global/GlobalSettings.java
@@ -15,8 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.global;
 
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
 
 @JsonSerialize(include=Inclusion.NON_NULL)
 public class GlobalSettings {

--- a/src/main/java/com/github/tomakehurst/wiremock/global/RequestDelaySpec.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/global/RequestDelaySpec.java
@@ -15,8 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.global;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class RequestDelaySpec {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
@@ -15,20 +15,20 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import static com.google.common.collect.Iterables.transform;
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Sets.newHashSet;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 
 @JsonSerialize(using = HttpHeadersJsonSerializer.class)
 @JsonDeserialize(using = HttpHeadersJsonDeserializer.class)

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeadersJsonDeserializer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeadersJsonDeserializer.java
@@ -15,25 +15,25 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
+import static com.google.common.collect.Iterables.transform;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 
-import static com.google.common.collect.Iterables.transform;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
 
 public class HttpHeadersJsonDeserializer extends JsonDeserializer<HttpHeaders> {
 
     @Override
     public HttpHeaders deserialize(JsonParser parser, DeserializationContext context) throws IOException {
         JsonNode rootNode = parser.readValueAsTree();
-        return new HttpHeaders(transform(all(rootNode.getFields()), toHttpHeaders()));
+        return new HttpHeaders(transform(all(rootNode.fields()), toHttpHeaders()));
     }
 
     private static Function<Map.Entry<String, JsonNode>, HttpHeader> toHttpHeaders() {
@@ -43,9 +43,9 @@ public class HttpHeadersJsonDeserializer extends JsonDeserializer<HttpHeaders> {
                 String key = field.getKey();
                 if (field.getValue().isArray()) {
                     return new HttpHeader(key,
-                            ImmutableList.copyOf(transform(all(field.getValue().getElements()), toStringValues())));
+                            ImmutableList.copyOf(transform(all(field.getValue().elements()), toStringValues())));
                 } else {
-                    return new HttpHeader(key, field.getValue().getTextValue());
+                    return new HttpHeader(key, field.getValue().textValue());
                 }
             }
         };
@@ -54,7 +54,7 @@ public class HttpHeadersJsonDeserializer extends JsonDeserializer<HttpHeaders> {
     private static Function<JsonNode, String> toStringValues() {
         return new Function<JsonNode, String>() {
             public String apply(JsonNode node) {
-                return node.getTextValue();
+                return node.textValue();
             }
         };
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeadersJsonSerializer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeadersJsonSerializer.java
@@ -15,11 +15,11 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.map.JsonSerializer;
-import org.codehaus.jackson.map.SerializerProvider;
-
 import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 
 public class HttpHeadersJsonSerializer extends JsonSerializer<HttpHeaders> {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
@@ -15,8 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonValue;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum RequestMethod {
 	GET, POST, PUT, DELETE, OPTIONS, HEAD, TRACE, ANY;

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -15,18 +15,20 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import com.github.tomakehurst.wiremock.common.Json;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import static com.google.common.base.Charsets.UTF_8;
+import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static javax.xml.bind.DatatypeConverter.parseBase64Binary;
+import static javax.xml.bind.DatatypeConverter.printBase64Binary;
 
 import java.nio.charset.Charset;
 
-import static com.google.common.base.Charsets.UTF_8;
-import static java.net.HttpURLConnection.*;
-import static javax.xml.bind.DatatypeConverter.parseBase64Binary;
-import static javax.xml.bind.DatatypeConverter.printBase64Binary;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
+import com.github.tomakehurst.wiremock.common.Json;
 
 @JsonSerialize(include=Inclusion.NON_NULL)
 public class ResponseDefinition {

--- a/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockClassRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockClassRule.java
@@ -1,12 +1,13 @@
 package com.github.tomakehurst.wiremock.junit;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 
 public class WireMockClassRule implements MethodRule, TestRule {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -15,6 +15,22 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
+import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.ANY;
+import static com.github.tomakehurst.wiremock.matching.ValuePattern.matching;
+import static com.google.common.collect.Iterables.all;
+import static com.google.common.collect.Iterables.any;
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.size;
+import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Maps.newLinkedHashMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.Request;
@@ -22,18 +38,6 @@ import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
-import static com.github.tomakehurst.wiremock.http.RequestMethod.ANY;
-import static com.github.tomakehurst.wiremock.matching.ValuePattern.matching;
-import static com.google.common.collect.Iterables.*;
-import static com.google.common.collect.Maps.newLinkedHashMap;
 
 @JsonSerialize(include=Inclusion.NON_NULL)
 public class RequestPattern {

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/ValuePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/ValuePattern.java
@@ -15,13 +15,13 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import com.google.common.base.Predicate;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import static java.util.regex.Pattern.DOTALL;
 
 import java.util.regex.Pattern;
 
-import static java.util.regex.Pattern.DOTALL;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
+import com.google.common.base.Predicate;
 
 @JsonSerialize(include=Inclusion.NON_NULL)
 public class ValuePattern {

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
@@ -15,13 +15,13 @@
  */
 package com.github.tomakehurst.wiremock.stubbing;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 
 @JsonSerialize(include=Inclusion.NON_NULL)
 @JsonPropertyOrder({ "request", "response" })

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/FindRequestsResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/FindRequestsResult.java
@@ -15,10 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.verification;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class FindRequestsResult {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -15,16 +15,20 @@
  */
 package com.github.tomakehurst.wiremock.verification;
 
-import com.github.tomakehurst.wiremock.http.*;
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonProperty;
+import static com.github.tomakehurst.wiremock.http.HttpHeaders.copyOf;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Set;
 
-import static com.github.tomakehurst.wiremock.http.HttpHeaders.copyOf;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
 
 public class LoggedRequest implements Request {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/Examples.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/Examples.java
@@ -15,19 +15,35 @@
  */
 package com.github.tomakehurst.wiremock;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.findAll;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.notMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+
 import com.github.tomakehurst.wiremock.client.VerificationException;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import org.junit.Test;
-
-import java.util.List;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 
 public class Examples extends AcceptanceTestBase {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -15,21 +15,32 @@
  */
 package com.github.tomakehurst.wiremock;
 
-import com.github.tomakehurst.wiremock.http.Fault;
-import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.notMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.apache.http.MalformedChunkCodingException;
 import org.apache.http.NoHttpResponseException;
 import org.apache.http.client.ClientProtocolException;
 import org.junit.Test;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
-import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
-import static java.net.HttpURLConnection.HTTP_OK;
-import static junit.framework.Assert.assertTrue;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 
 public class StubbingAcceptanceTest extends AcceptanceTestBase {
 	

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
@@ -26,13 +26,6 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import com.github.tomakehurst.wiremock.core.Admin;
-import com.github.tomakehurst.wiremock.global.GlobalSettings;
-import com.github.tomakehurst.wiremock.global.RequestDelayControl;
-import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
-import com.github.tomakehurst.wiremock.http.Request;
-import com.github.tomakehurst.wiremock.http.Response;
-import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
@@ -40,10 +33,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.github.tomakehurst.wiremock.global.GlobalSettingsHolder;
-import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.global.GlobalSettings;
+import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
 import com.github.tomakehurst.wiremock.http.BasicResponseRenderer;
-import com.github.tomakehurst.wiremock.verification.RequestJournal;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.http.Response;
+import com.github.tomakehurst.wiremock.matching.RequestPattern;
 
 @RunWith(JMock.class)
 public class AdminRequestHandlerTest {

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -20,11 +20,6 @@ import static com.github.tomakehurst.wiremock.http.Response.response;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalToJson;
 import static com.google.common.base.Charsets.UTF_8;
 
-import com.github.tomakehurst.wiremock.core.Admin;
-import com.github.tomakehurst.wiremock.http.HttpHeaders;
-import com.github.tomakehurst.wiremock.http.Request;
-import com.github.tomakehurst.wiremock.http.Response;
-import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
@@ -34,9 +29,13 @@ import org.junit.runner.RunWith;
 
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.common.IdGenerator;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
+import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.http.Response;
+import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder;
-import com.github.tomakehurst.wiremock.verification.RequestJournal;
 
 @RunWith(JMock.class)
 public class StubMappingJsonRecorderTest {


### PR DESCRIPTION
This patch upgrades Jackson all the way from 1.8.5 (released mid-2011) to 2.1.2 (released December 2012). Depending on this quite old version of Jackson has been making some recent work with Wiremock very inconvenient, so I've fixed it.

There's are very few substantial changes required outside of import renaming, with one notable exclusion: upgrading past 1.9.0 made ResponseDefinition hit [JACKSON-783](http://jira.codehaus.org/browse/JACKSON-783). This bug/feature means if you have two overloaded methods for the same property (here `setBody(String)` & `setBody(byte[])`), and you mark one as ignored, both are ignored, which differs from pre-1.9 behaviour, and breaks _everything_. setBody(String) is now explicitly marked as a `@JsonProperty`, thereby solving this.
