### PR TITLE
change Host header in proxy-all mode.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -15,20 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import com.github.tomakehurst.wiremock.common.ProxySettings;
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
-import org.apache.http.*;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.*;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.entity.StringEntity;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-
 import static com.github.tomakehurst.wiremock.common.HttpClientUtils.getEntityAsByteArrayAndCloseStream;
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
@@ -37,11 +23,38 @@ import static com.github.tomakehurst.wiremock.http.Response.response;
 import static com.google.common.collect.Iterables.transform;
 import static java.util.Arrays.asList;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpTrace;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.entity.StringEntity;
+
+import com.github.tomakehurst.wiremock.common.ProxySettings;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+
 public class ProxyResponseRenderer implements ResponseRenderer {
 
     private static final int MINUTES = 1000 * 60;
     private static final String TRANSFER_ENCODING = "transfer-encoding";
     private static final String CONTENT_LENGTH = "content-length";
+    private static final String HOST = "host";
 
     private final HttpClient client;
 	
@@ -122,7 +135,7 @@ public class ProxyResponseRenderer implements ResponseRenderer {
 	}
 
     private static boolean headerShouldBeTransferred(String key) {
-        return !ImmutableList.of(CONTENT_LENGTH, TRANSFER_ENCODING).contains(key.toLowerCase());
+        return !ImmutableList.of(CONTENT_LENGTH, TRANSFER_ENCODING, HOST).contains(key.toLowerCase());
     }
 
     private static void addBodyIfPostOrPut(HttpRequest httpRequest, ResponseDefinition response) throws UnsupportedEncodingException {


### PR DESCRIPTION
Hi,

First of all, I like this product very much. It exactly what I need for my current project.
Can you look into the following issue:

If you run the standalone version with the --proxy-all option, the 'Host' request header is forwarded to the destination server. In my case this was localhost:8080. The service could not handle this, and came back with an 'unknown route to host' error. The solution  was for me to change the 'Host' header in my firefox rest client to the same host as the destination server.

It would be a nice feature if it is possible in wiremock to control the Host header that is sends to the destination server.
