### PR TITLE
add JSON matching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
         	"com.fasterxml.jackson.core:jackson-annotations:2.1.2", 
         	"com.fasterxml.jackson.core:jackson-databind:2.1.2"
 	compile "org.apache.httpcomponents:httpclient:4.2.3"
+    compile "org.skyscreamer:jsonassert:1.2.1"
     compile "com.jayway.jsonpath:json-path:0.8.1"
 	compile "log4j:log4j:1.2.16"
 	compile "net.sf.jopt-simple:jopt-simple:4.3"

--- a/src/main/java/com/github/tomakehurst/wiremock/client/ValueMatchingStrategy.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ValueMatchingStrategy.java
@@ -23,6 +23,7 @@ import java.util.List;
 public class ValueMatchingStrategy {
 
 	private String equalTo;
+	private String equalToJson;
 	private String matches;
 	private String doesNotMatch;
 	private String contains;
@@ -31,6 +32,7 @@ public class ValueMatchingStrategy {
 	public ValuePattern asValuePattern() {
 		ValuePattern pattern = new ValuePattern();
 		pattern.setEqualTo(equalTo);
+		pattern.setEqualToJson(equalToJson);
 		pattern.setMatches(matches);
 		pattern.setDoesNotMatch(doesNotMatch);
 		pattern.setContains(contains);
@@ -52,6 +54,14 @@ public class ValueMatchingStrategy {
 		}
 	};
 	
+	public String getEqualToJson() {
+        return equalToJson;
+    }
+
+    public void setEqualToJson(String equalToJson) {
+        this.equalToJson = equalToJson;
+    }
+
 	public String getEqualTo() {
 		return equalTo;
 	}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -131,6 +131,12 @@ public class WireMock {
 		return headerStrategy;
 	}
 	
+    public static ValueMatchingStrategy equalToJson(String value) {
+        ValueMatchingStrategy headerStrategy = new ValueMatchingStrategy();
+        headerStrategy.setEqualToJson(value);
+        return headerStrategy;
+    }
+    
 	public static ValueMatchingStrategy containing(String value) {
 		ValueMatchingStrategy headerStrategy = new ValueMatchingStrategy();
 		headerStrategy.setContains(value);

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/ValuePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/ValuePatternTest.java
@@ -81,6 +81,20 @@ public class ValuePatternTest {
     }
 
     @Test
+    public void matchesOnIsEqualToJson() {
+        valuePattern.setEqualToJson("{\"x\":0}");
+        assertTrue("Expected exact match", valuePattern.isMatchFor("{\"x\":0}"));
+        assertTrue("Expected number json match", valuePattern.isMatchFor("{\"x\":0.0}"));
+    }
+    
+    @Test
+    public void matchesOnIsEqualToJsonMoveFields() {
+        valuePattern.setEqualToJson("{\"x\":0,\"y\":1}");
+        assertTrue("Expected exact match", valuePattern.isMatchFor("{\"x\":0,\"y\":1}"));
+        assertTrue("Expected move field json match", valuePattern.isMatchFor("{\"y\":1,\"x\":0.0}"));
+    }
+    
+    @Test
     public void matchesOnBasicJsonPaths() {
         valuePattern.setMatchesJsonPaths("$.one");
         assertTrue("Expected match when JSON attribute is present", valuePattern.isMatchFor("{ \"one\": 1 }"));


### PR DESCRIPTION
I added equalToJson matching method for incoming JSON body types. I am not sure if this was done yet. We needed it badly. 
JSON matching is defined as lenient. Meaning field order does not matter. Just that is it present in the JSON.
Since I did it on windows it looks like the diffs have hard time with line endings.
There really are not that many changes to the code. 
Would be good if something  like this was in the main branch.
