### PR TITLE
Add acceptance test around requiring scenario states with no scenario name

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
@@ -69,6 +69,9 @@ public class MappingBuilder {
 	}
 	
 	public StubMapping build() {
+		if (scenarioName == null && (requiredScenarioState != null || newScenarioState != null)) {
+			throw new IllegalStateException("Scenario name must be specified to require or set a new scenario state");
+		}
 		RequestPattern requestPattern = requestPatternBuilder.build();
 		ResponseDefinition response = responseDefBuilder.build();
 		StubMapping mapping = new StubMapping(requestPattern, response);

--- a/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
@@ -90,23 +90,17 @@ public class ScenarioAcceptanceTest extends AcceptanceTestBase {
 		assertThat(testClient.get("/stateful/resource").content(), is("Expected content"));
 	}
 
-    @Test
-    public void scenarioStateRequirementsAreIgnoredIfScenarioIsNotNamed() {
+    @Test(expected = IllegalStateException.class)
+    public void scenarioStateCannotBeSetIfScenarioIsNotNamed() {
         givenThat(get(urlEqualTo("/some/resource"))
                 .willReturn(aResponse().withBody("Initial"))
                 .whenScenarioStateIs(STARTED));
+    }
 
+    @Test(expected = IllegalStateException.class)
+    public void scenarioStateTransitionCannotBeSetIfScenarioIsNotNamed() {
         givenThat(put(urlEqualTo("/some/resource"))
                 .willReturn(aResponse().withStatus(HTTP_OK))
-                .willSetStateTo("BodyModified")
-                .whenScenarioStateIs(STARTED));
-
-        givenThat(get(urlEqualTo("/some/resource"))
-                .willReturn(aResponse().withBody("Modified"))
-                .whenScenarioStateIs("BodyModified"));
-
-        assertThat(testClient.get("/some/resource").content(), is("Modified"));
-        testClient.put("/some/resource");
-        assertThat(testClient.get("/some/resource").content(), is("Modified"));
+                .willSetStateTo("BodyModified"));
     }
 }


### PR DESCRIPTION
Hi,

As I was implementing scenarios support in wiremock-php, I realised I wasn't sure what would happen if I used whenScenarioStateIs() without also using inScenario(), so I wrote a quick test to be sure: it turns out the whenScenarioStateIs calls are effectively ignored. I thought it might be worth contributing to document the behaviour.

It might also be worth noting in the documentation?

Alternatively, MappingBuilder#build might want to ensure a scenarioName is set if requiredScenarioState or newScenarioState and throw an exception otherwise? That's the approach I've taken in wiremock-php. I'd be happy to put in a PR to that effect if you'd like.

Rowan
