### PR TITLE
Better servlet mapping detection

### DIFF
--- a/sample-war/src/main/webappCustomMapping/WEB-INF/web.xml
+++ b/sample-war/src/main/webappCustomMapping/WEB-INF/web.xml
@@ -31,14 +31,6 @@
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.StubRequestHandler</param-value>
   	</init-param>
-    <init-param>
-     <!-- A servlet mapping path may be specified to allow a mapping of wiremock to a different path.
-     This has to be equal to the servlet mappings (e.g. if the wiremock servlet is mapped under /mapping and
-     the wiremock admin servlet is mapped under /mapping/__admin then the correct value for this setting would be
-     /mapping) -->
-      <param-name>mappedUnder</param-name>
-      <param-value>/mapping</param-value>
-    </init-param>
   </servlet>
   <servlet-mapping>
   	<servlet-name>wiremock-mock-service-handler-servlet</servlet-name>
@@ -52,14 +44,6 @@
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.AdminRequestHandler</param-value>
   	</init-param>
-    <init-param>
-      <!-- A servlet mapping path may be specified to allow a mapping of wiremock to a different path.
-      This has to be equal to the servlet mappings (e.g. if the wiremock servlet is mapped under /mapping and
-      the wiremock admin servlet is mapped under /mapping/__admin then the correct value for this setting would be
-      /mapping) -->
-      <param-name>mappedUnder</param-name>
-      <param-value>/mapping/__admin</param-value>
-    </init-param>
   </servlet>
   <servlet-mapping>
   	<servlet-name>wiremock-admin-handler-servlet</servlet-name>

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/HandlerDispatchingServlet.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/HandlerDispatchingServlet.java
@@ -39,12 +39,10 @@ import static java.net.URLDecoder.decode;
 public class HandlerDispatchingServlet extends HttpServlet {
 
 	public static final String SHOULD_FORWARD_TO_FILES_CONTEXT = "shouldForwardToFilesContext";
-	public static final String MAPPED_UNDER_KEY = "mappedUnder";
 
 	private static final long serialVersionUID = -6602042274260495538L;
 	
 	private RequestHandler requestHandler;
-	private String mappedUnder;
 	private Notifier notifier;
 	private String wiremockFileSourceRoot = "/";
 	private boolean shouldForwardToFilesContext;
@@ -59,26 +57,9 @@ public class HandlerDispatchingServlet extends HttpServlet {
 	    }
 		
 		String handlerClassName = config.getInitParameter(RequestHandler.HANDLER_CLASS_KEY);
-		mappedUnder = getNormalizedMappedUnder(config);
-		context.log(RequestHandler.HANDLER_CLASS_KEY + " from context returned " + handlerClassName +
-			". Normlized mapped under returned '" + mappedUnder + "'");
+		context.log(RequestHandler.HANDLER_CLASS_KEY + " from context returned " + handlerClassName + ".");
 		requestHandler = (RequestHandler) context.getAttribute(handlerClassName);
 		notifier = (Notifier) context.getAttribute(Notifier.KEY);
-	}
-	
-	/**
-	 * @param config Servlet configuration to read
-	 * @return Normalized mappedUnder attribute without trailing slash
-	*/
-	private String getNormalizedMappedUnder(ServletConfig config) {
-		String mappedUnder = config.getInitParameter(MAPPED_UNDER_KEY);
-		if(mappedUnder == null) {
-			return null;
-		}
-		if (mappedUnder.endsWith("/")) {
-			mappedUnder = mappedUnder.substring(0, mappedUnder.length() - 1);
-		}
-		return mappedUnder;
 	}
 	
 	private boolean getFileContextForwardingFlagFrom(ServletConfig config) {
@@ -90,7 +71,7 @@ public class HandlerDispatchingServlet extends HttpServlet {
 	protected void service(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws ServletException, IOException {
 		LocalNotifier.set(notifier);
 		
-		Request request = new HttpServletRequestAdapter(httpServletRequest, mappedUnder);
+		Request request = new HttpServletRequestAdapter(httpServletRequest);
         notifier.info("Received request: " + httpServletRequest.toString());
 
 		Response response = requestHandler.handle(request);

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/HttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/HttpServletRequestAdapter.java
@@ -38,15 +38,9 @@ public class HttpServletRequestAdapter implements Request {
 	
 	private final HttpServletRequest request;
 	private String cachedBody;
-	private String urlPrefixToRemove;
 
 	public HttpServletRequestAdapter(HttpServletRequest request) {
 		this.request = request;
-	}
-
-	public HttpServletRequestAdapter(HttpServletRequest request, String urlPrefixToRemove) {
-		this.request = request;
-		this.urlPrefixToRemove = urlPrefixToRemove;
 	}
 
 	@Override
@@ -57,8 +51,9 @@ public class HttpServletRequestAdapter implements Request {
 		if (!isNullOrEmpty(contextPath) && url.startsWith(contextPath)) {
 			url = url.substring(contextPath.length());
 		}
-		if(!isNullOrEmpty(urlPrefixToRemove) && url.startsWith(urlPrefixToRemove)) {
-			url = url.substring(urlPrefixToRemove.length());
+		String servletMapping = request.getServletPath();
+		if(!isNullOrEmpty(servletMapping) && url.startsWith(servletMapping)) {
+			url = url.substring(servletMapping.length());
 		}
 
 		return withQueryStringIfPresent(url);


### PR DESCRIPTION
Actually the change that I committed before where you had to supply the servlet mapping explicitly was not so good. Actually we can determine the mapping of the active servlet from the HttpServletRequest. This change removes the now unnecessary configuration in the web xml. The respective tests are still running. Enjoy :-)
