### PR TITLE
Allow standalone runner to fetch mappings from classpath

### DIFF
--- a/docs-v2/_docs/running-standalone.md
+++ b/docs-v2/_docs/running-standalone.md
@@ -298,6 +298,29 @@ matching the URL exists. For example if a file exists
 `/things/myfile.html` then hitting
 `http://<host>:<port>/things/myfile.html` will serve the file.
 
+## Packaging the stubs into a standalone JAR
+
+If you want to package your stubs into the standalone JAR, so you can distribute an executable JAR with all the stubs intact, you can do this using the `--load-resources-from-classpath` option.
+
+For example, let's say have the following directory structure:
+
+```
+src/main/resources
+src/main/resources/wiremock-stuff
+src/main/resources/wiremock-stuff/__files
+src/main/resources/wiremock-stuff/mappings
+```
+
+You could then run the packaged JAR as:
+
+```
+java -jar custom-wiremock.jar --load-resources-from-classpath 'wiremock-stuff'
+```
+
+Which will load your files and mappings from the packaged JAR.
+
+Note that it is not currently possible to load from the root of the classpath.
+
 ### Shutting Down
 
 To shutdown the server, either call `WireMock.shutdownServer()` or post

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -113,6 +113,7 @@ public class CommandLineOptions implements Options {
     private static final String HTTPS_CA_KEYSTORE = "ca-keystore";
     private static final String HTTPS_CA_KEYSTORE_PASSWORD = "ca-keystore-password";
     private static final String HTTPS_CA_KEYSTORE_TYPE = "ca-keystore-type";
+    private static final String LOAD_RESOURCES_FROM_CLASSPATH = "load-resources-from-classpath";
 
     private final OptionSet optionSet;
     private final FileSource fileSource;
@@ -173,6 +174,7 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(HTTPS_CA_KEYSTORE, "Path to an alternative keystore containing a Certificate Authority private key & certificate for generating certificates when proxying HTTPS. Password is assumed to be \"password\" if not specified.").availableIf(ENABLE_BROWSER_PROXYING).withRequiredArg().defaultsTo(DEFAULT_CA_KEYSTORE_PATH);
         optionParser.accepts(HTTPS_CA_KEYSTORE_PASSWORD, "Password for the alternative CA keystore.").availableIf(HTTPS_CA_KEYSTORE).withRequiredArg().defaultsTo(DEFAULT_CA_KESTORE_PASSWORD);
         optionParser.accepts(HTTPS_CA_KEYSTORE_TYPE, "Type of the alternative CA keystore (jks or pkcs12).").availableIf(HTTPS_CA_KEYSTORE).withRequiredArg().defaultsTo("jks");
+        optionParser.accepts(LOAD_RESOURCES_FROM_CLASSPATH, "Specifies path on the classpath for storing recordings (parent for " + MAPPINGS_ROOT + " and " + WireMockApp.FILES_ROOT + " folders)").withRequiredArg();
 
         optionParser.accepts(HELP, "Print this message").forHelp();
 
@@ -180,7 +182,12 @@ public class CommandLineOptions implements Options {
         validate();
 		captureHelpTextIfRequested(optionParser);
 
-        fileSource = new SingleRootFileSource((String) optionSet.valueOf(ROOT_DIR));
+        if (optionSet.has(LOAD_RESOURCES_FROM_CLASSPATH)) {
+            fileSource = new ClasspathFileSource((String) optionSet.valueOf(LOAD_RESOURCES_FROM_CLASSPATH));
+        } else {
+            fileSource = new SingleRootFileSource((String) optionSet.valueOf(ROOT_DIR));
+        }
+
         mappingsSource = new JsonFileMappingsSource(fileSource.child(MAPPINGS_ROOT));
         extensions = buildExtensions();
 

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -16,9 +16,12 @@
 package com.github.tomakehurst.wiremock.standalone;
 
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
+import com.github.tomakehurst.wiremock.common.ClasspathFileSource;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
 import com.github.tomakehurst.wiremock.common.ProxySettings;
+import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
+import com.github.tomakehurst.wiremock.core.MappingsSaver;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
@@ -596,6 +599,43 @@ public class CommandLineOptionsTest {
         Object two = options.extensionsOfType(ResponseDefinitionTransformer.class).get(ResponseTemplateTransformer.NAME);
 
         assertSame(one, two);
+    }
+
+    @Test
+    public void fileSourceDefaultsToSingleRootFileSource() {
+        CommandLineOptions options = new CommandLineOptions();
+
+        FileSource fileSource = options.filesRoot();
+
+        assertThat(fileSource, instanceOf(SingleRootFileSource.class));
+    }
+
+    @Test
+    public void mappingsSourceDefaultsToJsonFileMappingsSource() {
+        CommandLineOptions options = new CommandLineOptions();
+
+        MappingsSaver mappingsSaver = options.mappingsSaver();
+
+        assertThat(mappingsSaver, instanceOf(JsonFileMappingsSource.class));
+    }
+
+    @Test
+    public void loadResourcesFromClasspathSetsFileSourceToUseClasspath() {
+        CommandLineOptions options = new CommandLineOptions("--load-resources-from-classpath=classpath-filesource");
+
+        FileSource fileSource = options.filesRoot();
+
+        assertThat(fileSource, instanceOf(ClasspathFileSource.class));
+        assertThat(fileSource.getTextFileNamed("__files/stuff.txt").readContentsAsString(), equalTo("THINGS!"));
+    }
+
+    @Test
+    public void loadResourcesFromClasspathSetsMappingsSourceToUseClasspath() {
+        CommandLineOptions options = new CommandLineOptions("--load-resources-from-classpath=wiremock-stuff");
+
+        MappingsSaver mappingsSaver = options.mappingsSaver();
+
+        assertThat(mappingsSaver, instanceOf(JsonFileMappingsSource.class));
     }
 
     public static class ResponseDefinitionTransformerExt1 extends ResponseDefinitionTransformer {


### PR DESCRIPTION
To allow consumers to shade their standalone JAR with the stubs they
want to produce, for instance to allow there to be a single artefact
with all their stubs and code, we should allow this being specified to
be part of the classpath.

This introduces a new flag, `--root-dir-under-classpath`, to allow
configuring both the `__files` and `mappings` directories, as it's more
likely that they'll be configured together, especially as the underlying
`FileSource` is shared.

Closes #1502.
