### PR TITLE
Fix intermittent StandaloneAcceptanceTest#canBeShutDownRemote() test

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -197,7 +197,7 @@ public class WireMockServer implements Container {
                     // We have to sleep briefly to finish serving the shutdown request before stopping the server, as
                     // there's no support in Jetty for shutting down after the current request.
                     // See http://stackoverflow.com/questions/4650713
-                    Thread.sleep(500);
+                    Thread.sleep(100);
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -78,6 +78,10 @@ public class WireMockServerRunner {
 		wireMockServer.stop();
 	}
 
+    public boolean isRunning() {
+        return wireMockServer.isRunning();
+    }
+
 	public static void main(String... args) {
 		new WireMockServerRunner().run(new SingleRootFileSource("."), args);
 	}

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -32,7 +32,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -55,9 +54,6 @@ public class StandaloneAcceptanceTest {
 	private static final String MAPPINGS = "mappings";
 
     private static final File FILE_SOURCE_ROOT = new File("build/standalone-files");
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
 	private WireMockServerRunner runner;
 	private WireMockTestClient testClient;
@@ -279,13 +275,14 @@ public class StandaloneAcceptanceTest {
 
         WireMock.shutdownServer();
 
-        // Keep trying the server until it shuts down, at which point an exception will be thrown. If the server does
-        // not shut down, no exception will be thrown, and the test will fail.
-        expectedException.expect(causedByHttpHostConnectException());
+        // Keep trying the server until it shuts down.
         long startTime = System.currentTimeMillis();
         while (System.currentTimeMillis() - startTime < 5000) {
-            testClient.get("/__admin");
+            if (!runner.isRunning()) {
+                return;
+            }
         }
+        fail("WireMock did not shut down");
     }
 
     private String contentsOfFirstFileNamedLike(String namePart) throws IOException {


### PR DESCRIPTION
Hi,

Following on from #79, I think this should fix the intermittent test that accidentally added.

I'd previously been thinking I must have introduced some horrid threading issue that was interacting with Jetty in some way, but on taking a step back I realised it probably wasn't that complicated: the test repeatedly polled WireMock over HTTP asking for it's status (/__admin), but Jetty's shutdown isn't graceful, so sometimes the requests would get picked up by Jetty, but then not serviced (because Jetty shut down in that instant), leaving the test client to timeout.

Things this patch does:
- Reduces the sleep time of the graceful shutdown thread to 100ms - empirically, this appears to be more than enough, so we may as well keep it nice and small.
- Exposes the WireMockServer's isRunning() state on WireMockServerRunner. This is purely for the benefit of the tests, but I'm assuming this is okay, because a) it's already been done (c.f. run() and stop()), and b) the only code that should have a reference to WireMockServerRunner is the tests.
- Tests the newly exposed isRunning() method, rather than going over HTTP, removing the opportunity for an HTTP request to time out.

Things this patch does NOT do:
- Remove the (fairly small, I think) chance that when WireMock is shutdown (via any mechanism, not just the remote shutdown command) a request might time out.

Hopefully that's acceptable. Also, can you sanity check my above argument - I'm fairly confident in it, but I've been wrong here once before, so it's worth double checking my thinking! :)

Thanks,
Rowan
