### PR TITLE
Add a method `addMockServiceRequestListener`

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
@@ -20,6 +20,7 @@ import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.RequestPatternBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.RequestListener;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
@@ -78,6 +79,32 @@ public class WireMockRule implements MethodRule, TestRule, Stubbing {
 			
 		};
 	}
+
+    /**
+     * <p>Add a {@link RequestListener} to the tests {@link WireMockServer}.
+     *
+     * <p><strong>WARNING:</strong> The Request passed to the listener will be scoped within the request and any
+     * information in the request (for example the url) will not exist outside the context of the listener call. What
+     * this means is you can't save the request for later inspection. If this is your intention then 'clone' the
+     * Request using something like:
+     *
+     * <pre><code>
+     *    final List&lt;Request> requests = new ArrayList&lt;Request>();
+     *    rule.addMockServiceRequestListener(new RequestListener() {
+     *       {@code @}Override
+     *        public void requestReceived(Request request, Response response) {
+     *            requests.add(LoggedRequest.createFrom(request));
+     *        }
+     *    });
+     *    // later, after doing the request
+     *    for (Request request : requests) {
+     *        assertNotNull(request.getUrl()); // should pass.
+     *    }
+     * </code></pre>
+     */
+    public void addMockServiceRequestListener(RequestListener requestListener) {
+        wireMockServer.addMockServiceRequestListener(requestListener);
+    }
 
     @Override
     public void givenThat(MappingBuilder mappingBuilder) {


### PR DESCRIPTION
Add a method `addMockServiceRequestListener` which forwards on to the underlying `WireMockServer`.

Update the tests to cover the new method and document it so that common pitfalls are not fallen into.

This fixes #87
