### PR TITLE
WIP: added support to enable slf4j notifier for standalone mode

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -92,9 +92,8 @@ public class CommandLineOptions implements Options {
     private static final String USE_CHUNKED_ENCODING = "use-chunked-encoding";
     private static final String MAX_TEMPLATE_CACHE_ENTRIES = "max-template-cache-entries";
     private static final String PERMITTED_SYSTEM_KEYS = "permitted-system-keys";
-
     private static final String DISABLE_GZIP = "disable-gzip";
-
+    private static final String ENABLED_SLF4J_NOTIFIER = "enable-slf4j-notifier";
 
     private final OptionSet optionSet;
     private final FileSource fileSource;
@@ -141,7 +140,7 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(MAX_TEMPLATE_CACHE_ENTRIES, "The maximum number of response template fragments that can be cached. Only has any effect when templating is enabled. Defaults to no limit.").withOptionalArg();
         optionParser.accepts(PERMITTED_SYSTEM_KEYS, "A list of case-insensitive regular expressions for names of permitted system properties and environment vars. Only has any effect when templating is enabled. Defaults to no limit.").withOptionalArg().ofType(String.class).withValuesSeparatedBy(",");
         optionParser.accepts(DISABLE_GZIP, "Disable gzipping of request and response bodies");
-
+        optionParser.accepts(ENABLED_SLF4J_NOTIFIER, "Enable SLF4JNotifier instead of default ConsoleNotifier");
 
         optionParser.accepts(HELP, "Print this message");
 
@@ -403,7 +402,13 @@ public class CommandLineOptions implements Options {
 
     @Override
     public Notifier notifier() {
-        return new ConsoleNotifier(verboseLoggingEnabled());
+        boolean verboseLoggingEnabled = verboseLoggingEnabled();
+
+        if (enableSlf4jNotifier()) {
+            return new Slf4jNotifier(verboseLoggingEnabled);
+        } else {
+            return new ConsoleNotifier(verboseLoggingEnabled);
+        }
     }
 
     @Override
@@ -434,6 +439,10 @@ public class CommandLineOptions implements Options {
         }
 
         return DEFAULT_CONTAINER_THREADS;
+    }
+
+    public boolean enableSlf4jNotifier() {
+        return optionSet.has(ENABLED_SLF4J_NOTIFIER);
     }
 
     @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -16,13 +16,15 @@
 package com.github.tomakehurst.wiremock.standalone;
 
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.common.ProxySettings;
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HandlebarsHelper;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
@@ -31,11 +33,11 @@ import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
 import com.github.tomakehurst.wiremock.security.Authenticator;
 import com.google.common.base.Optional;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.common.ProxySettings.NO_PROXY;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -443,7 +445,20 @@ public class CommandLineOptionsTest {
     public void defaultsToGzipEnabled() {
         CommandLineOptions options = new CommandLineOptions();
         assertThat(options.getGzipDisabled(), is(false));
+    }
 
+    @Test
+    public void enableSlf4jNotifier() {
+        CommandLineOptions options = new CommandLineOptions("--enable-slf4j-notifier");
+        assertThat(options.enableSlf4jNotifier(), is(true));
+        assertThat(options.notifier(), Matchers.instanceOf(Slf4jNotifier.class));
+    }
+
+    @Test
+    public void defaultsToConsoleNotifier() {
+        CommandLineOptions options = new CommandLineOptions();
+        assertThat(options.enableSlf4jNotifier(), is(false));
+        assertThat(options.notifier(), Matchers.instanceOf(ConsoleNotifier.class));
     }
 
     public static class ResponseDefinitionTransformerExt1 extends ResponseDefinitionTransformer {


### PR DESCRIPTION
This is only a WIP branch. We need to discuss how we can integrate with agreed upon logging framework.

@tomakehurst continuing from the email thread in wiremock-users (Subject: Slf4jNotifier cannot be enabled when running Wiremock in Standalone mode), I was wondering if we really need to tie it down to a particular framework or would it be preferable to keep wiremock independent of logging framework.

If we can make SLF4J work just by adding any desired framework and config into class-path at runtime (I need to verify if something like that would work), would that be better?