### PR TITLE
Added ability to do XPath matching using XMLUnit.assertXpathExists

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/ValueMatchingStrategy.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ValueMatchingStrategy.java
@@ -24,6 +24,7 @@ public class ValueMatchingStrategy {
 	private String equalTo;
 	private String equalToJson;
 	private String equalToXml;
+    private String equalToXPath;
     private JSONCompareMode jsonCompareMode;
     private String matches;
     private String doesNotMatch;
@@ -35,6 +36,7 @@ public class ValueMatchingStrategy {
 		pattern.setEqualTo(equalTo);
 		pattern.setEqualToJson(equalToJson);
 		pattern.setEqualToXml(equalToXml);
+        pattern.setEqualToXPath(equalToXPath);
         pattern.setJsonCompareMode(jsonCompareMode);
 		pattern.setMatches(matches);
 		pattern.setDoesNotMatch(doesNotMatch);
@@ -75,6 +77,14 @@ public class ValueMatchingStrategy {
 
     public void setEqualToXml(String equalToXml) {
         this.equalToXml = equalToXml;
+    }
+
+    public String getEqualToXPath() {
+        return equalToXPath;
+    }
+
+    public void setEqualToXPath(String equalToXPath) {
+        this.equalToXPath = equalToXPath;
     }
 
 	public String getEqualTo() {

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -159,6 +159,12 @@ public class WireMock {
         return headerStrategy;
     }
 
+    public static ValueMatchingStrategy equalToXPath(String value) {
+        ValueMatchingStrategy headerStrategy = new ValueMatchingStrategy();
+        headerStrategy.setEqualToXPath(value);
+        return headerStrategy;
+    }
+
 	public static ValueMatchingStrategy containing(String value) {
 		ValueMatchingStrategy headerStrategy = new ValueMatchingStrategy();
 		headerStrategy.setContains(value);

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -126,6 +126,13 @@ public class VerificationAcceptanceTest {
         }
 
         @Test
+        public void verifiesWithBodyEquallingXpath() {
+            testClient.postWithBody("/body/xml", "<thing><subThing>The stuff</subThing></thing>", "application/xml", "utf-8");
+            verify(postRequestedFor(urlEqualTo("/body/xml"))
+                    .withRequestBody(equalToXPath("//subThing[.='The stuff']")));
+        }
+
+        @Test
         public void verifiesWithBodyContainingString() {
             testClient.postWithBody("/body/json", SAMPLE_JSON, "application/json", "utf-8");
             verify(postRequestedFor(urlEqualTo("/body/json"))

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/ValuePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/ValuePatternTest.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.matching;
 
 import com.github.tomakehurst.wiremock.common.LocalNotifier;
 import com.github.tomakehurst.wiremock.common.Notifier;
+import junit.framework.Assert;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
@@ -26,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -98,6 +100,42 @@ public class ValuePatternTest {
         valuePattern.setEqualToXml("<thing attr1=\"one\" attr2=\"two\" attr3=\"three\" />");
         assertTrue("Expected similar match", valuePattern.isMatchFor(
                 "<thing attr3=\"three\" attr1=\"one\" attr2=\"two\"  />"));
+    }
+
+    @Test
+    public void matchesOnEqualToXPath() {
+        valuePattern.setEqualToXPath("//J[.='111']");
+        assertTrue("Expected XPath match", valuePattern.isMatchFor("<H><J>111</J><X>222</X></H>"));
+    }
+
+    @Test
+    public void matchesOnEqualToXPathWithNamespace() {
+        valuePattern.setEqualToXPath("//*[local-name() = 'J'][.='111']");
+        assertTrue("Expected XPath match", valuePattern.isMatchFor("<a:H xmlns:a='http://schemas.xmlsoap.org/soap/envelope/'><a:J>111</a:J><X>222</X></a:H>"));
+    }
+
+    @Test
+    public void doesNotMatchesOnEqualToXPath() {
+        valuePattern.setEqualToXPath("//J[.='222']");
+        assertFalse("Expected XPath match", valuePattern.isMatchFor("<H><J>111</J><X>222</X></H>"));
+    }
+
+    @Test
+    public void matchesOnEqualToXPathProperty() {
+        String mySolarSystemXML = "<solar-system>"
+                + "<planet name='Earth' position='3' supportsLife='yes'/>"
+                + "<planet name='Venus' position='4'/></solar-system>";
+        valuePattern.setEqualToXPath("//planet[@name='Earth']");
+        assertTrue("Expected XPath match", valuePattern.isMatchFor(mySolarSystemXML));
+    }
+
+    @Test
+    public void doesNotMatchesOnEqualToXPathProperty() {
+        String mySolarSystemXML = "<solar-system>"
+                + "<planet name='Earth' position='3' supportsLife='yes'/>"
+                + "<planet name='Venus' position='4'/></solar-system>";
+        valuePattern.setEqualToXPath("//star[@name='alpha centauri']");
+        assertFalse("Expected XPath non-match", valuePattern.isMatchFor(mySolarSystemXML));
     }
     
     @Test


### PR DESCRIPTION
I came across a use case where I wanted to only check certain fields in a soap request, for example, I wasn't interested in the value of the modified date.  This allowed me to do the following in a test:

```
        verify(postRequestedFor(urlEqualTo("/someurl"))
            .withRequestBody(equalToXPath("""//*[local-name() = 'eventId'][.='update']"""))
            .withRequestBody(equalToXPath("""//*[local-name() = 'source'][.='Prioritisation']""")));
```
