### PR TITLE
Making it possible to specify the address to listen to.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -66,6 +66,7 @@ public class WireMockServer implements Container {
 	private final FileSource fileSource;
 	private final Notifier notifier;
 	private final int port;
+	private final String bindAddress;
 
     private final Options options;
     private DelayableSocketConnector httpConnector;
@@ -75,6 +76,7 @@ public class WireMockServer implements Container {
         this.options = options;
         this.fileSource = options.filesRoot();
         this.port = options.portNumber();
+        this.bindAddress = options.bindAddress();
         this.notifier = options.notifier();
 
         requestDelayControl = new ThreadSafeRequestDelayControl();
@@ -224,6 +226,7 @@ public class WireMockServer implements Container {
 
     private DelayableSocketConnector createHttpConnector() {
         DelayableSocketConnector connector = new DelayableSocketConnector(requestDelayControl);
+        connector.setHost(bindAddress);
         connector.setPort(port);
         connector.setHeaderBufferSize(8192);
         return connector;

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.common.ProxySettings;
 public interface Options {
 
     public static final int DEFAULT_PORT = 8080;
+    public static final String DEFAULT_BIND_ADDRESS = "0.0.0.0";
 
     int portNumber();
     HttpsSettings httpsSettings();
@@ -31,5 +32,6 @@ public interface Options {
     FileSource filesRoot();
     Notifier notifier();
     boolean requestJournalDisabled();
+    public String bindAddress();
 
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -20,6 +20,7 @@ import com.github.tomakehurst.wiremock.common.*;
 public class WireMockConfiguration implements Options {
 
     private int portNumber = DEFAULT_PORT;
+    private String bindAddress = DEFAULT_BIND_ADDRESS;
     private Integer httpsPort = null;
     private String keyStorePath = null;
     private boolean browserProxyingEnabled = false;
@@ -76,6 +77,11 @@ public class WireMockConfiguration implements Options {
         this.notifier = notifier;
         return this;
     }
+    
+    public WireMockConfiguration bindAddress(String bindAddress){
+        this.bindAddress = bindAddress;
+        return this;
+    }
 
     public WireMockConfiguration disableRequestJournal() {
         requestJournalDisabled = true;
@@ -122,5 +128,10 @@ public class WireMockConfiguration implements Options {
 
     public boolean requestJournalDisabled() {
         return requestJournalDisabled;
+    }
+
+    @Override
+    public String bindAddress() {
+        return bindAddress;
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -33,6 +33,7 @@ public class CommandLineOptions implements Options {
 	private static final String PROXY_ALL = "proxy-all";
     private static final String PROXY_VIA = "proxy-via";
 	private static final String PORT = "port";
+        private static final String BIND_ADDRESS = "bind-address";
     private static final String HTTPS_PORT = "https-port";
     private static final String HTTPS_KEYSTORE = "https-keystore";
 	private static final String VERBOSE = "verbose";
@@ -47,6 +48,7 @@ public class CommandLineOptions implements Options {
 		OptionParser optionParser = new OptionParser();
 		optionParser.accepts(PORT, "The port number for the server to listen on").withRequiredArg();
         optionParser.accepts(HTTPS_PORT, "If this option is present WireMock will enable HTTPS on the specified port").withRequiredArg();
+        optionParser.accepts(BIND_ADDRESS, "The IP to listen connections").withRequiredArg();
         optionParser.accepts(HTTPS_KEYSTORE, "Path to an alternative keystore for HTTPS. Must have a password of \"password\".").withRequiredArg();
 		optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
         optionParser.accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests").withRequiredArg();
@@ -105,6 +107,15 @@ public class CommandLineOptions implements Options {
 
         return DEFAULT_PORT;
 	}
+
+    @Override
+    public String bindAddress(){
+	if (optionSet.has(BIND_ADDRESS)) {
+            return (String) optionSet.valueOf(BIND_ADDRESS);
+        }
+
+        return DEFAULT_BIND_ADDRESS;
+    }
 
     @Override
     public HttpsSettings httpsSettings() {

--- a/src/test/java/com/github/tomakehurst/wiremock/BindAddressTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/BindAddressTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2011 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.testsupport.MappingJsonSamples;
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+
+public class BindAddressTest {
+
+    private final int port = 8090;
+    private String localhost = "127.0.0.1";
+    private String nonBindAddress;
+    private WireMockServer wireMockServer;
+
+    @Test
+    public void shouldRespondInTheBindAddressOnly() throws Exception {
+        executeGetIn(localhost);
+        try {
+            executeGetIn(nonBindAddress);
+            Assert.fail("Should not accept the connection in [" + nonBindAddress + "]");
+        } catch (Exception ex) {
+        }
+    }
+
+    @Before
+    public void prepare() throws Exception {
+        nonBindAddress = getIpAddressOtherThan(localhost);
+        if (nonBindAddress == null) {
+            Assert.fail("Impossible to validate the binding address. This machine has only a one Ip address ["
+                    + localhost + "]");
+        }
+
+        WireMockConfiguration cfg = new WireMockConfiguration();
+        cfg.bindAddress(localhost);
+        cfg.port(port);
+
+        wireMockServer = new WireMockServer(cfg);
+        wireMockServer.start();
+    }
+
+    @After
+    public void stop() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    private void executeGetIn(String address) {
+        WireMockTestClient wireMockClient = new WireMockTestClient(port, address);
+        wireMockClient.addResponse(MappingJsonSamples.BASIC_MAPPING_REQUEST_WITH_RESPONSE_HEADER);
+        WireMockResponse response = wireMockClient.get("/a/registered/resource");
+        assertThat(response.statusCode(), is(401));
+    }
+
+    private String getIpAddressOtherThan(String lopbackAddress) throws SocketException {
+        Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+        for (NetworkInterface netInterface : Collections.list(networkInterfaces)) {
+            Enumeration<InetAddress> inetAddresses = netInterface.getInetAddresses();
+            for (InetAddress address : Collections.list(inetAddresses)) {
+                if (address instanceof Inet4Address && !address.getHostAddress().equals(lopbackAddress)) {
+                    return address.getHostAddress();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -75,7 +75,13 @@ public class CommandLineOptionsTest {
 	public void throwsExceptionWhenPortNumberSpecifiedWithoutNumber() {
 		new CommandLineOptions("--port");
 	}
-	
+    
+    @Test
+    public void returnsCorrecteyParsedBindAddress(){
+        CommandLineOptions options = new CommandLineOptions("--bind-address", "127.0.0.1");
+        assertThat(options.bindAddress(), is("127.0.0.1"));
+    }
+    
 	@Test
 	public void setsProxyAllRootWhenOptionPresent() {
 		CommandLineOptions options = new CommandLineOptions("--proxy-all", "http://someotherhost.com/site");

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
@@ -41,15 +41,21 @@ import static java.net.HttpURLConnection.HTTP_OK;
 
 public class WireMockTestClient {
 
-	private static final String LOCAL_WIREMOCK_ROOT = "http://localhost:%d%s";
-	private static final String LOCAL_WIREMOCK_NEW_RESPONSE_URL = "http://localhost:%d/__admin/mappings/new";
-	private static final String LOCAL_WIREMOCK_RESET_URL = "http://localhost:%d/__admin/reset";
-	private static final String LOCAL_WIREMOCK_RESET_DEFAULT_MAPPINS_URL = "http://localhost:%d/__admin/mappings/reset";
+    private static final String LOCAL_WIREMOCK_ROOT = "http://%s:%d%s";
+    private static final String LOCAL_WIREMOCK_NEW_RESPONSE_URL = "http://%s:%d/__admin/mappings/new";
+    private static final String LOCAL_WIREMOCK_RESET_URL = "http://%s:%d/__admin/reset";
+    private static final String LOCAL_WIREMOCK_RESET_DEFAULT_MAPPINS_URL = "http://%s:%d/__admin/mappings/reset";
 
 	private int port;
+    private String address;
 	
-	public WireMockTestClient(int port) {
+	public WireMockTestClient(int port, String address) {
 		this.port = port;
+                this.address = address;
+	}
+        
+        public WireMockTestClient(int port) {
+            this(port, "localhost");
 	}
 	
 	public WireMockTestClient() {
@@ -57,19 +63,19 @@ public class WireMockTestClient {
 	}
 	
 	private String mockServiceUrlFor(String path) {
-		return String.format(LOCAL_WIREMOCK_ROOT, port, path);
+		return String.format(LOCAL_WIREMOCK_ROOT, address, port, path);
 	}
 	
 	private String newMappingUrl() {
-		return String.format(LOCAL_WIREMOCK_NEW_RESPONSE_URL, port);
+		return String.format(LOCAL_WIREMOCK_NEW_RESPONSE_URL, address, port);
 	}
 	
 	private String resetUrl() {
-		return String.format(LOCAL_WIREMOCK_RESET_URL, port);
+		return String.format(LOCAL_WIREMOCK_RESET_URL, address, port);
 	}
 
     private String resetDefaultMappingsUrl() {
-        return String.format(LOCAL_WIREMOCK_RESET_DEFAULT_MAPPINS_URL, port);
+        return String.format(LOCAL_WIREMOCK_RESET_DEFAULT_MAPPINS_URL, address, port);
     }
 
 	public WireMockResponse get(String url, TestHttpHeader... headers) {
@@ -85,7 +91,7 @@ public class WireMockTestClient {
     public WireMockResponse getViaProxy(String url, int proxyPort) {
         URI targetUri = URI.create(url);
 
-        HttpHost proxy = new HttpHost("localhost", proxyPort, targetUri.getScheme());
+        HttpHost proxy = new HttpHost(address, proxyPort, targetUri.getScheme());
 
         DefaultHttpClient httpclient = new DefaultHttpClient(createClientConnectionManagerWithSSLSettings());
         try {


### PR DESCRIPTION
Now it's possible to pass a command line argument or a programming
configuration defining the IP address the server should listen to. If none
the server will listen in all interface.
