### PR TITLE
Update docs with reference to wiremock-php

### DIFF
--- a/_sources/index.txt
+++ b/_sources/index.txt
@@ -39,6 +39,12 @@ Here are some alternative JVM based libraries with similar goals:
 * `Betamax <http://freeside.co/betamax/>`_
 * `REST-driver <https://github.com/rest-driver/rest-driver>`_
 
+You say I can use languages other than Java - are there libraries for that?
+---------------------------------------------------------------------------
+
+There are some third-party libraries that wrap up the JSON API in a more convenient language binding:
+
+* `wiremock-php <https://github.com/rowanhill/wiremock-php>`_
 
 Contributors
 ------------

--- a/index.html
+++ b/index.html
@@ -119,6 +119,13 @@ environments.</p>
 <li><a class="reference external" href="https://github.com/rest-driver/rest-driver">REST-driver</a></li>
 </ul>
 </div>
+<div class="section" id="you-say-i-can-use-languages-other-than-java---are-there-libraries-for-that">
+<h2>You say I can use languages other than Java - are there libraries for that?<a class="headerlink" href="#you-say-i-can-use-languages-other-than-java---are-there-libraries-for-that" title="Permalink to this headline">¶</a></h2>
+<p>There are some third-party libraries that wrap up the JSON API in a more convenient language binding:</p>
+<ul class="simple">
+<li><a class="reference external" href="https://github.com/rowanhill/wiremock-php">wiremock-php</a></li>
+</ul>
+</div>
 <div class="section" id="contributors">
 <h2>Contributors<a class="headerlink" href="#contributors" title="Permalink to this headline">¶</a></h2>
 <p>Shouts to the following folks who&#8217;ve been kind enough to submit improvements:</p>


### PR DESCRIPTION
Hi,

I've been using WireMock recently (thanks - it's great!), both from Java and PHP. Mostly as a convenience for myself, I've started to write a PHP port of the Java API (making calls to the JSON API behind the scenes).

It's early days yet (I hope to add many more features), but you can see what I have so far at https://github.com/rowanhill/wiremock-php - it's pretty closely based on the Java implementation. There's a fair way to go, but the basics of stubbing and verifying are there.

I thought other people in my position (i.e. wanting to use WireMock from PHP) might want to know about the library (if only as a starting point, if it doesn't do what they want yet), so I was hoping to add it to a new section in the WireMock docs. Hopefully that's not too presumptuous! Perhaps if any other language bindings are known, they could be added in, too?

Embarrassingly, I'm not sure how you've been generating your pages, so I've just made these minor additions by hand - if you'd rather I follow some automated generation process, let me know how and I'll have a go and resubmit the pull request.

Thanks!
Rowan
