### PR TITLE
migrate WireMock to org.eclipse.jetty 7.6.15.v20140411

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ wiremock.iws
 copy-admin.sh
 .DS_Store
 **/.DS_Store
+/target/
+pom.xml
+src/test/resources/log4j.xml

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,9 @@ configurations {
 }
 
 dependencies {
-	compile "org.mortbay.jetty:jetty:6.1.26"
+	compile "org.eclipse.jetty:jetty-server:7.6.15.v20140411"
+    compile "org.eclipse.jetty:jetty-servlet:7.6.15.v20140411"
+    compile "org.eclipse.jetty:jetty-webapp:7.6.15.v20140411"
 	compile "com.google.guava:guava:13.0.1"
 	compile "com.fasterxml.jackson.core:jackson-core:2.1.2", 
         	"com.fasterxml.jackson.core:jackson-annotations:2.1.2", 

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty/DelayableSocketConnector.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty/DelayableSocketConnector.java
@@ -16,7 +16,8 @@
 package com.github.tomakehurst.wiremock.jetty;
 
 import com.github.tomakehurst.wiremock.global.RequestDelayControl;
-import org.mortbay.jetty.bio.SocketConnector;
+
+import org.eclipse.jetty.server.bio.SocketConnector;
 
 import java.io.IOException;
 import java.net.Socket;
@@ -42,7 +43,7 @@ public class DelayableSocketConnector extends SocketConnector {
         }
 
         configure(socket);
-        Connection connection = new Connection(socket) {
+        ConnectorEndPoint connection=new ConnectorEndPoint(socket)  {
             @Override
             public void run() {
                 ActiveSocket.set(socket);

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty/DelayableSslSocketConnector.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty/DelayableSslSocketConnector.java
@@ -16,14 +16,19 @@
 package com.github.tomakehurst.wiremock.jetty;
 
 import com.github.tomakehurst.wiremock.global.RequestDelayControl;
-import org.mortbay.jetty.security.SslSocketConnector;
-import org.mortbay.log.Log;
+
+import org.eclipse.jetty.server.ssl.SslSocketConnector;
+
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
 
 import javax.net.ssl.SSLException;
+
 import java.io.IOException;
 import java.net.Socket;
 
 public class DelayableSslSocketConnector extends SslSocketConnector {
+    private static final Logger log = Log.getLogger("DelayableSslSocketConnector");
 
     private final RequestDelayControl requestDelayControl;
 
@@ -47,7 +52,7 @@ public class DelayableSslSocketConnector extends SslSocketConnector {
             }
 
             configure(socket);
-            Connection connection = new SslConnection(socket) {
+            SslConnectorEndPoint connection = new SslConnectorEndPoint(socket) {
                 @Override
                 public void run() {
                     ActiveSocket.set(socket);
@@ -59,14 +64,14 @@ public class DelayableSslSocketConnector extends SslSocketConnector {
         }
         catch(SSLException e)
         {
-            Log.warn(e);
+            log.warn(e);
             try
             {
                 stop();
             }
             catch(Exception e2)
             {
-                Log.warn(e2);
+                log.warn(e2);
                 throw new IllegalStateException(e2.getMessage());
             }
         }

--- a/src/test/java/com/github/tomakehurst/wiremock/WarDeploymentAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WarDeploymentAcceptanceTest.java
@@ -19,13 +19,14 @@ import com.github.tomakehurst.wiremock.client.VerificationException;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+
+import org.eclipse.jetty.server.Server;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.webapp.WebAppContext;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static java.net.HttpURLConnection.HTTP_OK;
@@ -46,7 +47,7 @@ public class WarDeploymentAcceptanceTest {
 	public void init() throws Exception {
 		jetty = new Server(8085);
 		WebAppContext context = new WebAppContext("sample-war/src/main/webapp", "/wiremock");
-		jetty.addHandler(context);
+		jetty.setHandler(context);
 		jetty.start();
 		
 		WireMock.configureFor("localhost", 8085, "/wiremock");


### PR DESCRIPTION
I would take this with a little grain of salt, in my limited testing is seems to working, but i can't get the tests to pass. not sure what the deal is, i don't have a good gradle setup that's why you see my maven pom in .gitignore.

I hope you can use some/most of this change as inspiration. 
