### PR TITLE
Added the preserve-host-header option when running in proxy mode

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -191,6 +191,10 @@ When in record mode, capture request headers with the keys specified. See :ref:`
 Proxy all requests through to another base URL e.g. ``--proxy-all="http://api.someservice.com"``
 Typically used in conjunction with ``--record-mappings`` such that a session on another service can be recorded.
 
+``--preserve-host-header``: When in proxy mode, it passes the Host header as it comes from the client through to the
+proxied service. When this option is not present, the Host header value is deducted from the proxy URL. This option is
+only available if the ``--proxy-all`` option is specified.
+
 ``--proxy-via``:
 When proxying requests (either by using --proxy-all or by creating stub mappings that proxy to other hosts), route via
 another proxy server (useful when inside a corporate network that only permits internet access via an opaque proxy).

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -37,4 +37,6 @@ public interface Options {
     boolean requestJournalDisabled();
     public String bindAddress();
     List<CaseInsensitiveKey> matchingHeaders();
+    public String proxyUrl();
+    public boolean preserveHostHeader();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.core;
 
+import java.net.URI;
 import java.util.List;
 
 import com.github.tomakehurst.wiremock.common.*;
@@ -34,6 +35,28 @@ public class WireMockConfiguration implements Options {
     private Notifier notifier = new Log4jNotifier();
     private boolean requestJournalDisabled = false;
     private List<CaseInsensitiveKey> matchingHeaders;
+    private String proxyUrl;
+    private boolean preserveHostHeader;
+    private String proxyUrlBasedHostHeader;
+
+    private static WireMockConfiguration instance;
+
+    public static void init(Options options) {
+        instance = new WireMockConfiguration()
+                .withPreserveHostHeader(options.preserveHostHeader())
+                .withProxyUrl(options.proxyUrl());
+
+        if (options.proxyUrl() != null && !options.preserveHostHeader()) {
+           instance.withProxyUrlBasedHostHeader((URI.create(options.proxyUrl()).getHost()));
+        }
+    }
+
+    public static WireMockConfiguration getInstance() {
+        if (instance == null) {
+            instance = new WireMockConfiguration();
+        }
+        return instance;
+    }
 
     public static WireMockConfiguration wireMockConfig() {
         return new WireMockConfiguration();
@@ -98,6 +121,21 @@ public class WireMockConfiguration implements Options {
     	this.matchingHeaders = transform(headers, CaseInsensitiveKey.TO_CASE_INSENSITIVE_KEYS);
     	return this;
     }
+
+    public WireMockConfiguration withProxyUrl(String proxyUrl) {
+        this.proxyUrl = proxyUrl;
+        return this;
+    }
+
+    public WireMockConfiguration withPreserveHostHeader(boolean preserveHostHeader) {
+        this.preserveHostHeader = preserveHostHeader;
+        return this;
+    }
+
+    public WireMockConfiguration withProxyUrlBasedHostHeader(String hostHeaderValue) {
+        this.proxyUrlBasedHostHeader = hostHeaderValue;
+        return this;
+    }
     
     @Override
     public int portNumber() {
@@ -149,5 +187,19 @@ public class WireMockConfiguration implements Options {
     @Override
     public List<CaseInsensitiveKey>matchingHeaders() {
     	return matchingHeaders;
+    }
+
+    @Override
+    public String proxyUrl() {
+        return proxyUrl;
+    }
+
+    @Override
+    public boolean preserveHostHeader() {
+        return preserveHostHeader;
+    }
+
+    public String proxyUrlBasedHostHeader() {
+        return proxyUrlBasedHostHeader;
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -40,6 +40,7 @@ public class CommandLineOptions implements Options {
 	private static final String RECORD_MAPPINGS = "record-mappings";
 	private static final String MATCH_HEADERS = "match-headers";
 	private static final String PROXY_ALL = "proxy-all";
+    private static final String PRESERVE_HOST_HEADER = "preserve-host-header";
     private static final String PROXY_VIA = "proxy-via";
 	private static final String PORT = "port";
         private static final String BIND_ADDRESS = "bind-address";
@@ -60,6 +61,7 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(BIND_ADDRESS, "The IP to listen connections").withRequiredArg();
         optionParser.accepts(HTTPS_KEYSTORE, "Path to an alternative keystore for HTTPS. Must have a password of \"password\".").withRequiredArg();
 		optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
+        optionParser.accepts(PRESERVE_HOST_HEADER, "Will transfer the original host header from the client to the proxied service");
         optionParser.accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests").withRequiredArg();
 		optionParser.accepts(RECORD_MAPPINGS, "Enable recording of all (non-admin) requests as mapping files");
 		optionParser.accepts(MATCH_HEADERS, "Enable request header matching when recording through a proxy").withRequiredArg();
@@ -162,14 +164,20 @@ public class CommandLineOptions implements Options {
 	public String helpText() {
 		return helpText;
 	}
-	
+
 	public boolean specifiesProxyUrl() {
 		return optionSet.has(PROXY_ALL);
 	}
-	
+
+    @Override
 	public String proxyUrl() {
 		return (String) optionSet.valueOf(PROXY_ALL);
 	}
+
+    @Override
+    public boolean preserveHostHeader() {
+        return optionSet.has(PRESERVE_HOST_HEADER);
+    }
 	
 	@Override
     public boolean browserProxyingEnabled() {

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.standalone;
 import com.github.tomakehurst.wiremock.Log4jConfiguration;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
@@ -38,6 +39,7 @@ public class WireMockServerRunner {
 			return;
 		}
         Log4jConfiguration.configureLogging(options.verboseLoggingEnabled());
+        WireMockConfiguration.init(options);
 
 		FileSource fileSource = options.filesRoot();
 		fileSource.createIfNecessary();

--- a/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2011 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.core;
+
+import com.github.tomakehurst.wiremock.standalone.CommandLineOptions;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class WireMockConfigurationTest {
+
+
+    @Test
+    public void testInitWithProxyAllAndNoPreservingHostHeaderUsesProxyUrlBasedHost() {
+        CommandLineOptions options = new CommandLineOptions("--proxy-all", "http://localhost:8080");
+        WireMockConfiguration.init(options);
+
+        assertThat(WireMockConfiguration.getInstance().preserveHostHeader(), is(false));
+        assertThat(WireMockConfiguration.getInstance().proxyUrl(), is("http://localhost:8080"));
+        assertThat(WireMockConfiguration.getInstance().proxyUrlBasedHostHeader(), is("localhost"));
+    }
+
+    @Test
+    public void testInitWithProxyAllAndPreservingHostHeaderDoesNotHoldTheProxyUrlBasedHost() {
+        CommandLineOptions options = new CommandLineOptions("--proxy-all", "http://localhost:8080", "--preserve-host-header");
+        WireMockConfiguration.init(options);
+
+        assertThat(WireMockConfiguration.getInstance().preserveHostHeader(), is(true));
+        assertThat(WireMockConfiguration.getInstance().proxyUrl(), is("http://localhost:8080"));
+        assertThat(WireMockConfiguration.getInstance().proxyUrlBasedHostHeader(), is(nullValue()));
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -144,6 +144,18 @@ public class CommandLineOptionsTest {
         assertThat(options.requestJournalDisabled(), is(true));
     }
 
+    @Test
+    public void returnPreserveHostHeaderTrueWhenPresent() {
+        CommandLineOptions options = new CommandLineOptions("--preserve-host-header");
+        assertThat(options.preserveHostHeader(), is(true));
+    }
+
+    @Test
+    public void returnPreserveHostHeaderFalseWhenNotPresent() {
+        CommandLineOptions options = new CommandLineOptions("--port", "8080");
+        assertThat(options.preserveHostHeader(), is(false));
+    }
+
     @Test(expected=IllegalArgumentException.class)
     public void preventsRecordingWhenRequestJournalDisabled() {
         new CommandLineOptions("--no-request-journal", "--record-mappings");


### PR DESCRIPTION
As discussed in the Google group, I'm adding the --preserve-host-header option to tell Wiremock that we want it passes the Host header value as it comes from the client when running in proxy mode. If the --preserve-host-header option is not specified, it takes the host name from the url specified in the --proxy-all option.

Because I don't know the code deeply, this might not be the perfect solution. If you have any suggested change don't hesitate in letting me know.

Regarding the reason why I started to use the class WiremockConfiguration as an static holder of the configuration values is because the following reasons:
1. CommanLineOptions makes me thing about it simply as a way to communicate the user's needs to the application, with no logic at all, and to be used only in the highest layer of the application, because it's contact point to the external world.
2. We need to access to configuration values from the lower layers of the application, and I don't thing you want to change the signatures all the way down to pass the values through, mainly because we should keep the app flexible enough to support future changes in the parameter list (it wouldn't be nice to change the signatures again if a new option is added). 
