### PR TITLE
Allow stubbing and verification via the junit rules when binding to any available port

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockClassRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockClassRule.java
@@ -35,12 +35,11 @@ public class WireMockClassRule implements MethodRule, TestRule, Stubbing {
 
     private final Options options;
     private final WireMockServer wireMockServer;
-    private final WireMock wireMock;
+    private WireMock wireMock;
 
     public WireMockClassRule(Options options) {
         this.options = options;
         this.wireMockServer = new WireMockServer(options);
-        this.wireMock = new WireMock("localhost", options.portNumber());
     }
 
     public WireMockClassRule(int port, Integer httpsPort) {
@@ -74,7 +73,8 @@ public class WireMockClassRule implements MethodRule, TestRule, Stubbing {
                     }
                 } else {
                     wireMockServer.start();
-                    WireMock.configureFor("localhost", options.portNumber());
+                    wireMock = new WireMock("localhost", port());
+                    WireMock.configureFor("localhost", port());
                     try {
                         base.evaluate();
                     } finally {

--- a/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
@@ -34,13 +34,12 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 public class WireMockRule implements MethodRule, TestRule, Stubbing {
 
     private final Options options;
-    private final WireMock wireMock;
+    private WireMock wireMock;
 
     private WireMockServer wireMockServer;
 
     public WireMockRule(Options options) {
         this.options = options;
-        this.wireMock = new WireMock("localhost", options.portNumber());
     }
 
     public WireMockRule(int port) {
@@ -68,7 +67,8 @@ public class WireMockRule implements MethodRule, TestRule, Stubbing {
 			public void evaluate() throws Throwable {
 				wireMockServer = new WireMockServer(options);
 				wireMockServer.start();
-				WireMock.configureFor("localhost", options.portNumber());
+				WireMock.configureFor("localhost", port());
+                wireMock = new WireMock("localhost", port());
 				try {
                     base.evaluate();
                 } finally {

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
@@ -135,9 +135,14 @@ public class WireMockJUnitRuleTest {
         @ClassRule
         public static WireMockClassRule serviceTwo = new WireMockClassRule(wireMockConfig().port(9092));
         @Rule
-        public static WireMockRule serviceThree = new WireMockRule(wireMockConfig().port(9093));
+        public WireMockRule serviceThree = new WireMockRule(wireMockConfig().port(9093));
         @Rule
-        public static WireMockRule serviceFour = new WireMockRule(wireMockConfig().port(9094));
+        public WireMockRule serviceFour = new WireMockRule(wireMockConfig().port(9094));
+
+        @Rule
+        public WireMockRule portZeroRule = new WireMockRule(wireMockConfig().port(0));
+        @Rule
+        public WireMockClassRule portZeroClassRule = new WireMockClassRule(wireMockConfig().port(0));
 
         @Test
         public void canStubAndVerifyMultipleWireMockRulesWithoutInterferenceBetweenRuleInstances() {
@@ -150,6 +155,15 @@ public class WireMockJUnitRuleTest {
             stubIsCalledAndResponseIsCorrect(serviceTwo, 9092, "service two");
             stubIsCalledAndResponseIsCorrect(serviceThree, 9093, "service three");
             stubIsCalledAndResponseIsCorrect(serviceFour, 9094, "service four");
+        }
+
+        @Test
+        public void canStubOnPortZero() {
+            setupStubbing(portZeroRule, "port zero rule");
+            setupStubbing(portZeroClassRule, "port zero class rule");
+
+            stubIsCalledAndResponseIsCorrect(portZeroRule, portZeroRule.port(), "port zero rule");
+            stubIsCalledAndResponseIsCorrect(portZeroClassRule, portZeroClassRule.port(), "port zero class rule");
         }
 
         private void setupStubbing(Stubbing stubbing, String body) {


### PR DESCRIPTION
This fixes an issue I introduced with the ability to bind to any available port. I've also added tests that show the issue.
