### PR TITLE
Fix for missing PATCH method when rendering proxied responses

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -106,6 +106,8 @@ public class ProxyResponseRenderer implements ResponseRenderer {
 			return new HttpOptions(url);
 		case TRACE:
 			return new HttpTrace(url);
+		case PATCH:
+			return new HttpPatch(url);
 		default:
 			throw new RuntimeException("Cannot create HttpMethod for " + method);
 		}


### PR DESCRIPTION
When trying to proxy a PATCH request in standalone this error is thrown:

```
java.lang.RuntimeException: Cannot create HttpMethod for PATCH
at com.github.tomakehurst.wiremock.http.ProxyResponseRenderer.getHttpRequestFor(ProxyResponseRenderer.java:110)
at com.github.tomakehurst.wiremock.http.ProxyResponseRenderer.render(ProxyResponseRenderer.java:62)
at com.github.tomakehurst.wiremock.http.StubResponseRenderer.render(StubResponseRenderer.java:47)
at com.github.tomakehurst.wiremock.http.AbstractRequestHandler.handle(AbstractRequestHandler.java:40)
at com.github.tomakehurst.wiremock.servlet.HandlerDispatchingServlet.service(HandlerDispatchingServlet.java:77)
at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)
at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:511)
at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:401)
at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:766)
at org.mortbay.jetty.handler.HandlerCollection.handle(HandlerCollection.java:114)
at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)
at org.mortbay.jetty.Server.handle(Server.java:326)
at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)
at org.mortbay.jetty.HttpConnection$RequestHandler.headerComplete(HttpConnection.java:928)
at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:549)
at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:212)
at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)
at org.mortbay.jetty.bio.SocketConnector$Connection.run(SocketConnector.java:228)
at com.github.tomakehurst.wiremock.jetty.DelayableSocketConnector$1.run(DelayableSocketConnector.java:49)
at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java:582) 
```

Added a case for PATCH to ProxyResponseRenderer.
