### PR TITLE
Added IgnoreWireMockRule annotation

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/IgnoreWireMockRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/IgnoreWireMockRule.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2014 Emanuele Blanco
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Prevents {@link com.github.tomakehurst.wiremock.junit.WireMockRule} to start a WireMock server for the test annotated with this annotation. Useful if you want a test for specific behaviour that happens when a downstream service is not reachable.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface IgnoreWireMockRule {
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
@@ -22,11 +22,9 @@ import com.github.tomakehurst.wiremock.junit.Stubbing;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -34,6 +32,7 @@ import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -266,6 +265,25 @@ public class WireMockJUnitRuleTest {
             assertThat(urls.get(0), is("/test/listener"));
         }
 
+    }
+
+    public static class IgnoreWireMockRuleAnnotationTest {
+
+        @Rule
+        public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8089));
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        @Test
+        @IgnoreWireMockRule
+        public void wireMockServerDoesntStartUp_WhenTestIsMarkedWithIgnoreRule() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage(containsString("Connection to http://localhost:8089 refused"));
+
+            WireMockTestClient testClient = new WireMockTestClient(8089);
+
+            testClient.get("/whatever-url");
+        }
     }
 
     private static void assertNoPreviousRequestsReceived() {


### PR DESCRIPTION
I'm using WireMock a lot recently and I really like the way a JUnit Rule could be created to automatically spin up a WireMock server.

Some of the tests I'm working on require the server not to be running, i.e. testing what happens when downstream services are unreachable. 

Instead of using a programmatic approach to start/stop the WireMock server, I thought an annotation could be useful. If you annotate a test with `@IgnoreWireMockRule`, the `apply()` method will prevent starting the server. 

As part of that, I also removed implementing a deprecated interface. Hope this is helpful.
