### PR TITLE
Reset WireMock server instance between tests.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockClassRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockClassRule.java
@@ -69,7 +69,7 @@ public class WireMockClassRule implements MethodRule, TestRule, Stubbing {
                     try {
                         base.evaluate();
                     } finally {
-                        WireMock.reset();
+                        wireMock.resetMappings();
                     }
                 } else {
                     wireMockServer.start();


### PR DESCRIPTION
The Junit WIreMockClassRule only resets the default instance of the wire mock server. I belief this is not the expected behavior if you use more then one WIreMockClassRule in your tests.
