### PR TITLE
Improved support for the charset parameter on Content-Type headers.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
@@ -41,11 +41,11 @@ public class ContentTypeHeader extends HttpHeader {
 	}
 	
 	public Optional<String> encodingPart() {
-	    for( int i = 1; i < parts.length; i++ ) {
-	        if( parts[i].matches("\\s*charset\\s*=.*") ) {
-	            return Optional.of(parts[i].split("=")[1]);
-	        }
-	    }
-        return Optional.absent();
+		for( int i = 1; i < parts.length; i++ ) {
+			if( parts[i].matches("\\s*charset\\s*=.*") ) {
+				return Optional.of(parts[i].split("=")[1]);
+			}
+		}
+		return Optional.absent();
 	}
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
@@ -55,10 +55,10 @@ public class ContentTypeHeaderTest {
 	
 	@Test
 	public void returnsCharsetWhenNotFirstParameter() {
-	    ContentTypeHeader header = new ContentTypeHeader("text/plain; param=value; charset=utf-8");
-	    Optional<String> encoding = header.encodingPart();
-	    assertTrue(encoding.isPresent());
-	    assertThat(encoding.get(), is("utf-8"));
+		ContentTypeHeader header = new ContentTypeHeader("text/plain; param=value; charset=utf-8");
+		Optional<String> encoding = header.encodingPart();
+		assertTrue(encoding.isPresent());
+		assertThat(encoding.get(), is("utf-8"));
 	}
 	
 	@Test


### PR DESCRIPTION
- charset can now be missing when other parameters are supplied.
- charset no longer needs to be the first parameter.
