### PR TITLE
Make it possible to register StubMapping

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -115,8 +115,12 @@ public class WireMock {
 
 	public void register(MappingBuilder mappingBuilder) {
 		StubMapping mapping = mappingBuilder.build();
-		admin.addStubMapping(mapping);
+		register(mapping);
 	}
+
+    public void register(StubMapping mapping) {
+        admin.addStubMapping(mapping);
+    }
 
     public ListStubMappingsResult allStubMappings() {
         return admin.listAllStubMappings();

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientTest.java
@@ -195,6 +195,14 @@ public class WireMockClientTest {
 		urlStrategy.setUrl("/wrong/url");
 		wireMock.verifyThat(new RequestPatternBuilder(RequestMethod.DELETE, urlStrategy));
 	}
+
+    @Test
+    public void shouldRegisterStubMapping() {
+        expectExactlyOneAddResponseCallWithJson(MappingJsonSamples.WITH_RESPONSE_BODY);
+        StubMapping mapping = StubMapping.buildFrom(MappingJsonSamples.SPEC_WITH_RESPONSE_BODY);
+
+        wireMock.register(mapping);
+    }
 	
 	public void expectExactlyOneAddResponseCallWithJson(final String json) {
         final StubMapping stubMapping = Json.read(json, StubMapping.class);

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MappingJsonSamples.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MappingJsonSamples.java
@@ -67,6 +67,18 @@ public class MappingJsonSamples {
 		"		\"body\": \"Some content\"					\n" +
 		"	}												\n" +
 		"}													";
+
+    public static final String SPEC_WITH_RESPONSE_BODY =
+        "{                                                  \n" +
+        "   \"request\": {                                  \n" +
+        "      \"url\": \"/with/body\",                     \n" +
+        "       \"method\": \"GET\"                         \n" +
+        "   },                                              \n" +
+        "   \"response\": {                                 \n" +
+        "       \"body\": \"Some content\",                 \n" +
+        "       \"status\": 200                             \n" +
+        "   }                                               \n" +
+        "}                                                  ";
 	
 	public static final String BASIC_GET =
 		"{ 													\n" +


### PR DESCRIPTION
Allow to register Stub Mapping so that it is possible to register stub from mapping spec without the need to call `/__admin/mappings/new` endpoint or saving it beforehand.
