### PR TITLE
File source root as a command-line option

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.standalone;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.common.*;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.google.common.base.Joiner;
@@ -37,14 +38,12 @@ public class CommandLineOptions implements Options {
 	private static final String VERBOSE = "verbose";
 	private static final String ENABLE_BROWSER_PROXYING = "enable-browser-proxying";
     private static final String DISABLE_REQUEST_JOURNAL = "no-request-journal";
+    private static final String RECORDINGS_PATH = "recordings-path";
 
-    private final FileSource fileSource;
-	private final OptionSet optionSet;
+    private final OptionSet optionSet;
 	private String helpText;
 
-    public CommandLineOptions(FileSource fileSource, String... args) {
-        this.fileSource = fileSource;
-
+    public CommandLineOptions(String... args) {
 		OptionParser optionParser = new OptionParser();
 		optionParser.accepts(PORT, "The port number for the server to listen on").withRequiredArg();
         optionParser.accepts(HTTPS_PORT, "If this option is present WireMock will enable HTTPS on the specified port").withRequiredArg();
@@ -52,6 +51,7 @@ public class CommandLineOptions implements Options {
 		optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
         optionParser.accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests").withRequiredArg();
 		optionParser.accepts(RECORD_MAPPINGS, "Enable recording of all (non-admin) requests as mapping files");
+		optionParser.accepts(RECORDINGS_PATH, "Specifies path for storing recordings (parent for " + WireMockServer.MAPPINGS_ROOT + " and " + WireMockServer.FILES_ROOT + " folders)").withRequiredArg().defaultsTo(".");
 		optionParser.accepts(VERBOSE, "Enable verbose logging to stdout");
 		optionParser.accepts(ENABLE_BROWSER_PROXYING, "Allow wiremock to be set as a browser's proxy server");
         optionParser.accepts(DISABLE_REQUEST_JOURNAL, "Disable the request journal (to avoid heap growth when running wiremock for long periods without reset)");
@@ -70,10 +70,6 @@ public class CommandLineOptions implements Options {
         if (optionSet.has(RECORD_MAPPINGS) && optionSet.has(DISABLE_REQUEST_JOURNAL)) {
             throw new IllegalArgumentException("Request journal must be enabled to record stubs");
         }
-    }
-
-    public CommandLineOptions(String... args) {
-        this(new SingleRootFileSource("."), args);
     }
 
     private void captureHelpTextIfRequested(OptionParser optionParser) {
@@ -160,7 +156,7 @@ public class CommandLineOptions implements Options {
 
     @Override
     public FileSource filesRoot() {
-        return fileSource;
+        return new SingleRootFileSource((String) optionSet.valueOf(RECORDINGS_PATH));
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -18,7 +18,6 @@ package com.github.tomakehurst.wiremock.standalone;
 import com.github.tomakehurst.wiremock.Log4jConfiguration;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.common.FileSource;
-import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
@@ -32,14 +31,15 @@ import static java.lang.System.out;
 public class WireMockServerRunner {
 	private WireMockServer wireMockServer;
 	
-	public void run(FileSource fileSource, String... args) {
-		CommandLineOptions options = new CommandLineOptions(fileSource, args);
+	public void run(String... args) {
+		CommandLineOptions options = new CommandLineOptions(args);
 		if (options.help()) {
 			out.println(options.helpText());
 			return;
 		}
         Log4jConfiguration.configureLogging(options.verboseLoggingEnabled());
-		
+
+		FileSource fileSource = options.filesRoot();
 		fileSource.createIfNecessary();
 		FileSource filesFileSource = fileSource.child(FILES_ROOT);
 		filesFileSource.createIfNecessary();
@@ -81,6 +81,6 @@ public class WireMockServerRunner {
     }
 
 	public static void main(String... args) {
-		new WireMockServerRunner().run(new SingleRootFileSource("."), args);
+		new WireMockServerRunner().run(args);
 	}
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -16,7 +16,6 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
 import com.github.tomakehurst.wiremock.standalone.WireMockServerRunner;
 import com.github.tomakehurst.wiremock.testsupport.MappingJsonSamples;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
@@ -31,12 +30,13 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.*;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -46,6 +46,7 @@ import static com.google.common.io.Files.createParentDirs;
 import static com.google.common.io.Files.write;
 import static java.io.File.separator;
 import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -111,12 +112,20 @@ public class StandaloneAcceptanceTest {
 		"}													";
 	
 	@Test
-	public void readsMapppingFromMappingsDir() {
+	public void readsMappingFromMappingsDir() {
 		writeMappingFile("test-mapping-1.json", MAPPING_REQUEST);
 		startRunner();
 		assertThat(testClient.get("/resource/from/file").content(), is("Body from mapping file"));
 	}
 	
+	@Test
+	public void readsMappingFromSpecifiedRecordingsPath() {
+		String differentRoot = FILE_SOURCE_ROOT + separator + "differentRoot";
+		writeFile(differentRoot + separator + underMappings("test-mapping-1.json"), MAPPING_REQUEST);
+		startRunner("--recordings-path", differentRoot);
+		assertThat(testClient.get("/resource/from/file").content(), is("Body from mapping file"));
+	}
+
 	@Test
 	public void servesFileFromFilesDir() {
 		writeFileToFilesDir("test-1.xml", "<content>Blah</content>");
@@ -127,6 +136,17 @@ public class StandaloneAcceptanceTest {
 		assertThat(response.header("Content-Type"), is("application/xml"));
 	}
 	
+	@Test
+	public void servesFileFromSpecifiedRecordingsPath() {
+		String differentRoot = FILE_SOURCE_ROOT + separator + "differentRoot";
+		writeFile(differentRoot + separator + underFiles("test-1.xml"), "<content>Blah</content>");
+		startRunner("--recordings-path", differentRoot);
+		WireMockResponse response = testClient.get("/test-1.xml");
+		assertThat(response.statusCode(), is(200));
+		assertThat(response.content(), is("<content>Blah</content>"));
+		assertThat(response.header("Content-Type"), is("application/xml"));
+	}
+
 	@Test
 	public void servesFileAsJsonWhenNoFileExtension() {
 		writeFileToFilesDir("json/12345", "{ \"key\": \"value\" }");
@@ -315,48 +335,63 @@ public class StandaloneAcceptanceTest {
     }
 	
 	private void writeFileToFilesDir(String name, String contents) {
-		writeFileUnderFileSourceRoot(FILES + separator + name, contents);
-	}
+		writeFile(underFileSourceRoot(underFiles(name)), contents);
+    }
 
     private void writeFileToFilesDir(String name, byte[] contents) {
-        writeFileUnderFileSourceRoot(FILES + separator + name, contents);
-    }
-	
-	private void writeMappingFile(String name, String contents) {
-		writeFileUnderFileSourceRoot(MAPPINGS + separator + name, contents);
-	}
-	
-	private void writeFileUnderFileSourceRoot(String relativePath, String contents) {
 		try {
-			String filePath = FILE_SOURCE_ROOT + separator + relativePath;
+			String filePath = underFileSourceRoot(underFiles(name));
 			File file = new File(filePath);
 			createParentDirs(file);
-			write(contents, file, Charsets.UTF_8);
+			write(contents, file);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 	}
 
-    private void writeFileUnderFileSourceRoot(String relativePath, byte[] contents) {
+	private void writeMappingFile(String name, String contents) {
+		writeFile(underFileSourceRoot(underMappings(name)), contents);
+	}
+
+	private void writeFile(String absolutePath, String contents) {
         try {
-            String filePath = FILE_SOURCE_ROOT + separator + relativePath;
-            File file = new File(filePath);
+			File file = new File(absolutePath);
             createParentDirs(file);
-            write(contents, file);
+			write(contents, file, Charsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-	private void startRunner(String... args) {
-		runner.run(new SingleRootFileSource(FILE_SOURCE_ROOT.getPath()), args);
+	private String underFiles(String name) {
+		return FILES + separator + name;
 	}
-	
+
+	private String underMappings(String name) {
+		return MAPPINGS + separator + name;
+	}
+
+	private String underFileSourceRoot(String relativePath) {
+		return FILE_SOURCE_ROOT + separator + relativePath;
+	}
+
+	private void startRunner(String... args) {
+		runner.run(argsWithRecordingsPath(args));
+	}
+
+	private String[] argsWithRecordingsPath(String[] args) {
+		List<String> argsAsList = new ArrayList<String>(asList(args));
+		if (!argsAsList.contains("--recordings-path")) {
+			argsAsList.addAll(asList("--recordings-path", FILE_SOURCE_ROOT.getPath()));
+		}
+		return argsAsList.toArray(new String[]{});
+	}
+
 	private void startRecordingSystemOut() {
 		out = new ByteArrayOutputStream();
 		System.setOut(new PrintStream(out));
 	}
-	
+
 	private String systemOutText() {
 		return new String(out.toByteArray());
 	}


### PR DESCRIPTION
Introduced "--recordings-path" as a new command-line option to specify parent folder of "mappings" and "__files" folders. The value defaults to "." (the earlier hardcoded value).

Providing file source root as an option is very helpful to teams who want to manage wiremock recordings, eg. via version-control, sharing across projects or test suites, etc.
