### PR TITLE
WireMockServerRunner in proxy mode now uses existing recordings

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -67,7 +67,10 @@ public class WireMockServerRunner {
 				requestPattern.setUrlPattern(".*");
 				ResponseDefinition responseDef = new ResponseDefinition();
 				responseDef.setProxyBaseUrl(baseUrl);
-				stubMappings.addMapping(new StubMapping(requestPattern, responseDef));
+
+				StubMapping proxyBasedMapping = new StubMapping(requestPattern, responseDef);
+				proxyBasedMapping.setPriority(StubMapping.DEFAULT_PRIORITY + 100);
+				stubMappings.addMapping(proxyBasedMapping);
 			}
 		});
 	}

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -236,6 +236,21 @@ public class StandaloneAcceptanceTest {
 	}
 
 	@Test
+	public void respondsWithPreExistingRecordingInProxyMode() {
+		writeMappingFile("test-mapping-2.json", BODY_FILE_MAPPING_REQUEST);
+		writeFileToFilesDir("body-test.xml", "Existing recorded body");
+
+		WireMock otherServerClient = start8084ServerAndCreateClient();
+		otherServerClient.register(
+                get(urlEqualTo("/body/file"))
+                        .willReturn(aResponse().withStatus(HTTP_OK).withBody("Proxied body")));
+
+		startRunner("--proxy-all", "http://localhost:8084");
+
+		assertThat(testClient.get("/body/file").content(), is("Existing recorded body"));
+	}
+
+	@Test
 	public void recordsProxiedRequestsWhenSpecifiedOnCommandLine() throws Exception {
 	    WireMock otherServerClient = start8084ServerAndCreateClient();
 		startRunner("--record-mappings");


### PR DESCRIPTION
When the server runner is started in proxy mode with recordings enabled, it does not consider any existing recordings already specified in the mappings folder. It will end up recording latest responses for urls that may already be recorded. This creates multiple recordings and may have unintended effects. The solution in this commit is to de-prioritize the proxy-based stub mapping so that existing recordings (usually with default priority) are looked up first.

Corresponding acceptance test added.
