### PR TITLE
Add link to JUnit 5 docs from Getting Started page

### DIFF
--- a/docs-v2/_docs/getting-started.md
+++ b/docs-v2/_docs/getting-started.md
@@ -109,6 +109,10 @@ int port = wireMockRule.port();
 int httpsPort = wireMockRule.httpsPort();
 ```
 
+## Writing a test with JUnit 5.x
+
+See [JUnit 5+ Jupiter Usage](/docs/junit-jupiter/) for various JUnit 5 usage scenarios.
+
 ## Non-JUnit and general Java usage
 
 If you're not using JUnit or neither of the WireMock rules manage its


### PR DESCRIPTION
At first glance it looks like JUnit 5 is not well supported due to specific callout for JUnit 4 usage and no mention of JUnit 5. This should help fix that.