### PR TITLE
Added ability to record binary equal request bodies

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -153,9 +153,9 @@ public class WireMockServer implements Container {
 		stubRequestHandler.addRequestListener(listener);
 	}
 	
-	public void enableRecordMappings(FileSource mappingsFileSource, FileSource filesFileSource) {
+	public void enableRecordMappings(FileSource mappingsFileSource, FileSource filesFileSource, boolean recordBinaryEqual) {
 	    addMockServiceRequestListener(
-                new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, wireMockApp));
+                new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, wireMockApp, recordBinaryEqual));
 	    notifier.info("Recording mappings to " + mappingsFileSource.getPath());
 	}
 	

--- a/src/main/java/com/github/tomakehurst/wiremock/client/ValueMatchingStrategy.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ValueMatchingStrategy.java
@@ -29,6 +29,7 @@ public class ValueMatchingStrategy {
     private String doesNotMatch;
     private String contains;
     private String matchesJsonPath;
+    private byte[] equalToByteArray;
 
     public ValuePattern asValuePattern() {
 		ValuePattern pattern = new ValuePattern();
@@ -40,6 +41,7 @@ public class ValueMatchingStrategy {
 		pattern.setDoesNotMatch(doesNotMatch);
 		pattern.setContains(contains);
         pattern.setMatchesJsonPaths(matchesJsonPath);
+        pattern.setEqualToByteArray(equalToByteArray);
 		return pattern;
 	}
 	

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeader.java
@@ -90,7 +90,7 @@ public class HttpHeader {
     private boolean anyValueMatches(final ValuePattern valuePattern) {
         return any(values, new Predicate<String>() {
             public boolean apply(String headerValue) {
-                return valuePattern.isMatchFor(headerValue);
+                return valuePattern.isMatchFor(headerValue, null);
             }
         });
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.http;
 
 import com.github.tomakehurst.wiremock.common.ProxySettings;
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import org.apache.http.*;
 import org.apache.http.client.HttpClient;
@@ -135,11 +136,12 @@ public class ProxyResponseRenderer implements ResponseRenderer {
 
     private static HttpEntity buildEntityFrom(Request originalRequest) {
         ContentTypeHeader contentTypeHeader = originalRequest.contentTypeHeader().or("text/plain");
-        ContentType contentType = ContentType.create(contentTypeHeader.mimeTypePart(), contentTypeHeader.encodingPart().or("utf-8"));
+        Optional<String> encodingPart = contentTypeHeader.encodingPart();
+        ContentType contentType = ContentType.create(contentTypeHeader.mimeTypePart(), encodingPart.isPresent() ? encodingPart.get() : null);
 
         if (originalRequest.containsHeader(TRANSFER_ENCODING) &&
                 originalRequest.header(TRANSFER_ENCODING).firstValue().equals("chunked")) {
-            return new InputStreamEntity(new ByteArrayInputStream(originalRequest.getBodyAsString().getBytes()), -1, contentType);
+            return new InputStreamEntity(new ByteArrayInputStream(originalRequest.getBodyAsByteArray()), -1, contentType);
         }
 
         return new StringEntity(originalRequest.getBodyAsString(), contentType);

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -29,6 +29,7 @@ public interface Request {
 	boolean containsHeader(String key);
 	Set<String> getAllHeaderKeys();
 	String getBodyAsString();
+	byte[] getBodyAsByteArray();
 	boolean isBrowserProxyRequest();
 	
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -145,7 +145,7 @@ public class RequestPattern {
 			return true;
 		}
 		
-		boolean matches = all(bodyPatterns, matching(request.getBodyAsString()));
+		boolean matches = all(bodyPatterns, matching(request.getBodyAsString(), request.getBodyAsByteArray()));
 		
 		if (!matches) {
 			notifier().info(String.format("URL %s is match, but body is not: %s", request.getUrl(), request.getBodyAsString()));

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/ValuePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/ValuePattern.java
@@ -24,6 +24,7 @@ import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import org.custommonkey.xmlunit.Diff;
@@ -54,6 +55,7 @@ public class ValuePattern {
 	private String doesNotMatch;
     private Boolean absent;
     private String matchesJsonPath;
+    private byte[] equalToByteArray;
 
 	public static ValuePattern equalTo(String value) {
 		ValuePattern valuePattern = new ValuePattern();
@@ -97,8 +99,14 @@ public class ValuePattern {
         valuePattern.absent = true;
         return valuePattern;
     }
+    
+    public static ValuePattern equalToByteArray(byte[] value) {
+        ValuePattern valuePattern = new ValuePattern();
+        valuePattern.equalToByteArray = value;
+        return valuePattern;
+    }
 	
-	public boolean isMatchFor(String value) {
+	public boolean isMatchFor(String value, byte[] orArray) {
 		checkOneMatchTypeSpecified();
 
         if (absent != null) {
@@ -117,15 +125,17 @@ public class ValuePattern {
 			return !isMatch(doesNotMatch, value);
 		} else if (matchesJsonPath != null) {
             return isJsonPathMatch(value);
+        } else if (orArray != null && equalToByteArray != null) {
+            return Arrays.equals(this.equalToByteArray, orArray);
         }
 		
 		return false;
 	}
 	
-	public static Predicate<ValuePattern> matching(final String value) {
+	public static Predicate<ValuePattern> matching(final String value, final byte[] orArray) {
 		return new Predicate<ValuePattern>() {
 			public boolean apply(ValuePattern input) {
-				return input.isMatchFor(value);
+				return input.isMatchFor(value, orArray);
 			}
 		};
 	}
@@ -200,7 +210,7 @@ public class ValuePattern {
 	}
 	
 	private int countAllAttributes() {
-		return count(equalToJson, equalToXml, equalTo, contains, matches, doesNotMatch, absent, matchesJsonPath);
+		return count(equalToJson, equalToXml, equalTo, contains, matches, doesNotMatch, absent, matchesJsonPath, equalToByteArray);
 	}
 	
 	private int count(Object... objects) {
@@ -254,6 +264,10 @@ public class ValuePattern {
         checkNoMoreThanOneMatchTypeSpecified();
     }
 
+    public void setEqualToByteArray(byte[] equalToByteArray) {
+        this.equalToByteArray = equalToByteArray;
+    }
+
 	public String getEqualTo() {
 		return equalTo;
 	}
@@ -297,6 +311,10 @@ public class ValuePattern {
     public boolean nullSafeIsAbsent() {
         return (absent != null && absent);
     }
+    
+    public byte[] getEqualToByteArray() {
+        return equalToByteArray;
+    }
 	
 	@Override
 	public String toString() {
@@ -314,6 +332,8 @@ public class ValuePattern {
 			return "not match " + doesNotMatch;
         } else if (matchesJsonPath != null) {
             return "matches JSON path " + matchesJsonPath;
+        } else if (equalToByteArray != null) {
+            return "equalToByteArray " + Arrays.toString(equalToByteArray);
 		} else {
             return "is absent";
         }
@@ -335,6 +355,8 @@ public class ValuePattern {
         if (matches != null ? !matches.equals(that.matches) : that.matches != null) return false;
         if (matchesJsonPath != null ? !matchesJsonPath.equals(that.matchesJsonPath) : that.matchesJsonPath != null)
             return false;
+        if (equalToByteArray != null ? !equalToByteArray.equals(that.equalToByteArray) : that.equalToByteArray != null)
+            return false;
 
         return true;
     }
@@ -349,6 +371,7 @@ public class ValuePattern {
         result = 31 * result + (doesNotMatch != null ? doesNotMatch.hashCode() : 0);
         result = 31 * result + (absent != null ? absent.hashCode() : 0);
         result = 31 * result + (matchesJsonPath != null ? matchesJsonPath.hashCode() : 0);
+        result = 31 * result + (equalToByteArray != null ? equalToByteArray.hashCode() : 0);
         return result;
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -30,6 +30,7 @@ public class CommandLineOptions implements Options {
 	
 	private static final String HELP = "help";
 	private static final String RECORD_MAPPINGS = "record-mappings";
+	private static final String RECORD_BINARY_EQUAL = "record-binary-equal";
 	private static final String PROXY_ALL = "proxy-all";
     private static final String PROXY_VIA = "proxy-via";
 	private static final String PORT = "port";
@@ -53,6 +54,7 @@ public class CommandLineOptions implements Options {
 		optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
         optionParser.accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests").withRequiredArg();
 		optionParser.accepts(RECORD_MAPPINGS, "Enable recording of all (non-admin) requests as mapping files");
+		optionParser.accepts(RECORD_BINARY_EQUAL, "Enable binary request comparison strategy while recording of all (non-admin) requests as mapping files is turned on");
 		optionParser.accepts(ROOT_DIR, "Specifies path for storing recordings (parent for " + WireMockServer.MAPPINGS_ROOT + " and " + WireMockServer.FILES_ROOT + " folders)").withRequiredArg().defaultsTo(".");
 		optionParser.accepts(VERBOSE, "Enable verbose logging to stdout");
 		optionParser.accepts(ENABLE_BROWSER_PROXYING, "Allow wiremock to be set as a browser's proxy server");
@@ -71,6 +73,10 @@ public class CommandLineOptions implements Options {
 
         if (optionSet.has(RECORD_MAPPINGS) && optionSet.has(DISABLE_REQUEST_JOURNAL)) {
             throw new IllegalArgumentException("Request journal must be enabled to record stubs");
+        }
+        
+        if (!optionSet.has(RECORD_MAPPINGS) && optionSet.has(RECORD_BINARY_EQUAL)) {
+            throw new IllegalArgumentException("Recording mappings must be enabled to use binary equal strategy");
         }
     }
 
@@ -94,6 +100,10 @@ public class CommandLineOptions implements Options {
 	public boolean recordMappingsEnabled() {
 		return optionSet.has(RECORD_MAPPINGS);
 	}
+    
+    public boolean recordBinaryEqualEnabled() {
+        return optionSet.has(RECORD_BINARY_EQUAL);
+    }
 	
 	private boolean specifiesPortNumber() {
 		return optionSet.has(PORT);

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -49,7 +49,7 @@ public class WireMockServerRunner {
         wireMockServer = new WireMockServer(options);
 
         if (options.recordMappingsEnabled()) {
-            wireMockServer.enableRecordMappings(mappingsFileSource, filesFileSource);
+            wireMockServer.enableRecordMappings(mappingsFileSource, filesFileSource, options.recordBinaryEqualEnabled());
         }
 
 		if (options.specifiesProxyUrl()) {

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -37,6 +37,7 @@ public class LoggedRequest implements Request {
 	private final RequestMethod method;
 	private final HttpHeaders headers;
 	private final String body;
+	private final byte[] bodyAsByteArray;
 	private final boolean isBrowserProxyRequest;
     private final Date loggedDate;
 	
@@ -46,6 +47,7 @@ public class LoggedRequest implements Request {
                 request.getMethod(),
                 copyOf(request.getHeaders()),
                 request.getBodyAsString(),
+                request.getBodyAsByteArray(),
                 request.isBrowserProxyRequest(),
                 new Date());
 	}
@@ -56,6 +58,7 @@ public class LoggedRequest implements Request {
                          @JsonProperty("method") RequestMethod method,
                          @JsonProperty("headers") HttpHeaders headers,
                          @JsonProperty("body") String body,
+                         @JsonProperty("bodyAsByteArray") byte[] bodyAsByteArray,
                          @JsonProperty("browserProxyRequest") boolean isBrowserProxyRequest,
                          @JsonProperty("loggedDate") Date loggedDate) {
 
@@ -63,6 +66,7 @@ public class LoggedRequest implements Request {
         this.absoluteUrl = absoluteUrl;
         this.method = method;
         this.body = body;
+        this.bodyAsByteArray = bodyAsByteArray;
         this.headers = headers;
         this.isBrowserProxyRequest = isBrowserProxyRequest;
         this.loggedDate = loggedDate;
@@ -114,6 +118,12 @@ public class LoggedRequest implements Request {
 	public String getBodyAsString() {
 		return body;
 	}
+
+    @Override
+    @JsonProperty("bodyAsByteArray")
+    public byte[] getBodyAsByteArray() {
+        return bodyAsByteArray;
+    }
 
 	@Override
     @JsonIgnore

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/ValuePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/ValuePatternTest.java
@@ -49,102 +49,103 @@ public class ValuePatternTest {
 	@Test
 	public void matchesOnEqualTo() {
 		valuePattern.setEqualTo("text/plain");
-		assertTrue(valuePattern.isMatchFor("text/plain"));
+		assertTrue(valuePattern.isMatchFor("text/plain", null));
 	}
 	
 	@Test
 	public void matchesOnRegex() {
 		valuePattern.setMatches("[0-9]{6}");
-		assertTrue(valuePattern.isMatchFor("938475"));
-		assertFalse(valuePattern.isMatchFor("abcde"));
+		assertTrue(valuePattern.isMatchFor("938475", null));
+		assertFalse(valuePattern.isMatchFor("abcde", null));
 	}
 	
 	@Test
 	public void matchesOnNegativeRegex() {
 		valuePattern.setDoesNotMatch("[0-9]{6}");
-		assertFalse(valuePattern.isMatchFor("938475"));
-		assertTrue(valuePattern.isMatchFor("abcde"));
+		assertFalse(valuePattern.isMatchFor("938475", null));
+		assertTrue(valuePattern.isMatchFor("abcde", null));
 	}
 	
 	@Test
 	public void matchesOnContains() {
 		valuePattern.setContains("some text");
-		assertFalse(valuePattern.isMatchFor("Nothing to see here"));
-		assertTrue(valuePattern.isMatchFor("There's some text here"));
+		assertFalse(valuePattern.isMatchFor("Nothing to see here", null));
+		assertTrue(valuePattern.isMatchFor("There's some text here", null));
 	}
 
     @Test
     public void matchesOnAbsent() {
         valuePattern = ValuePattern.absent();
-        assertFalse("Absent value should not be a match for a string", valuePattern.isMatchFor("Something"));
-        assertTrue("Absent value should be match for null", valuePattern.isMatchFor(null));
+        assertFalse("Absent value should not be a match for a string", valuePattern.isMatchFor("Something", null));
+        assertTrue("Absent value should be match for null", valuePattern.isMatchFor(null, null));
         assertTrue("isAbsent() should be true", valuePattern.isAbsent());
     }
 
     @Test
     public void matchesOnIsEqualToXml() {
         valuePattern.setEqualToXml("<H><J>111</J></H>");
-        assertTrue("Expected exact match", valuePattern.isMatchFor("<H><J>111</J></H>\n"));
+        assertTrue("Expected exact match", valuePattern.isMatchFor("<H><J>111</J></H>\n", null));
     }
     
     @Test
     public void ignoresSubElementOrderWhenMatchingXml() {
         valuePattern.setEqualToXml("<H><J>111</J><X>222</X></H>");
-        assertTrue("Expected similar match", valuePattern.isMatchFor("<H><X>222</X><J>111</J></H>\n"));
+        assertTrue("Expected similar match", valuePattern.isMatchFor("<H><X>222</X><J>111</J></H>\n", null));
     }
 
     @Test
     public void ignoresAttributeOrderWhenMatchingXml() {
         valuePattern.setEqualToXml("<thing attr1=\"one\" attr2=\"two\" attr3=\"three\" />");
         assertTrue("Expected similar match", valuePattern.isMatchFor(
-                "<thing attr3=\"three\" attr1=\"one\" attr2=\"two\"  />"));
+                "<thing attr3=\"three\" attr1=\"one\" attr2=\"two\"  />",
+                null));
     }
     
     @Test
     public void matchesOnIsEqualToJson() {
         valuePattern.setEqualToJson("{\"x\":0}");
-        assertTrue("Expected exact match", valuePattern.isMatchFor("{\"x\":0}"));
-        assertTrue("Expected number json match", valuePattern.isMatchFor("{\"x\":0.0}"));
+        assertTrue("Expected exact match", valuePattern.isMatchFor("{\"x\":0}", null));
+        assertTrue("Expected number json match", valuePattern.isMatchFor("{\"x\":0.0}", null));
     }
     
     @Test
     public void matchesOnIsEqualToJsonMoveFields() {
         valuePattern.setEqualToJson("{\"x\":0,\"y\":1}");
-        assertTrue("Expected exact match", valuePattern.isMatchFor("{\"x\":0,\"y\":1}"));
-        assertTrue("Expected move field json match", valuePattern.isMatchFor("{\"y\":1,\"x\":0.0}"));
+        assertTrue("Expected exact match", valuePattern.isMatchFor("{\"x\":0,\"y\":1}", null));
+        assertTrue("Expected move field json match", valuePattern.isMatchFor("{\"y\":1,\"x\":0.0}", null));
     }
 
     @Test
     public void permitsExtraFieldsWhenJsonCompareModeIsLENIENT() {
         valuePattern.setEqualToJson("{ \"x\": 0 }");
         valuePattern.setJsonCompareMode(JSONCompareMode.LENIENT);
-        assertTrue("Expected match when unknown field is present in LENIENT mode", valuePattern.isMatchFor("{ \"x\": 0, \"y\": 1 }"));
+        assertTrue("Expected match when unknown field is present in LENIENT mode", valuePattern.isMatchFor("{ \"x\": 0, \"y\": 1 }", null));
     }
 
     @Test
     public void doesNotMatchOnEqualToJsonWhenFieldMissing() {
         valuePattern.setEqualToJson("{ \"x\": 0 }");
-        assertFalse("Expected no match when unknown field is present", valuePattern.isMatchFor("{ \"x\": 0, \"y\": 1 }"));
+        assertFalse("Expected no match when unknown field is present", valuePattern.isMatchFor("{ \"x\": 0, \"y\": 1 }", null));
     }
     
     @Test
     public void matchesOnBasicJsonPaths() {
         valuePattern.setMatchesJsonPaths("$.one");
-        assertTrue("Expected match when JSON attribute is present", valuePattern.isMatchFor("{ \"one\": 1 }"));
-        assertFalse("Expected no match when JSON attribute is absent", valuePattern.isMatchFor("{ \"two\": 2 }"));
+        assertTrue("Expected match when JSON attribute is present", valuePattern.isMatchFor("{ \"one\": 1 }", null));
+        assertFalse("Expected no match when JSON attribute is absent", valuePattern.isMatchFor("{ \"two\": 2 }", null));
     }
 
     @Test
     public void matchesOnJsonPathsWithFilters() {
         valuePattern.setMatchesJsonPaths("$.numbers[?(@.number == '2')]");
-        assertTrue("Expected match when JSON attribute is present", valuePattern.isMatchFor("{ \"numbers\": [ {\"number\": 1}, {\"number\": 2} ]}"));
-        assertFalse("Expected no match when JSON attribute is absent", valuePattern.isMatchFor("{ \"numbers\": [{\"number\": 7} ]}"));
+        assertTrue("Expected match when JSON attribute is present", valuePattern.isMatchFor("{ \"numbers\": [ {\"number\": 1}, {\"number\": 2} ]}", null));
+        assertFalse("Expected no match when JSON attribute is absent", valuePattern.isMatchFor("{ \"numbers\": [{\"number\": 7} ]}", null));
     }
 
     @Test
     public void matchesOnJsonPathsWithFiltersOnNestedObjects() {
         valuePattern.setMatchesJsonPaths("$..*[?(@.innerOne == 11)]");
-        assertTrue("Expected match", valuePattern.isMatchFor("{ \"things\": { \"thingOne\": { \"innerOne\": 11 }, \"thingTwo\": 2 }}"));
+        assertTrue("Expected match", valuePattern.isMatchFor("{ \"things\": { \"thingOne\": { \"innerOne\": 11 }, \"thingTwo\": 2 }}", null));
     }
 
     @Test
@@ -152,7 +153,7 @@ public class ValuePatternTest {
         expectInfoNotification("Warning: JSON path expression '$.something' failed to match document 'Not a JSON document' because the JSON document couldn't be parsed");
 
         valuePattern.setMatchesJsonPaths("$.something");
-        assertFalse("Expected the match to fail", valuePattern.isMatchFor("Not a JSON document"));
+        assertFalse("Expected the match to fail", valuePattern.isMatchFor("Not a JSON document", null));
     }
 
     @Test
@@ -160,7 +161,7 @@ public class ValuePatternTest {
         expectInfoNotification("Warning: JSON path expression '$.something' failed to match document '{ \"nothing\": 1 }' because the JSON path didn't match the document structure");
 
         valuePattern.setMatchesJsonPaths("$.something");
-        assertFalse("Expected the match to fail", valuePattern.isMatchFor("{ \"nothing\": 1 }"));
+        assertFalse("Expected the match to fail", valuePattern.isMatchFor("{ \"nothing\": 1 }", null));
     }
 
     @Test(expected=IllegalStateException.class)
@@ -183,7 +184,7 @@ public class ValuePatternTest {
 
 	@Test(expected=IllegalStateException.class)
 	public void doesNotPermitZeroMatchTypes() {
-		valuePattern.isMatchFor("blah");
+		valuePattern.isMatchFor("blah", null);
 	}
 
     private void expectInfoNotification(final String message) {

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -55,7 +55,7 @@ public class StubMappingJsonRecorderTest {
 		filesFileSource = context.mock(FileSource.class, "filesFileSource");
         admin = context.mock(Admin.class);
 
-		listener = new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, admin);
+		listener = new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, admin, false);
 		listener.setIdGenerator(fixedIdGenerator("1$2!3"));
 	}
 	

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
@@ -103,6 +103,7 @@ public class MockRequestBuilder {
 			allowing(request).getAllHeaderKeys(); will(returnValue(newLinkedHashSet(headers.keys())));
 			allowing(request).containsHeader(with(any(String.class))); will(returnValue(false));
 			allowing(request).getBodyAsString(); will(returnValue(body));
+			allowing(request).getBodyAsByteArray(); will(returnValue(null));
 			allowing(request).getAbsoluteUrl(); will(returnValue("http://localhost:8080" + url));
 			allowing(request).isBrowserProxyRequest(); will(returnValue(browserProxyRequest));
 		}});

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
@@ -73,6 +73,7 @@ public class LoggedRequestTest {
             "        \"Accept-Language\" : \"en-us,en;q=0.5\"\n" +
             "      },\n" +
             "      \"body\" : \"some text\",\n" +
+            "      \"bodyAsByteArray\" : \"\",\n" +
             "      \"browserProxyRequest\" : true,\n" +
             "      \"loggedDate\" : %d,\n" +
             "      \"loggedDateString\" : \"" + DATE + "\"\n" +
@@ -90,6 +91,7 @@ public class LoggedRequestTest {
                 RequestMethod.GET,
                 headers,
                 "some text",
+                new byte[] {},
                 true,
                 loggedDate);
 


### PR DESCRIPTION
Hi guys,

I'm using WireMock to mock Hessian service. Also I'm recording mappings using WireMock built-in ability to proxy not mocked yet requests to the real service and then save them as mappings.

I've found that this approach does not work for Hessian as it sends binary data in the request body and does not specify content encoding. So "iso-8859-1" encoding is used to convert this request body to string (as WireMock uses strings to match requests) and some raw request body bytes are not interpreted well.

As a result WireMock records bad request bodies and also send this bad requests to the proxied Hessian service, which does not understand the request and responses with fail.

So, I've decided to extend WireMock's value matching strategies by adding binary matching (equalToByteArray) matching strategy.

Feel free to point me a better way to implement this as I'm new to this code base.

Thank you,
ILYA Sedlovsky
