### PR TITLE
Add support for verifying PATCH requests

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -270,6 +270,10 @@ public class WireMock {
 	public static RequestPatternBuilder deleteRequestedFor(UrlMatchingStrategy urlMatchingStrategy) {
 		return new RequestPatternBuilder(RequestMethod.DELETE, urlMatchingStrategy);
 	}
+
+	public static RequestPatternBuilder patchRequestedFor(UrlMatchingStrategy urlMatchingStrategy) {
+		return new RequestPatternBuilder(RequestMethod.PATCH, urlMatchingStrategy);
+	}
 	
 	public static RequestPatternBuilder headRequestedFor(UrlMatchingStrategy urlMatchingStrategy) {
 		return new RequestPatternBuilder(RequestMethod.HEAD, urlMatchingStrategy);

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -16,7 +16,6 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.http.Fault;
-import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.stubbing.ListStubMappingsResult;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
@@ -269,6 +268,16 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
         assertThat(mapping2.getRequest().getMethod(), is(GET));
         assertThat(mapping2.getRequest().getUrl(), is("/stub/one"));
         assertThat(mapping2.getResponse().getBody(), is("One"));
+    }
+
+    @Test
+    public void stubbingPatch() {
+        stubFor(patch(urlEqualTo("/a/registered/resource")).withRequestBody(equalTo("some body"))
+                .willReturn(aResponse().withStatus(204)));
+
+        WireMockResponse response = testClient.patchWithBody("/a/registered/resource", "some body", "text/plain");
+
+        assertThat(response.statusCode(), is(204));
     }
 
 	private void getAndAssertUnderlyingExceptionInstanceClass(String url, Class<?> expectedClass) {

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -23,7 +23,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
@@ -194,6 +193,13 @@ public class VerificationAcceptanceTest {
                         containsString("Requests received: "),
                         containsString("/some/request")));
             }
+        }
+
+        @Test
+        public void verifiesPatchRequests() {
+            testClient.patchWithBody("/patch/this", SAMPLE_JSON, "application/json");
+            verify(patchRequestedFor(urlEqualTo("/patch/this"))
+                    .withRequestBody(matching(".*\"importantKey\": \"Important value\".*")));
         }
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
@@ -20,17 +20,12 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.*;
 import org.apache.http.conn.params.ConnRoutePNames;
-import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.params.HttpParams;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -116,13 +111,23 @@ public class WireMockTestClient {
 	
 	public WireMockResponse putWithBody(String url, String body, String contentType, TestHttpHeader... headers) {
 		HttpPut httpPut = new HttpPut(mockServiceUrlFor(url));
+		return requestWithBody(httpPut, body, contentType, headers);
+	}
+
+	public WireMockResponse patchWithBody(String url, String body, String contentType, TestHttpHeader... headers) {
+		HttpPatch httpPatch = new HttpPatch(mockServiceUrlFor(url));
+		return requestWithBody(httpPatch, body, contentType, headers);
+	}
+
+	private WireMockResponse requestWithBody(
+			HttpEntityEnclosingRequestBase request, String body, String contentType, TestHttpHeader... headers) {
 		try {
-			httpPut.setEntity(new StringEntity(body, contentType, "utf-8"));
+			request.setEntity(new StringEntity(body, contentType, "utf-8"));
 		} catch (UnsupportedEncodingException e) {
 			throw new RuntimeException(e);
 		}
-		
-		return executeMethodAndCovertExceptions(httpPut, headers);
+
+		return executeMethodAndCovertExceptions(request, headers);
 	}
 	
 	public WireMockResponse postWithBody(String url, String body, String bodyMimeType, String bodyEncoding) {


### PR DESCRIPTION
Hi,

Just a small change to add support to verify PATCH requests, as a compliment to recent support for stubbing them (from #93). Unless I'm missing something, I can't see why it PATCH verification support shouldn't exist? I've also added a couple of quick tests.

Thanks,
Rowan
