### PR TITLE
Update getting-started.rst

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -70,7 +70,6 @@ If you want the server to continue to run between test cases (JUnit 4.9 and newe
 .. code-block:: java
 
     @ClassRule
-    @Rule
     public static WireMockClassRule wireMockRule = new WireMockClassRule(8089);
 
 


### PR DESCRIPTION
@Rule must be removed when using @ClassRule otherwise server is started twice and port already in use exception is thrown
