### PR TITLE
Draft: Migrate project tests to JUnit 5 from JUnit 4

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/admin/model/GetScenariosResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/model/GetScenariosResult.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 
 import java.util.List;
-import java.util.Map;
 
 public class GetScenariosResult {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
@@ -32,7 +32,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Maps.newLinkedHashMap;
 
 class BasicMappingBuilder implements ScenarioMappingBuilder {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/common/DateTimeOffset.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/DateTimeOffset.java
@@ -17,10 +17,7 @@ package com.github.tomakehurst.wiremock.common;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.TimeZone;
-
 import static com.github.tomakehurst.wiremock.common.DateTimeUnit.SECONDS;
 
 public class DateTimeOffset {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/DateTimeParser.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/DateTimeParser.java
@@ -19,7 +19,6 @@ import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.Rend
 
 import java.time.*;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 import java.util.Date;

--- a/src/main/java/com/github/tomakehurst/wiremock/common/DateTimeTruncation.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/DateTimeTruncation.java
@@ -17,9 +17,7 @@ package com.github.tomakehurst.wiremock.common;
 
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.RenderableDate;
 
-import java.text.SimpleDateFormat;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Date;

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Gzip.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Gzip.java
@@ -27,7 +27,6 @@ import java.util.zip.GZIPOutputStream;
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 import static com.github.tomakehurst.wiremock.common.Strings.DEFAULT_CHARSET;
 import static com.github.tomakehurst.wiremock.common.Strings.bytesFromString;
-import static com.google.common.base.Charsets.UTF_8;
 
 public class Gzip {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/common/ProxySettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/ProxySettings.java
@@ -15,15 +15,9 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
-import static com.google.common.base.Splitter.on;
-import static com.google.common.collect.Iterables.get;
-import static com.google.common.collect.Iterables.getFirst;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterables;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/XPathException.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/XPathException.java
@@ -17,9 +17,6 @@ package com.github.tomakehurst.wiremock.common.xml;
 
 import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.InvalidInputException;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-
 import javax.xml.xpath.XPathExpressionException;
 
 public class XPathException extends InvalidInputException {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/XmlDocument.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/XmlDocument.java
@@ -16,26 +16,19 @@
 package com.github.tomakehurst.wiremock.common.xml;
 
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
-import org.custommonkey.xmlunit.SimpleNamespaceContext;
-import org.custommonkey.xmlunit.jaxp13.XMLUnitNamespaceContext2Jaxp13;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xmlunit.util.Convert;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
-import javax.xml.transform.Transformer;
 import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpressionException;
 
-import java.io.StringWriter;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 import static javax.xml.xpath.XPathConstants.NODESET;
 
 public class XmlDocument extends XmlNode {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/XmlException.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/XmlException.java
@@ -20,8 +20,6 @@ import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
-import javax.xml.xpath.XPathExpressionException;
-
 public class XmlException extends InvalidInputException {
 
     protected XmlException(Errors errors) {

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
@@ -23,12 +23,10 @@ import com.github.tomakehurst.wiremock.recording.RecordSpec;
 import com.github.tomakehurst.wiremock.recording.RecordSpecBuilder;
 import com.github.tomakehurst.wiremock.recording.RecordingStatusResult;
 import com.github.tomakehurst.wiremock.recording.SnapshotRecordResult;
-import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubImport;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.verification.*;
 
-import java.util.List;
 import java.util.UUID;
 
 public interface Admin {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/Parameters.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/Parameters.java
@@ -19,11 +19,8 @@ import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Metadata;
 import com.google.common.collect.ImmutableMap;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 public class Parameters extends Metadata {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -40,7 +40,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 public class ResponseTemplateTransformer extends ResponseDefinitionTransformer implements StubLifecycleListener {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ArrayHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ArrayHelper.java
@@ -19,9 +19,6 @@ import com.github.jknack.handlebars.Options;
 import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import static java.util.Arrays.asList;
 
 public class ArrayHelper extends HandlebarsHelper<Object> {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsHelper.java
@@ -19,9 +19,6 @@ import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.RenderCache;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 
 /**

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelper.java
@@ -16,24 +16,15 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
 import com.github.jknack.handlebars.Options;
-import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.RenderCache;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.ParseContext;
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
-
-import javax.xml.parsers.DocumentBuilder;
 import java.io.IOException;
-import java.io.StringReader;
-import java.util.Map;
-
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 public class HandlebarsJsonPathHelper extends HandlebarsHelper<Object> {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HostnameHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HostnameHelper.java
@@ -18,9 +18,6 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 import com.github.jknack.handlebars.Options;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
-
-import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 
 public class HostnameHelper extends HandlebarsHelper<Object> {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RandomDecimalHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RandomDecimalHelper.java
@@ -18,11 +18,9 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 import com.github.jknack.handlebars.Options;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HelperUtils.coerceToDouble;
-import static java.math.BigDecimal.ROUND_HALF_UP;
 
 public class RandomDecimalHelper extends HandlebarsHelper<Void> {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RangeHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RangeHelper.java
@@ -18,7 +18,6 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 import com.github.jknack.handlebars.Options;
 
 import java.io.IOException;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelper.java
@@ -20,7 +20,6 @@ import com.github.tomakehurst.wiremock.extension.responsetemplating.SystemKeyAut
 import org.apache.commons.lang3.StringUtils;
 
 import java.security.AccessControlException;
-import java.util.regex.Pattern;
 
 public class SystemValueHelper extends HandlebarsHelper<Object> {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
@@ -18,9 +18,6 @@ package com.github.tomakehurst.wiremock.http;
 import com.github.tomakehurst.wiremock.common.Strings;
 import com.google.common.base.Optional;
 import java.nio.charset.Charset;
-import static com.google.common.base.Charsets.UTF_8;
-
-import java.nio.charset.Charset;
 
 public class ContentTypeHeader extends HttpHeader {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
@@ -19,8 +19,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.Encoding;
 import com.github.tomakehurst.wiremock.common.Strings;
-import com.google.common.net.MediaType;
-
 import java.nio.charset.Charset;
 
 import static com.google.common.net.MediaType.OCTET_STREAM;

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -25,8 +25,6 @@ import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.AbstractTransformer;
 import com.github.tomakehurst.wiremock.extension.Parameters;
-import com.google.common.net.MediaType;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
@@ -21,11 +21,8 @@ import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
 import com.github.tomakehurst.wiremock.global.GlobalSettingsHolder;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import com.google.common.base.MoreObjects;
-
 import java.util.List;
 
-import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
 import static com.github.tomakehurst.wiremock.http.Response.response;
 import static com.google.common.base.MoreObjects.firstNonNull;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/multipart/PartParser.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/multipart/PartParser.java
@@ -15,7 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.http.multipart;
 
-import com.github.tomakehurst.wiremock.common.Exceptions;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.Request;

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ssl/HostVerifyingSSLSocketFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ssl/HostVerifyingSSLSocketFactory.java
@@ -19,7 +19,6 @@ import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpsFaultInjector.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpsFaultInjector.java
@@ -17,9 +17,6 @@ package com.github.tomakehurst.wiremock.jetty9;
 
 import com.github.tomakehurst.wiremock.core.FaultInjector;
 import com.google.common.base.Charsets;
-import org.eclipse.jetty.io.SelectChannelEndPoint;
-import org.eclipse.jetty.io.ssl.SslConnection;
-import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyUtils.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyUtils.java
@@ -17,10 +17,8 @@ package com.github.tomakehurst.wiremock.jetty9;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.Socket;
-import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/MultipartParser.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/MultipartParser.java
@@ -20,10 +20,8 @@ import com.github.tomakehurst.wiremock.servlet.WireMockHttpServletMultipartAdapt
 import com.google.common.base.Function;
 import org.eclipse.jetty.util.MultiPartInputStreamParser;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.Part;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.Collection;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty94/SslContexts.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty94/SslContexts.java
@@ -19,13 +19,10 @@ import com.github.tomakehurst.wiremock.common.BrowserProxySettings;
 import com.github.tomakehurst.wiremock.common.HttpsSettings;
 import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
-import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.http.ssl.CertificateAuthority;
 import com.github.tomakehurst.wiremock.http.ssl.CertificateGenerationUnsupportedException;
 import com.github.tomakehurst.wiremock.http.ssl.X509KeyStore;
-import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http2.HTTP2Cipher;
-import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import java.io.IOException;

--- a/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
@@ -16,18 +16,11 @@
 package com.github.tomakehurst.wiremock.junit;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.VerificationException;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.Options;
-import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import com.github.tomakehurst.wiremock.verification.NearMiss;
-import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
-import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
-
-import java.util.List;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -26,8 +26,6 @@ import org.junit.platform.commons.support.AnnotationSupport;
 
 import java.util.Optional;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 public class WireMockExtension extends DslWrapper implements ParameterResolver, BeforeEachCallback, BeforeAllCallback, AfterEachCallback, AfterAllCallback {
 
     private static final Options DEFAULT_OPTIONS = WireMockConfiguration.options().dynamicPort();

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractDateTimePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractDateTimePattern.java
@@ -22,18 +22,12 @@ import com.github.tomakehurst.wiremock.common.DateTimeUnit;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.common.DateTimeParser.ZONED_PARSERS;
-import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
-import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static java.util.Locale.US;
 
 public abstract class AbstractDateTimePattern extends StringValuePattern {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/AfterDateTimePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/AfterDateTimePattern.java
@@ -16,8 +16,6 @@
 package com.github.tomakehurst.wiremock.matching;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.tomakehurst.wiremock.common.DateTimeOffset;
-import com.github.tomakehurst.wiremock.common.DateTimeTruncation;
 import com.github.tomakehurst.wiremock.common.DateTimeUnit;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/ContentPatternDeserialiser.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/ContentPatternDeserialiser.java
@@ -17,25 +17,13 @@ package com.github.tomakehurst.wiremock.matching;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.github.tomakehurst.wiremock.common.Json;
-import com.github.tomakehurst.wiremock.common.Pair;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.util.List;
 import java.util.Map;
-
-import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
-import static com.github.tomakehurst.wiremock.common.Pair.pair;
 
 public class ContentPatternDeserialiser extends JsonDeserializer<ContentPattern<?>> {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToDateTimePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToDateTimePattern.java
@@ -16,7 +16,6 @@
 package com.github.tomakehurst.wiremock.matching;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.tomakehurst.wiremock.common.DateTimeTruncation;
 import com.github.tomakehurst.wiremock.common.DateTimeUnit;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.xml.Xml;
 import com.google.common.base.Joiner;
 import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.w3c.dom.Document;
@@ -34,7 +33,6 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.xmlunit.diff.ComparisonType.*;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/LogicalOr.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/LogicalOr.java
@@ -19,8 +19,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import static java.util.Arrays.asList;
 
 public class LogicalOr extends StringValuePattern {

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
@@ -23,11 +23,7 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 
 import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
-import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
 @JsonSerialize(using = JsonPathPatternJsonSerializer.class)

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
@@ -19,12 +19,10 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
-import com.github.tomakehurst.wiremock.common.Pair;
 import com.github.tomakehurst.wiremock.common.xml.*;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.stream.Collectors;

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/PathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/PathPattern.java
@@ -16,10 +16,8 @@
 package com.github.tomakehurst.wiremock.matching;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
 
-import java.util.List;
 import java.util.Objects;
 
 public abstract class PathPattern extends StringValuePattern {

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/PathPatternJsonSerializer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/PathPatternJsonSerializer.java
@@ -18,9 +18,7 @@ package com.github.tomakehurst.wiremock.matching;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.BeanSerializerBuilder;
 import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
 
 import java.io.IOException;

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePattern.java
@@ -18,8 +18,6 @@ package com.github.tomakehurst.wiremock.matching;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.tomakehurst.wiremock.common.DateTimeOffset;
 import com.github.tomakehurst.wiremock.common.DateTimeUnit;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.google.common.base.Optional;

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/ProxiedServeEventFilters.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/ProxiedServeEventFilters.java
@@ -15,7 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.recording;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/RequestBodyPatternFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/RequestBodyPatternFactory.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.matching.ContentPattern;
-import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 
 /**
  * Factory for the StringValuePattern to use in a recorded stub mapping to match request bodies

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHandlerDispatchingServlet.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHandlerDispatchingServlet.java
@@ -42,7 +42,6 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.URLDecoder.decode;
-import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class WireMockHandlerDispatchingServlet extends HttpServlet {

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -34,11 +34,9 @@ import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.*;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 
 import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
-import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
 import static com.github.tomakehurst.wiremock.common.Urls.splitQuery;
 import static com.google.common.base.Charsets.UTF_8;

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -23,7 +23,6 @@ import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockApp;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.extension.ExtensionLoader;
-import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.HttpServerFactory;

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSource.java
@@ -20,15 +20,12 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.stubbing.StubMappingCollection;
 import com.github.tomakehurst.wiremock.stubbing.StubMappings;
 import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.common.AbstractFileSource.byFileExtension;
-import static com.github.tomakehurst.wiremock.common.Json.write;
 import static com.github.tomakehurst.wiremock.common.Json.writePrivate;
 import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Iterables.filter;

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappings.java
@@ -37,7 +37,6 @@ import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
 import static com.github.tomakehurst.wiremock.http.ResponseDefinition.copyOf;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.FluentIterable.from;
-import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.find;
 import static com.google.common.collect.Iterables.tryFind;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/Scenarios.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/Scenarios.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.collect.FluentIterable.from;
 
 public class Scenarios {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.Timing;
-import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.PostServeActionDefinition;
 import com.github.tomakehurst.wiremock.http.LoggedResponse;
 import com.github.tomakehurst.wiremock.http.Response;
@@ -31,7 +30,6 @@ import com.google.common.base.Predicate;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.*;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Metadata;
 import com.github.tomakehurst.wiremock.extension.Parameters;
-import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.extension.PostServeActionDefinition;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappings.java
@@ -21,7 +21,6 @@ import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.google.common.base.Optional;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 public interface StubMappings {

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -21,13 +21,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.Dates;
 import com.github.tomakehurst.wiremock.common.Json;
-import com.github.tomakehurst.wiremock.common.Urls;
 import com.github.tomakehurst.wiremock.http.*;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableMap;
-
-import java.net.URI;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Date;
@@ -36,14 +32,12 @@ import java.util.Set;
 
 import java.nio.charset.Charset;
 
-import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 import static com.github.tomakehurst.wiremock.common.Urls.*;
 import static com.google.common.base.Charsets.UTF_8;
 
 import static com.github.tomakehurst.wiremock.common.Encoding.decodeBase64;
 import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
 import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
-import static com.github.tomakehurst.wiremock.http.HttpHeaders.copyOf;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.FluentIterable.from;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/diff/NamedCustomMatcherLine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/diff/NamedCustomMatcherLine.java
@@ -18,7 +18,6 @@ package com.github.tomakehurst.wiremock.verification.diff;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
-import com.github.tomakehurst.wiremock.matching.ValueMatcher;
 
 public class NamedCustomMatcherLine extends DiffLine<Request> {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/diff/PlainTextDiffRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/diff/PlainTextDiffRenderer.java
@@ -17,9 +17,6 @@ package com.github.tomakehurst.wiremock.verification.diff;
 
 import com.github.tomakehurst.wiremock.common.Strings;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.text.WordUtils;
-
 import java.util.Map;
 
 import static java.lang.System.lineSeparator;

--- a/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
@@ -20,9 +20,9 @@ import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.Stubbing;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,7 +43,7 @@ public class AcceptanceTestBase {
 
 	protected static Stubbing wm;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setupServer() {
 		setupServerWithEmptyFileRoot();
 
@@ -52,7 +52,7 @@ public class AcceptanceTestBase {
 		Locale.setDefault(Locale.ENGLISH);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void serverShutdown() {
 		wireMockServer.stop();
 	}
@@ -93,7 +93,7 @@ public class AcceptanceTestBase {
         wm = wireMockServer;
     }
 
-	@Before
+	@BeforeEach
 	public void init() throws InterruptedException {
 		WireMock.resetToDefault();
 	}

--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -36,8 +36,8 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.File;
@@ -55,18 +55,17 @@ import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalsMultiLine;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.matches;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartEquals;
-import static net.javacrumbs.jsonunit.JsonMatchers.jsonStringPartEquals;
 import static org.apache.http.entity.ContentType.TEXT_PLAIN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class AdminApiTest extends AcceptanceTestBase {
 
     static Stubbing dsl = wireMockServer;
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         deleteAllBodyFiles();
     }
@@ -691,7 +690,7 @@ public class AdminApiTest extends AcceptanceTestBase {
         int statusCode = testClient.delete("/__admin/files/bar.txt").statusCode();
 
         assertEquals(200, statusCode);
-        assertFalse("File should have been deleted", Paths.get(fileSource.getTextFileNamed(fileName).getPath()).toFile().exists());
+        assertFalse(Paths.get(fileSource.getTextFileNamed(fileName).getPath()).toFile().exists(), "File should have been deleted");
     }
 
     @Test
@@ -704,7 +703,7 @@ public class AdminApiTest extends AcceptanceTestBase {
         int statusCode = testClient.putWithBody("/__admin/files/bar.txt", "BBB", "text/plain").statusCode();
 
         assertEquals(200, statusCode);
-        assertEquals("File should have been changed", "BBB", fileSource.getTextFileNamed(fileName).readContentsAsString());
+        assertEquals("BBB", fileSource.getTextFileNamed(fileName).readContentsAsString(), "File should have been changed");
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/BasicAuthAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/BasicAuthAcceptanceTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;

--- a/src/test/java/com/github/tomakehurst/wiremock/BindAddressTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/BindAddressTest.java
@@ -19,8 +19,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.net.Inet4Address;
 import java.net.InetAddress;
@@ -29,15 +29,14 @@ import java.net.SocketException;
 import java.util.Collections;
 import java.util.Enumeration;
 
-import com.github.tomakehurst.wiremock.common.HttpClientUtils;
 import com.github.tomakehurst.wiremock.http.HttpClientFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.util.EntityUtils;
-import org.junit.*;
-
-import com.github.tomakehurst.wiremock.testsupport.MappingJsonSamples;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 
@@ -49,13 +48,13 @@ public class BindAddressTest {
 
     final HttpClient client = HttpClientFactory.createClient();
 
-    @Before
+    @BeforeEach
     public void prepare() throws Exception {
         nonBindAddress = getIpAddressOtherThan(localhost);
 
         assumeFalse(
-            "Impossible to validate the binding address. This machine has only a one Ip address [" + localhost + "]",
-            nonBindAddress == null);
+            nonBindAddress == null,
+            "Impossible to validate the binding address. This machine has only a one Ip address [" + localhost + "]");
 
         wireMockServer = new WireMockServer(wireMockConfig()
             .bindAddress(localhost)
@@ -68,7 +67,7 @@ public class BindAddressTest {
             .willReturn(aResponse().withStatus(200)));
     }
 
-    @After
+    @AfterEach
     public void stop() {
         if (wireMockServer != null) {
             wireMockServer.stop();

--- a/src/test/java/com/github/tomakehurst/wiremock/BrowserProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/BrowserProxyAcceptanceTest.java
@@ -17,7 +17,6 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import org.junit.*;

--- a/src/test/java/com/github/tomakehurst/wiremock/ConcurrentProxyingTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ConcurrentProxyingTest.java
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.junit.Rule;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;

--- a/src/test/java/com/github/tomakehurst/wiremock/ConcurrentProxyingTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ConcurrentProxyingTest.java
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;

--- a/src/test/java/com/github/tomakehurst/wiremock/ConcurrentProxyingTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ConcurrentProxyingTest.java
@@ -15,12 +15,9 @@
  */
 package com.github.tomakehurst.wiremock;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;

--- a/src/test/java/com/github/tomakehurst/wiremock/CookieMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CookieMatchingAcceptanceTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/CrossOriginTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CrossOriginTest.java
@@ -18,10 +18,10 @@ package com.github.tomakehurst.wiremock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -41,7 +41,7 @@ public class CrossOriginTest {
 
         WireMockTestClient testClient;
 
-        @Before
+        @BeforeEach
         public void init() {
             testClient = new WireMockTestClient(wm.port());
         }
@@ -80,7 +80,7 @@ public class CrossOriginTest {
 
         WireMockTestClient testClient;
 
-        @Before
+        @BeforeEach
         public void init() {
             testClient = new WireMockTestClient(wm.port());
         }

--- a/src/test/java/com/github/tomakehurst/wiremock/CrossOriginTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CrossOriginTest.java
@@ -18,10 +18,10 @@ package com.github.tomakehurst.wiremock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import org.junit.Before;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -41,7 +41,7 @@ public class CrossOriginTest {
 
         WireMockTestClient testClient;
 
-        @BeforeEach
+        @Before
         public void init() {
             testClient = new WireMockTestClient(wm.port());
         }
@@ -80,7 +80,7 @@ public class CrossOriginTest {
 
         WireMockTestClient testClient;
 
-        @BeforeEach
+        @Before
         public void init() {
             testClient = new WireMockTestClient(wm.port());
         }

--- a/src/test/java/com/github/tomakehurst/wiremock/CustomMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CustomMatchingAcceptanceTest.java
@@ -20,6 +20,7 @@ import com.github.tomakehurst.wiremock.common.AdminException;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.RequestMatcher;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
@@ -27,6 +28,7 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
@@ -37,19 +39,20 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class CustomMatchingAcceptanceTest {
 
     @SuppressWarnings("unchecked")
-    @Rule
-    public WireMockRule wmRule = new WireMockRule(options()
-        .dynamicPort()
-        .extensions(MyExtensionRequestMatcher.class),
-        false);
+    @RegisterExtension
+    public WireMockExtension wmRule = WireMockExtension.newInstance()
+        .options(options()
+                .dynamicPort()
+                .extensions(MyExtensionRequestMatcher.class))
+        .build();
 
     WireMockTestClient client;
     WireMock wm;
 
     @BeforeEach
     public void init() {
-        client = new WireMockTestClient(wmRule.port());
-        wm = WireMock.create().port(wmRule.port()).build();
+        client = new WireMockTestClient(wmRule.getRuntimeInfo().getHttpPort());
+        wm = WireMock.create().port(wmRule.getRuntimeInfo().getHttpPort()).build();
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/CustomMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CustomMatchingAcceptanceTest.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.client.WireMockBuilder;
 import com.github.tomakehurst.wiremock.common.AdminException;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Request;
@@ -23,15 +24,15 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.RequestMatcher;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import org.junit.Before;
 import org.junit.Rule;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CustomMatchingAcceptanceTest {
@@ -46,7 +47,7 @@ public class CustomMatchingAcceptanceTest {
     WireMockTestClient client;
     WireMock wm;
 
-    @BeforeEach
+    @Before
     public void init() {
         client = new WireMockTestClient(wmRule.port());
         wm = WireMock.create().port(wmRule.port()).build();
@@ -107,14 +108,12 @@ public class CustomMatchingAcceptanceTest {
         assertThat(client.postJson("/the/correct/one", "{}").statusCode(), is(404));
     }
 
-    @Test
+    @Test(expected = AdminException.class)
     public void throwsExecptionIfInlineCustomMatcherUsedWithRemote() {
-        assertThrows(AdminException.class, () -> {
-            wm.register(get(urlPathMatching("/the/.*/one"))
-                    .andMatching(new MyRequestMatcher())
-                    .willReturn(ok())
-            );
-        });
+        wm.register(get(urlPathMatching("/the/.*/one"))
+                .andMatching(new MyRequestMatcher())
+                .willReturn(ok())
+        );
     }
 
     public static class MyRequestMatcher extends RequestMatcherExtension {

--- a/src/test/java/com/github/tomakehurst/wiremock/CustomMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CustomMatchingAcceptanceTest.java
@@ -16,7 +16,6 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.client.WireMockBuilder;
 import com.github.tomakehurst.wiremock.common.AdminException;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Request;
@@ -24,15 +23,15 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.RequestMatcher;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
-import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CustomMatchingAcceptanceTest {
@@ -47,7 +46,7 @@ public class CustomMatchingAcceptanceTest {
     WireMockTestClient client;
     WireMock wm;
 
-    @Before
+    @BeforeEach
     public void init() {
         client = new WireMockTestClient(wmRule.port());
         wm = WireMock.create().port(wmRule.port()).build();
@@ -108,12 +107,14 @@ public class CustomMatchingAcceptanceTest {
         assertThat(client.postJson("/the/correct/one", "{}").statusCode(), is(404));
     }
 
-    @Test(expected = AdminException.class)
+    @Test
     public void throwsExecptionIfInlineCustomMatcherUsedWithRemote() {
-        wm.register(get(urlPathMatching("/the/.*/one"))
-                .andMatching(new MyRequestMatcher())
-                .willReturn(ok())
-        );
+        assertThrows(AdminException.class, () -> {
+            wm.register(get(urlPathMatching("/the/.*/one"))
+                    .andMatching(new MyRequestMatcher())
+                    .willReturn(ok())
+            );
+        });
     }
 
     public static class MyRequestMatcher extends RequestMatcherExtension {

--- a/src/test/java/com/github/tomakehurst/wiremock/DateHeaderAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/DateHeaderAcceptanceTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.Matchers.contains;

--- a/src/test/java/com/github/tomakehurst/wiremock/DeadlockTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/DeadlockTest.java
@@ -16,8 +16,12 @@
 package com.github.tomakehurst.wiremock;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.*;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,17 +32,19 @@ import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodName.class)
 public class DeadlockTest {
 
     private static final int READ_TIMEOUT = 500;
 
     private static WireMockServer wireMockServer;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         wireMockServer = new WireMockServer(options()
                 .dynamicPort()
@@ -47,12 +53,12 @@ public class DeadlockTest {
         wireMockServer.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         wireMockServer.stop();
     }
 
-    @Before
+    @BeforeEach
     public void reset() {
         System.out.println("reset");
         wireMockServer.resetAll();

--- a/src/test/java/com/github/tomakehurst/wiremock/DebugHeadersAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/DebugHeadersAcceptanceTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/DelayAndCustomMatcherAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/DelayAndCustomMatcherAcceptanceTest.java
@@ -26,7 +26,7 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import com.google.common.base.Stopwatch;
 import org.junit.Rule;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;

--- a/src/test/java/com/github/tomakehurst/wiremock/DelayAndCustomMatcherAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/DelayAndCustomMatcherAcceptanceTest.java
@@ -21,12 +21,12 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import com.google.common.base.Stopwatch;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
@@ -37,18 +37,20 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DelayAndCustomMatcherAcceptanceTest {
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort().extensions(BodyChanger.class));
+    @RegisterExtension
+    public WireMockExtension wireMockRule = WireMockExtension.newInstance()
+            .options(options().dynamicPort().extensions(BodyChanger.class))
+            .build();
 
     @Test
     public void delayIsAddedWhenCustomResponseTransformerPresent() {
-        stubFor(get(urlEqualTo("/delay-this"))
+        wireMockRule.stubFor(get(urlEqualTo("/delay-this"))
             .willReturn(aResponse()
                 .withStatus(200)
                 .withTransformers("response-body-changer")
                 .withUniformRandomDelay(500, 1000)));
 
-        WireMockTestClient client = new WireMockTestClient(wireMockRule.port());
+        WireMockTestClient client = new WireMockTestClient(wireMockRule.getRuntimeInfo().getHttpPort());
 
         Stopwatch stopwatch = Stopwatch.createStarted();
         WireMockResponse response = client.get("/delay-this");

--- a/src/test/java/com/github/tomakehurst/wiremock/DelayAndCustomMatcherAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/DelayAndCustomMatcherAcceptanceTest.java
@@ -26,7 +26,7 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import com.google.common.base.Stopwatch;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;

--- a/src/test/java/com/github/tomakehurst/wiremock/EditMappingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/EditMappingAcceptanceTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/com/github/tomakehurst/wiremock/EditStubMappingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/EditStubMappingAcceptanceTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.google.common.base.Predicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/GlobalSettingsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/GlobalSettingsAcceptanceTest.java
@@ -19,7 +19,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
 import com.github.tomakehurst.wiremock.http.LogNormal;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;

--- a/src/test/java/com/github/tomakehurst/wiremock/GlobalSettingsListenerExtensionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/GlobalSettingsListenerExtensionTest.java
@@ -21,10 +21,10 @@ import com.github.tomakehurst.wiremock.common.JsonException;
 import com.github.tomakehurst.wiremock.extension.GlobalSettingsListener;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Before;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -33,7 +33,7 @@ import java.util.List;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.Assert.fail;
 
 @RunWith(Enclosed.class)
 public class GlobalSettingsListenerExtensionTest {
@@ -47,7 +47,7 @@ public class GlobalSettingsListenerExtensionTest {
                 .dynamicPort()
                 .extensions(listener));
 
-        @BeforeEach
+        @Before
         public void init() {
             listener.events.clear();
         }

--- a/src/test/java/com/github/tomakehurst/wiremock/GlobalSettingsListenerExtensionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/GlobalSettingsListenerExtensionTest.java
@@ -21,10 +21,10 @@ import com.github.tomakehurst.wiremock.common.JsonException;
 import com.github.tomakehurst.wiremock.extension.GlobalSettingsListener;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -33,7 +33,7 @@ import java.util.List;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @RunWith(Enclosed.class)
 public class GlobalSettingsListenerExtensionTest {
@@ -47,7 +47,7 @@ public class GlobalSettingsListenerExtensionTest {
                 .dynamicPort()
                 .extensions(listener));
 
-        @Before
+        @BeforeEach
         public void init() {
             listener.events.clear();
         }

--- a/src/test/java/com/github/tomakehurst/wiremock/GzipAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/GzipAcceptanceTest.java
@@ -25,10 +25,10 @@ import org.apache.http.client.entity.GzipCompressingEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.eclipse.jetty.util.Jetty;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -37,8 +37,8 @@ import static com.github.tomakehurst.wiremock.common.Gzip.unGzipToString;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assume.assumeTrue;
 
 @RunWith(Enclosed.class)
 public class GzipAcceptanceTest {
@@ -98,7 +98,7 @@ public class GzipAcceptanceTest {
 
         WireMockTestClient testClient;
 
-        @Before
+        @BeforeEach
         public void init() {
             testClient = new WireMockTestClient(wm.port());
         }
@@ -135,7 +135,7 @@ public class GzipAcceptanceTest {
 
         WireMockTestClient testClient;
 
-        @Before
+        @BeforeEach
         public void init() {
             testClient = new WireMockTestClient(wm.port());
         }

--- a/src/test/java/com/github/tomakehurst/wiremock/GzipAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/GzipAcceptanceTest.java
@@ -25,10 +25,10 @@ import org.apache.http.client.entity.GzipCompressingEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.eclipse.jetty.util.Jetty;
+import org.junit.Before;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -37,8 +37,8 @@ import static com.github.tomakehurst.wiremock.common.Gzip.unGzipToString;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 @RunWith(Enclosed.class)
 public class GzipAcceptanceTest {
@@ -98,7 +98,7 @@ public class GzipAcceptanceTest {
 
         WireMockTestClient testClient;
 
-        @BeforeEach
+        @Before
         public void init() {
             testClient = new WireMockTestClient(wm.port());
         }
@@ -135,7 +135,7 @@ public class GzipAcceptanceTest {
 
         WireMockTestClient testClient;
 
-        @BeforeEach
+        @Before
         public void init() {
             testClient = new WireMockTestClient(wm.port());
         }

--- a/src/test/java/com/github/tomakehurst/wiremock/HeaderMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HeaderMatchingAcceptanceTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.testsupport.MappingJsonSamples;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;

--- a/src/test/java/com/github/tomakehurst/wiremock/Http2AcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/Http2AcceptanceTest.java
@@ -22,9 +22,8 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
-import org.eclipse.jetty.http.HttpVersion;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;

--- a/src/test/java/com/github/tomakehurst/wiremock/Http2AcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/Http2AcceptanceTest.java
@@ -16,30 +16,27 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.http.HttpClientFactory;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.eclipse.jetty.http.HttpVersion.HTTP_2;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class Http2AcceptanceTest {
 
-    @Rule
-    public WireMockRule wm = new WireMockRule(
-            wireMockConfig()
-                    .dynamicPort()
-                    .dynamicHttpsPort()
-    );
+    @RegisterExtension
+    public WireMockExtension wm = WireMockExtension.newInstance()
+            .options(options().dynamicPort().dynamicHttpsPort()).build();
 
     @Test
     public void supportsHttp2Connections() throws Exception {
@@ -47,7 +44,7 @@ public class Http2AcceptanceTest {
 
         wm.stubFor(get("/thing").willReturn(ok("HTTP/2 response")));
 
-        ContentResponse response = client.GET("https://localhost:" + wm.httpsPort() + "/thing");
+        ContentResponse response = client.GET("https://localhost:" + wm.getRuntimeInfo().getHttpsPort() + "/thing");
         assertThat(response.getStatus(), is(200));
     }
 
@@ -57,7 +54,7 @@ public class Http2AcceptanceTest {
 
         wm.stubFor(get("/thing").willReturn(ok("HTTP/2 response")));
 
-        ContentResponse response = client.GET("http://localhost:" + wm.port() + "/thing");
+        ContentResponse response = client.GET("http://localhost:" + wm.getRuntimeInfo().getHttpPort() + "/thing");
         assertThat(response.getVersion(), is(HTTP_2));
         assertThat(response.getStatus(), is(200));
     }
@@ -68,7 +65,7 @@ public class Http2AcceptanceTest {
 
         wm.stubFor(get("/thing").willReturn(ok("HTTP/1.1 response")));
 
-        HttpGet get = new HttpGet("https://localhost:" + wm.httpsPort() + "/thing");
+        HttpGet get = new HttpGet("https://localhost:" + wm.getRuntimeInfo().getHttpsPort() + "/thing");
         try (CloseableHttpResponse response = client.execute(get)) {
             assertThat(response.getStatusLine().getStatusCode(), is(200));
         }

--- a/src/test/java/com/github/tomakehurst/wiremock/Http2AcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/Http2AcceptanceTest.java
@@ -22,8 +22,9 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpVersion;
 import org.junit.Rule;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpsAcceptanceTest.java
@@ -37,10 +37,8 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.util.EntityUtils;
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
@@ -60,10 +58,11 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.*;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class HttpsAcceptanceTest {
 
@@ -71,10 +70,7 @@ public class HttpsAcceptanceTest {
     private WireMockServer proxy;
     private HttpClient httpClient;
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
-    @After
+    @AfterEach
     public void serverShutdown() {
         if (wireMockServer != null) {
             wireMockServer.stop();
@@ -95,29 +91,26 @@ public class HttpsAcceptanceTest {
 
     @Test
     public void shouldReturnOnlyOnHttpsWhenHttpDisabled() throws Exception {
-        // HTTP
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("Not listening on HTTP port. Either HTTP is not enabled or the WireMock server is stopped.");
-        // HTTPS
-        WireMockConfiguration config = wireMockConfig().httpDisabled(true).dynamicHttpsPort();
-        wireMockServer = new WireMockServer(config);
-        wireMockServer.start();
-        WireMock.configureFor("https", "localhost", wireMockServer.httpsPort());
-        httpClient = HttpClientFactory.createClient();
+        Throwable exception = assertThrows(IllegalStateException.class, () -> {
+            // HTTPS
+            WireMockConfiguration config = wireMockConfig().httpDisabled(true).dynamicHttpsPort();
+            wireMockServer = new WireMockServer(config);
+            wireMockServer.start();
+            WireMock.configureFor("https", "localhost", wireMockServer.httpsPort());
+            httpClient = HttpClientFactory.createClient();
 
-        stubFor(get(urlEqualTo("/https-test")).willReturn(aResponse().withStatus(200).withBody("HTTPS content")));
+            stubFor(get(urlEqualTo("/https-test")).willReturn(aResponse().withStatus(200).withBody("HTTPS content")));
 
-        wireMockServer.port();
-        assertThat(contentFor(url("/https-test")), is("HTTPS content"));
+            wireMockServer.port();
+            assertThat(contentFor(url("/https-test")), is("HTTPS content"));
+        });
+        assertTrue(exception.getMessage().contains("Not listening on HTTP port. Either HTTP is not enabled or the WireMock server is stopped."));
     }
-
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
 
     @Test
     public void connectionResetByPeerFault() throws IOException {
-        assumeFalse("This feature does not work on Windows " +
-            "because of differing native socket behaviour", SystemUtils.IS_OS_WINDOWS);
+        assumeFalse(SystemUtils.IS_OS_WINDOWS, "This feature does not work on Windows " +
+            "because of differing native socket behaviour");
 
         startServerWithDefaultKeystore();
         stubFor(get(urlEqualTo("/connection/reset")).willReturn(
@@ -166,10 +159,12 @@ public class HttpsAcceptanceTest {
         getAndAssertUnderlyingExceptionInstanceClass(url("/random/data"), ProtocolException.class);
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void throwsExceptionWhenBadAlternativeKeystore() {
-        String testKeystorePath = Resources.getResource("bad-keystore").toString();
-        startServerWithKeystore(testKeystorePath);
+        assertThrows(Exception.class, () -> {
+            String testKeystorePath = Resources.getResource("bad-keystore").toString();
+            startServerWithKeystore(testKeystorePath);
+        });
     }
 
     @Test
@@ -297,7 +292,7 @@ public class HttpsAcceptanceTest {
             thrown = true;
         }
 
-        assertTrue("No exception was thrown", thrown);
+        assertTrue(thrown, "No exception was thrown");
     }
 
     private String contentFor(String url) throws Exception {

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyClientAuthAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyClientAuthAcceptanceTest.java
@@ -28,7 +28,7 @@ import org.apache.http.ssl.SSLContexts;
 import org.apache.http.util.EntityUtils;
 import org.junit.ClassRule;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyClientAuthAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyClientAuthAcceptanceTest.java
@@ -28,7 +28,7 @@ import org.apache.http.ssl.SSLContexts;
 import org.apache.http.util.EntityUtils;
 import org.junit.ClassRule;
 import org.junit.Rule;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;

--- a/src/test/java/com/github/tomakehurst/wiremock/JvmProxyConfigAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/JvmProxyConfigAcceptanceTest.java
@@ -7,8 +7,8 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -18,13 +18,12 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 public class JvmProxyConfigAcceptanceTest {
 
     WireMockServer wireMockServer;
 
-    @After
+    @AfterEach
     public void cleanup() {
         if (wireMockServer != null) {
             wireMockServer.stop();

--- a/src/test/java/com/github/tomakehurst/wiremock/LogTimingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/LogTimingAcceptanceTest.java
@@ -17,9 +17,9 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.common.Timing;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
@@ -27,10 +27,10 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@Ignore("Very slow and not likely to change any time soon")
+@Disabled("Very slow and not likely to change any time soon")
 public class LogTimingAcceptanceTest extends AcceptanceTestBase {
 
-    @BeforeClass
+    @BeforeAll
     public static void setupServer() {
         setupServer(options().asynchronousResponseEnabled(true).asynchronousResponseThreads(5));
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/MappingsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MappingsAcceptanceTest.java
@@ -17,21 +17,21 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.testsupport.MappingJsonSamples;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.testsupport.MappingJsonSamples.BINARY_COMPRESSED_CONTENT;
 import static com.github.tomakehurst.wiremock.testsupport.MappingJsonSamples.MAPPING_REQUEST_FOR_BINARY_BYTE_BODY;
 import static com.github.tomakehurst.wiremock.testsupport.MappingJsonSamples.MAPPING_REQUEST_FOR_BYTE_BODY;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MappingsAcceptanceTest extends AcceptanceTestBase {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setupServer() {
 		setupServerWithMappingsInFileRoot();
 	}
@@ -186,7 +186,7 @@ public class MappingsAcceptanceTest extends AcceptanceTestBase {
         WireMockResponse response = testClient.get("/with/body");
 
         assertThat(response.firstHeader("Content-Length"), is("12"));
-        assertFalse("expected Transfer-Encoding head to be absent", response.headers().containsKey("Transfer-Encoding"));
+        assertFalse(response.headers().containsKey("Transfer-Encoding"), "expected Transfer-Encoding head to be absent");
     }
 
 	private void getResponseAndAssert200Status(String url) {

--- a/src/test/java/com/github/tomakehurst/wiremock/MappingsLoaderAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MappingsLoaderAcceptanceTest.java
@@ -20,13 +20,11 @@ import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.standalone.JsonFileMappingsSource;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
-import com.github.tomakehurst.wiremock.testsupport.TestFiles;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -43,12 +41,12 @@ public class MappingsLoaderAcceptanceTest {
 	private WireMockServer wireMockServer;
 	private WireMockTestClient testClient;
 
-	@Before
+	@BeforeEach
 	public void init() {
         configuration = wireMockConfig().dynamicPort();
 	}
 
-	@After
+	@AfterEach
 	public void stopWireMock() {
 		wireMockServer.stop();
 	}

--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
@@ -25,7 +25,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.util.EntityUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.testsupport.MultipartBody.part;

--- a/src/test/java/com/github/tomakehurst/wiremock/MultithreadConfigurationInheritanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultithreadConfigurationInheritanceTest.java
@@ -17,23 +17,19 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import java.io.File;
-import java.net.URL;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.Assert.assertEquals;
 
 public class MultithreadConfigurationInheritanceTest {
 
     private static WireMockServer wireMockServer;
     private static WireMockTestClient client;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup(){
         wireMockServer = new WireMockServer(0);
         wireMockServer.start();
@@ -41,12 +37,13 @@ public class MultithreadConfigurationInheritanceTest {
         client = new WireMockTestClient(wireMockServer.port());
     }
 
-    @AfterClass
+    @AfterAll
     public static void shutdown(){
         wireMockServer.shutdown();
     }
 
-    @Test(timeout = 5000) //Add a timeout so the test will execute in a new thread
+    @Test
+    @Timeout(5000) //Add a timeout so the test will execute in a new thread
     public void verifyConfigurationInherited() {
         //Make a call to the wiremock server. If this doesn't call to 8082 this will fail
         //with an exception

--- a/src/test/java/com/github/tomakehurst/wiremock/NearMissesAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/NearMissesAcceptanceTest.java
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.github.tomakehurst.wiremock.verification.NearMiss;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/NearMissesRuleAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/NearMissesRuleAcceptanceTest.java
@@ -26,12 +26,10 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import ignored.ManyUnmatchedRequestsTest;
 import ignored.SingleUnmatchedRequestTest;
 import org.apache.http.entity.StringEntity;
-import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.RunWith;
 import org.junit.runner.notification.Failure;
@@ -43,6 +41,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static com.github.tomakehurst.wiremock.verification.diff.JUnitStyleDiffRenderer.junitStyleDiffMessage;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(Enclosed.class)
@@ -51,9 +51,6 @@ public class NearMissesRuleAcceptanceTest {
     public static class NearMissesRuleTest {
 
         static TestNotifier testNotifier = new TestNotifier();
-
-        @Rule
-        public ExpectedException thrown = ExpectedException.none();
 
         @ClassRule
         public static WireMockRule wm = new WireMockRule(options()
@@ -64,7 +61,7 @@ public class NearMissesRuleAcceptanceTest {
 
         WireMockTestClient client;
 
-        @Before
+        @BeforeEach
         public void init() {
             client = new WireMockTestClient(wm.port());
             testNotifier.reset();
@@ -121,12 +118,13 @@ public class NearMissesRuleAcceptanceTest {
 
         @Test
         public void shouldFindNearMatch() {
-            thrown.expect(VerificationException.class);
-            thrown.expectMessage("No requests exactly matched. Most similar request was:");
+            Throwable exception = assertThrows(VerificationException.class, () -> {
 
-            client.get("/123");
+                client.get("/123");
 
-            wm.verify(getRequestedFor(urlPathEqualTo("/")));
+                wm.verify(getRequestedFor(urlPathEqualTo("/")));
+            });
+            assertTrue(exception.getMessage().contains("No requests exactly matched. Most similar request was:"));
         }
 
         private static String runTestAndGetMessage(Class<?> testClass) {
@@ -166,7 +164,7 @@ public class NearMissesRuleAcceptanceTest {
 
         WireMockTestClient client;
 
-        @Before
+        @BeforeEach
         public void init() {
             client = new WireMockTestClient(wm.port());
             wm.resetAll();

--- a/src/test/java/com/github/tomakehurst/wiremock/NetworkTrafficListenerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/NetworkTrafficListenerAcceptanceTest.java
@@ -17,8 +17,8 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.http.trafficlistener.CollectingNetworkTrafficListener;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -26,7 +26,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class NetworkTrafficListenerAcceptanceTest extends AcceptanceTestBase {
 	private static CollectingNetworkTrafficListener networkTrafficListener = new CollectingNetworkTrafficListener();
 
-	@BeforeClass
+	@BeforeAll
 	public static void setupServer() {
 		setupServer(new WireMockConfiguration().networkTrafficListener(networkTrafficListener));
 	}

--- a/src/test/java/com/github/tomakehurst/wiremock/NotMatchedPageAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/NotMatchedPageAcceptanceTest.java
@@ -27,18 +27,13 @@ import com.github.tomakehurst.wiremock.extension.requestfilter.RequestWrapper;
 import com.github.tomakehurst.wiremock.extension.requestfilter.StubRequestFilter;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import com.github.tomakehurst.wiremock.testsupport.TestHttpHeader;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import com.github.tomakehurst.wiremock.verification.diff.PlainTextDiffRenderer;
 import com.github.tomakehurst.wiremock.verification.notmatched.NotMatchedRenderer;
-import com.github.tomakehurst.wiremock.verification.notmatched.PlainTextStubNotMatchedRenderer;
-import org.apache.http.HttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -58,7 +53,7 @@ public class NotMatchedPageAcceptanceTest {
     WireMockServer wm;
     WireMockTestClient testClient;
 
-    @After
+    @AfterEach
     public void stop() {
         wm.stop();
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/PortNumberTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/PortNumberTest.java
@@ -20,9 +20,9 @@ import com.github.tomakehurst.wiremock.testsupport.MappingJsonSamples;
 import com.github.tomakehurst.wiremock.testsupport.Network;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,18 +30,19 @@ import java.util.List;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PortNumberTest {
 
     private List<WireMockServer> createdServers;
 
-    @Before
+    @BeforeEach
     public void setup() {
         createdServers = new ArrayList<WireMockServer>();
     }
 
-    @After
+    @AfterEach
     public void stopServers() {
         for (WireMockServer wireMockServer : createdServers) {
             if(wireMockServer.isRunning()) {
@@ -74,21 +75,27 @@ public class PortNumberTest {
         assertThat(wireMockServer.httpsPort(), is(httpsPort));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void unstartedServerThrowsExceptionWhenAttemptingToRetrievePort() {
-        createServer(wireMockConfig().port(Network.findFreePort())).port();
+        assertThrows(IllegalStateException.class, () -> {
+            createServer(wireMockConfig().port(Network.findFreePort())).port();
+        });
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void unstartedServerThrowsExceptionWhenAttemptingToRetrieveHttpsPort() {
-        createServer(wireMockConfig().httpsPort(Network.findFreePort())).httpsPort();
+        assertThrows(IllegalStateException.class, () -> {
+            createServer(wireMockConfig().httpsPort(Network.findFreePort())).httpsPort();
+        });
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void serverWithoutHttpsThrowsExceptionWhenAttemptingToRetrieveHttpsPort() {
-        WireMockServer wireMockServer = createServer(wireMockConfig().port(Network.findFreePort()));
-        wireMockServer.start();
-        wireMockServer.httpsPort();
+        assertThrows(IllegalStateException.class, () -> {
+            WireMockServer wireMockServer = createServer(wireMockConfig().port(Network.findFreePort()));
+            wireMockServer.start();
+            wireMockServer.httpsPort();
+        });
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/PostServeActionExtensionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/PostServeActionExtensionTest.java
@@ -31,8 +31,8 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -45,7 +45,6 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartEquals;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
@@ -62,7 +61,7 @@ public class PostServeActionExtensionTest {
         client = new WireMockTestClient(wm.port());
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         if (wm != null) {
             wm.stop();

--- a/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
@@ -38,14 +38,13 @@ import com.sun.net.httpserver.HttpServer;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.entity.GzipCompressingEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
@@ -57,7 +56,7 @@ import static org.apache.http.entity.ContentType.TEXT_PLAIN;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ProxyAcceptanceTest {
@@ -95,7 +94,7 @@ public class ProxyAcceptanceTest {
         init(wireMockConfig());
     }
 	
-	@After
+	@AfterEach
 	public void stop() {
 		targetService.stop();
         proxyingService.stop();
@@ -399,8 +398,8 @@ public class ProxyAcceptanceTest {
 
         testClient.get("/no-accept-encoding-header");
         LoggedRequest lastRequest = getLast(target.find(getRequestedFor(urlEqualTo("/no-accept-encoding-header"))));
-        assertFalse("Accept-Encoding header should not be present",
-                lastRequest.getHeaders().getHeader("Accept-Encoding").isPresent());
+        assertFalse(lastRequest.getHeaders().getHeader("Accept-Encoding").isPresent(),
+                "Accept-Encoding header should not be present");
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/QueuedThreadPoolAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/QueuedThreadPoolAcceptanceTest.java
@@ -20,15 +20,15 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ThreadPool;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class QueuedThreadPoolAcceptanceTest extends AcceptanceTestBase {
 
-    @BeforeClass
+    @BeforeAll
     public static void setupServer() {
         setupServer(new WireMockConfiguration().threadPoolFactory(new InstrumentedThreadPoolFactory()));
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/RecordApiAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecordApiAcceptanceTest.java
@@ -24,9 +24,9 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import com.google.common.base.Predicate;
 import org.apache.http.entity.StringEntity;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.util.UUID;
@@ -40,7 +40,7 @@ import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.findMappi
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.collect.Iterables.find;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RecordApiAcceptanceTest extends AcceptanceTestBase {
@@ -63,12 +63,12 @@ public class RecordApiAcceptanceTest extends AcceptanceTestBase {
         proxyServerStart(wireMockConfig().withRootDirectory("src/test/resources/empty"));
     }
 
-    @Before
+    @BeforeEach
     public void clearTargetServerMappings() {
         wireMockServer.resetMappings();
     }
 
-    @After
+    @AfterEach
     public void proxyServerShutdown() {
         // delete any persisted stub mappings to ensure test isolation
         proxyingService.resetMappings();

--- a/src/test/java/com/github/tomakehurst/wiremock/RecordingDslAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecordingDslAcceptanceTest.java
@@ -28,8 +28,8 @@ import org.apache.http.HttpEntity;
 import org.apache.http.client.entity.GzipCompressingEntity;
 import org.apache.http.entity.StringEntity;
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.List;
@@ -45,6 +45,7 @@ import static org.apache.http.entity.ContentType.APPLICATION_OCTET_STREAM;
 import static org.apache.http.entity.ContentType.TEXT_PLAIN;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RecordingDslAcceptanceTest extends AcceptanceTestBase {
@@ -71,7 +72,7 @@ public class RecordingDslAcceptanceTest extends AcceptanceTestBase {
         adminClient = WireMock.create().port(proxyingService.port()).build();
     }
 
-    @After
+    @AfterEach
     public void proxyServerShutdown() {
         proxyingService.resetMappings();
         proxyingService.stop();
@@ -373,28 +374,38 @@ public class RecordingDslAcceptanceTest extends AcceptanceTestBase {
         assertThat(bodyFileName, nullValue());
     }
 
-    @Test(expected = NotRecordingException.class)
+    @Test
     public void throwsAnErrorIfAttemptingToStopViaStaticRemoteDslWhenNotRecording() {
-        stopRecording();
+        assertThrows(NotRecordingException.class, () -> {
+            stopRecording();
+        });
     }
 
-    @Test(expected = NotRecordingException.class)
+    @Test
     public void throwsAnErrorIfAttemptingToStopViaInstanceRemoteDslWhenNotRecording() {
-        adminClient.stopStubRecording();
+        assertThrows(NotRecordingException.class, () -> {
+            adminClient.stopStubRecording();
+        });
     }
 
-    @Test(expected = NotRecordingException.class)
+    @Test
     public void throwsAnErrorIfAttemptingToStopViaDirectDslWhenNotRecording() {
-        proxyingService.stopRecording();
+        assertThrows(NotRecordingException.class, () -> {
+            proxyingService.stopRecording();
+        });
     }
 
-    @Test(expected = InvalidInputException.class)
+    @Test
     public void throwsValidationErrorWhenAttemptingToStartRecordingViaStaticDslWithNoTargetUrl() {
-        startRecording(recordSpec());
+        assertThrows(InvalidInputException.class, () -> {
+            startRecording(recordSpec());
+        });
     }
 
-    @Test(expected = InvalidInputException.class)
+    @Test
     public void throwsValidationErrorWhenAttemptingToStartRecordingViaDirectDslWithNoTargetUrl() {
-        proxyingService.startRecording(recordSpec());
+        assertThrows(InvalidInputException.class, () -> {
+            proxyingService.startRecording(recordSpec());
+        });
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/RecordingDslAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecordingDslAcceptanceTest.java
@@ -29,6 +29,7 @@ import org.apache.http.client.entity.GzipCompressingEntity;
 import org.apache.http.entity.StringEntity;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -57,6 +58,7 @@ public class RecordingDslAcceptanceTest extends AcceptanceTestBase {
     private String targetBaseUrl;
     private File fileRoot;
 
+    @BeforeEach
     public void init() {
         fileRoot = setupTempFileRoot();
         proxyingService = new WireMockServer(wireMockConfig()

--- a/src/test/java/com/github/tomakehurst/wiremock/RemoteMappingsLoaderAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RemoteMappingsLoaderAcceptanceTest.java
@@ -17,10 +17,9 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.admin.model.SingleStubMappingResult;
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.client.WireMockBuilder;
 import com.google.common.io.Resources;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.UUID;
@@ -34,7 +33,7 @@ public class RemoteMappingsLoaderAcceptanceTest extends AcceptanceTestBase {
     static WireMock wmClient;
     static File rootDir;
 
-    @BeforeClass
+    @BeforeAll
     public static void initWithTempDir() throws Exception {
         setupServerWithTempFileRoot();
         wmClient = WireMock.create().port(wireMockServer.port()).build();

--- a/src/test/java/com/github/tomakehurst/wiremock/RemoveStubMappingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RemoveStubMappingAcceptanceTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.google.common.base.Predicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/RequestFilterAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RequestFilterAcceptanceTest.java
@@ -22,11 +22,10 @@ import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 
@@ -148,12 +147,12 @@ public class RequestFilterAcceptanceTest {
         proxyTarget.stop();
     }
 
-    @Before
+    @BeforeEach
     public void init() {
         url = "/" + RandomStringUtils.randomAlphabetic(5);
     }
 
-    @After
+    @AfterEach
     public void stopServer() {
         wm.stop();
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/RequestQueryAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RequestQueryAcceptanceTest.java
@@ -29,7 +29,7 @@ import static com.google.common.base.Charsets.UTF_8;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
 import java.util.Date;

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionTransformerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionTransformerAcceptanceTest.java
@@ -23,8 +23,8 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -32,6 +32,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.defaultTestFilesRoot;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ResponseDefinitionTransformerAcceptanceTest {
@@ -120,12 +121,14 @@ public class ResponseDefinitionTransformerAcceptanceTest {
         assertThat(response.content(), is("Non-global transformed body"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     @SuppressWarnings("unchecked")
     public void preventsMoreThanOneExtensionWithTheSameNameFromBeingAdded() {
-        new WireMockServer(wireMockConfig()
-                .dynamicPort()
-                .extensions(ExampleTransformer.class, AnotherExampleTransformer.class));
+        assertThrows(IllegalArgumentException.class, () -> {
+            new WireMockServer(wireMockConfig()
+                    .dynamicPort()
+                    .extensions(ExampleTransformer.class, AnotherExampleTransformer.class));
+        });
     }
 
     @Test
@@ -160,7 +163,7 @@ public class ResponseDefinitionTransformerAcceptanceTest {
         client = new WireMockTestClient(wm.port());
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         if (wm != null) {
             wm.stop();

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDelayAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDelayAcceptanceTest.java
@@ -24,10 +24,9 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.SocketTimeoutException;
 import java.util.concurrent.ExecutorService;
@@ -39,8 +38,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static java.lang.Thread.sleep;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResponseDelayAcceptanceTest {
 
@@ -52,13 +52,10 @@ public class ResponseDelayAcceptanceTest {
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(Options.DYNAMIC_PORT, Options.DYNAMIC_PORT);
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     private HttpClient httpClient;
     private WireMockTestClient testClient;
 
-    @Before
+    @BeforeEach
     public void init() {
         httpClient = HttpClientFactory.createClient(SOCKET_TIMEOUT_MILLISECONDS);
         testClient = new WireMockTestClient(wireMockRule.port());
@@ -158,13 +155,13 @@ public class ResponseDelayAcceptanceTest {
 
     @Test
     public void requestTimesOutWhenDelayIsLongerThanSocketTimeout() throws Exception {
-        stubFor(get(urlEqualTo("/delayed")).willReturn(
-                aResponse()
-                        .withStatus(200)
-                        .withFixedDelay(LONGER_THAN_SOCKET_TIMEOUT)));
-
-        exception.expect(SocketTimeoutException.class);
-        httpClient.execute(new HttpGet(String.format("http://localhost:%d/delayed", wireMockRule.port())));
+        assertThrows(SocketTimeoutException.class, () -> {
+            stubFor(get(urlEqualTo("/delayed")).willReturn(
+                    aResponse()
+                            .withStatus(200)
+                            .withFixedDelay(LONGER_THAN_SOCKET_TIMEOUT)));
+            httpClient.execute(new HttpGet(String.format("http://localhost:%d/delayed", wireMockRule.port())));
+        });
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDelayAsynchronousAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDelayAsynchronousAcceptanceTest.java
@@ -23,7 +23,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.junit.Rule;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDelayAsynchronousAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDelayAsynchronousAcceptanceTest.java
@@ -23,7 +23,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDribbleAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDribbleAcceptanceTest.java
@@ -23,9 +23,9 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
 import org.hamcrest.Matcher;
+import org.junit.Before;
 import org.junit.Rule;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import java.io.IOException;
 
@@ -50,7 +50,7 @@ public class ResponseDribbleAcceptanceTest {
 
     private HttpClient httpClient;
 
-    @BeforeEach
+    @Before
     public void init() throws IOException {
         stubFor(get("/warmup").willReturn(ok()));
         httpClient = HttpClientFactory.createClient(SOCKET_TIMEOUT_MILLISECONDS);

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDribbleAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDribbleAcceptanceTest.java
@@ -23,9 +23,9 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
 import org.hamcrest.Matcher;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -50,7 +50,7 @@ public class ResponseDribbleAcceptanceTest {
 
     private HttpClient httpClient;
 
-    @Before
+    @BeforeEach
     public void init() throws IOException {
         stubFor(get("/warmup").willReturn(ok()));
         httpClient = HttpClientFactory.createClient(SOCKET_TIMEOUT_MILLISECONDS);

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
@@ -20,10 +20,10 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import java.net.InetAddress;
@@ -34,7 +34,6 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.defaultTestFilesRoot;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(Enclosed.class)
 public class ResponseTemplatingAcceptanceTest {
@@ -49,7 +48,7 @@ public class ResponseTemplatingAcceptanceTest {
                 .extensions(new ResponseTemplateTransformer(false))
         );
 
-        @Before
+        @BeforeEach
         public void init() {
             client = new WireMockTestClient(wm.port());
         }
@@ -85,7 +84,7 @@ public class ResponseTemplatingAcceptanceTest {
                 .extensions(new ResponseTemplateTransformer(true))
         );
 
-        @Before
+        @BeforeEach
         public void init() {
             client = new WireMockTestClient(wm.port());
         }
@@ -262,7 +261,7 @@ public class ResponseTemplatingAcceptanceTest {
                 )
         );
 
-        @Before
+        @BeforeEach
         public void init() {
             client = new WireMockTestClient(wm.port());
         }

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
@@ -20,10 +20,10 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import org.junit.Before;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import java.net.InetAddress;
@@ -34,6 +34,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.defaultTestFilesRoot;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Enclosed.class)
 public class ResponseTemplatingAcceptanceTest {
@@ -48,7 +49,7 @@ public class ResponseTemplatingAcceptanceTest {
                 .extensions(new ResponseTemplateTransformer(false))
         );
 
-        @BeforeEach
+        @Before
         public void init() {
             client = new WireMockTestClient(wm.port());
         }
@@ -84,7 +85,7 @@ public class ResponseTemplatingAcceptanceTest {
                 .extensions(new ResponseTemplateTransformer(true))
         );
 
-        @BeforeEach
+        @Before
         public void init() {
             client = new WireMockTestClient(wm.port());
         }
@@ -261,7 +262,7 @@ public class ResponseTemplatingAcceptanceTest {
                 )
         );
 
-        @BeforeEach
+        @Before
         public void init() {
             client = new WireMockTestClient(wm.port());
         }

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseTransformerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseTransformerAcceptanceTest.java
@@ -22,7 +22,7 @@ import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.Response;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/SavingMappingsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/SavingMappingsAcceptanceTest.java
@@ -24,9 +24,9 @@ import org.apache.commons.io.FileUtils;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
@@ -56,13 +56,13 @@ public class SavingMappingsAcceptanceTest extends AcceptanceTestBase {
         }
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setupServer() {
         resetFileSourceRoot();
         setupServer(wireMockConfig().fileSource(new SingleRootFileSource(FILE_SOURCE_ROOT)));
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         resetFileSourceRoot();
         reset();

--- a/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
@@ -19,7 +19,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
@@ -30,6 +30,7 @@ import static com.github.tomakehurst.wiremock.stubbing.Scenario.withName;
 import static com.google.common.collect.Iterables.find;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ScenarioAcceptanceTest extends AcceptanceTestBase {
@@ -97,11 +98,13 @@ public class ScenarioAcceptanceTest extends AcceptanceTestBase {
 		assertThat(testClient.get("/stateful/resource").content(), is("Expected content"));
 	}
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void settingScenarioNameToNullCausesException() {
-        get(urlEqualTo("/some/resource"))
-                .willReturn(aResponse())
-                .inScenario(null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            get(urlEqualTo("/some/resource"))
+                    .willReturn(aResponse())
+                    .inScenario(null);
+        });
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
@@ -29,6 +29,7 @@ import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -53,6 +54,7 @@ public class SnapshotDslAcceptanceTest extends AcceptanceTestBase {
     private WireMock adminClient;
     private StubMapping proxyStub;
 
+    @BeforeEach
     public void init() {
         proxyingService = new WireMockServer(wireMockConfig()
             .dynamicPort()

--- a/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
@@ -28,8 +28,8 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import com.google.common.collect.ImmutableMap;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.List;
@@ -40,8 +40,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SnapshotDslAcceptanceTest extends AcceptanceTestBase {
 
@@ -67,7 +69,7 @@ public class SnapshotDslAcceptanceTest extends AcceptanceTestBase {
         adminClient = WireMock.create().port(proxyingService.port()).build();
     }
 
-    @After
+    @AfterEach
     public void proxyServerShutdown() {
         proxyingService.resetMappings();
         proxyingService.stop();
@@ -87,7 +89,7 @@ public class SnapshotDslAcceptanceTest extends AcceptanceTestBase {
         List<StubMapping> returnedMappings = proxyingService.snapshotRecord().getStubMappings();
         List<StubMapping> serverMappings = proxyingService.getStubMappings();
 
-        assertTrue("All of the returned mappings should be present in the server", serverMappings.containsAll(returnedMappings));
+        assertTrue(serverMappings.containsAll(returnedMappings), "All of the returned mappings should be present in the server");
         assertThat(returnedMappings.size(), is(3));
 
         assertThat(returnedMappings.get(0).getRequest().getUrl(), is("/one"));

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -29,10 +29,10 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.rules.ExpectedException;
 
 import java.io.*;
@@ -56,7 +56,8 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class StandaloneAcceptanceTest {
 	private static final String FILES = "__files";
@@ -76,11 +77,8 @@ public class StandaloneAcceptanceTest {
 
 	private File mappingsDirectory;
 	private File filesDirectory;
-
-	@Rule
-    public ExpectedException expectException = ExpectedException.none();
 	
-	@Before
+	@BeforeEach
 	public void init() throws Exception {
 		if (FILE_SOURCE_ROOT.exists()) {
             FileUtils.deleteDirectory(FILE_SOURCE_ROOT);
@@ -96,7 +94,7 @@ public class StandaloneAcceptanceTest {
 		WireMock.configure();
 	}
 	
-	@After
+	@AfterEach
 	public void stopServerRunner() {
 		runner.stop();
 		if (otherServer != null) {
@@ -444,14 +442,19 @@ public class StandaloneAcceptanceTest {
     public void failsWithUsefulErrorMessageWhenMappingFileIsInvalid() {
         writeMappingFile("bad-mapping.json", BAD_MAPPING);
 
-        expectException.expectMessage(allOf(
+		RuntimeException exception = assertThrows(RuntimeException.class, new Executable() {
+			@Override
+			public void execute() throws Throwable {
+				startRunner();
+			}
+		});
+        assertThat(exception.getMessage(), allOf(
             containsString("Error loading file"),
             containsString("bad-mapping.json"),
             containsString("Unrecognized field \"requesttttt\""),
             containsString("class com.github.tomakehurst.wiremock.stubbing.StubMapping"),
             containsString("not marked as ignorable")
         ));
-        startRunner();
     }
 
     private String contentsOfFirstFileNamedLike(String namePart) throws IOException {

--- a/src/test/java/com/github/tomakehurst/wiremock/StubImportAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubImportAcceptanceTest.java
@@ -18,8 +18,8 @@ package com.github.tomakehurst.wiremock;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
@@ -35,7 +35,7 @@ public class StubImportAcceptanceTest extends AcceptanceTestBase {
 
     private static Admin admin;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         admin = wireMockServer;
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/StubLifecycleListenerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubLifecycleListenerAcceptanceTest.java
@@ -22,12 +22,12 @@ import com.github.tomakehurst.wiremock.extension.StubLifecycleListener;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -35,24 +35,26 @@ import java.util.UUID;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class StubLifecycleListenerAcceptanceTest {
 
     TestStubLifecycleListener loggingListener = new TestStubLifecycleListener();
     ExceptionThrowingStubLifecycleListener exceptionThrowingListener = new ExceptionThrowingStubLifecycleListener();
 
-    @ClassRule
-    public static TemporaryFolder tempDir = new TemporaryFolder();
+    @TempDir
+    public static File tempDir;
 
     @Rule
     public WireMockRule wm = new WireMockRule(options()
             .dynamicPort()
-            .withRootDirectory(tempDir.getRoot().getAbsolutePath())
+            .withRootDirectory(tempDir.getAbsolutePath())
             .extensions(loggingListener, exceptionThrowingListener));
 
-    @Before
+    @BeforeEach
     public void init() {
         loggingListener.events.clear();
         exceptionThrowingListener.throwException = false;

--- a/src/test/java/com/github/tomakehurst/wiremock/StubLifecycleListenerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubLifecycleListenerAcceptanceTest.java
@@ -22,12 +22,12 @@ import com.github.tomakehurst.wiremock.extension.StubLifecycleListener;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -35,26 +35,24 @@ import java.util.UUID;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.Assert.*;
 
 public class StubLifecycleListenerAcceptanceTest {
 
     TestStubLifecycleListener loggingListener = new TestStubLifecycleListener();
     ExceptionThrowingStubLifecycleListener exceptionThrowingListener = new ExceptionThrowingStubLifecycleListener();
 
-    @TempDir
-    public static File tempDir;
+    @ClassRule
+    public static TemporaryFolder tempDir = new TemporaryFolder();
 
     @Rule
     public WireMockRule wm = new WireMockRule(options()
             .dynamicPort()
-            .withRootDirectory(tempDir.getAbsolutePath())
+            .withRootDirectory(tempDir.getRoot().getAbsolutePath())
             .extensions(loggingListener, exceptionThrowingListener));
 
-    @BeforeEach
+    @Before
     public void init() {
         loggingListener.events.clear();
         exceptionThrowingListener.throwException = false;

--- a/src/test/java/com/github/tomakehurst/wiremock/StubMappingPersistenceAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubMappingPersistenceAcceptanceTest.java
@@ -23,8 +23,8 @@ import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
 import com.github.tomakehurst.wiremock.junit.Stubbing;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -48,7 +48,7 @@ public class StubMappingPersistenceAcceptanceTest {
     WireMockTestClient testClient;
     Stubbing wm;
 
-    @Before
+    @BeforeEach
     public void init() throws Exception {
         rootDir = Files.createTempDirectory("temp-filesource");
         mappingsDir = rootDir.resolve("mappings");

--- a/src/test/java/com/github/tomakehurst/wiremock/StubMetadataAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubMetadataAcceptanceTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.common.Metadata;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/test/java/com/github/tomakehurst/wiremock/StubRequestLoggingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubRequestLoggingAcceptanceTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingWithBrowserProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingWithBrowserProxyAcceptanceTest.java
@@ -26,10 +26,10 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.util.EntityUtils;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -56,7 +56,7 @@ public class StubbingWithBrowserProxyAcceptanceTest {
 
     static CloseableHttpClient client;
 
-    @BeforeAll
+    @BeforeClass
     public static void init() {
         client = HttpClientBuilder.create()
                 .setDnsResolver(new CustomLocalTldDnsResolver("internal"))

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingWithBrowserProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingWithBrowserProxyAcceptanceTest.java
@@ -26,10 +26,10 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.apache.http.util.EntityUtils;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -56,7 +56,7 @@ public class StubbingWithBrowserProxyAcceptanceTest {
 
     static CloseableHttpClient client;
 
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         client = HttpClientBuilder.create()
                 .setDnsResolver(new CustomLocalTldDnsResolver("internal"))

--- a/src/test/java/com/github/tomakehurst/wiremock/TransferEncodingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/TransferEncodingAcceptanceTest.java
@@ -19,12 +19,11 @@ import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.http.HttpClientFactory;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
@@ -153,7 +152,7 @@ public class TransferEncodingAcceptanceTest {
         testClient = new WireMockTestClient(wm.port());
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         wm.stop();
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/UrlMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/UrlMatchingAcceptanceTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -32,8 +32,8 @@ import com.github.tomakehurst.wiremock.verification.RequestJournalDisabledExcept
 import com.google.common.base.Optional;
 import org.apache.http.entity.StringEntity;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
-import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
@@ -52,9 +52,8 @@ import static com.github.tomakehurst.wiremock.verification.diff.JUnitStyleDiffRe
 import static java.lang.System.lineSeparator;
 import static org.apache.http.entity.ContentType.TEXT_PLAIN;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.Assert.fail;
 
 @RunWith(Enclosed.class)
 public class VerificationAcceptanceTest {
@@ -73,28 +72,22 @@ public class VerificationAcceptanceTest {
             verify(anyRequestedFor(urlEqualTo("/this/got/requested?query")));
         }
 
-        @Test
+        @Test(expected=VerificationException.class)
         public void throwsVerificationExceptionOnUrlEqualsWhenQueryMissing() {
-            assertThrows(VerificationException.class, () -> {
-                testClient.get("/this/got/requested?query");
-                verify(getRequestedFor(urlEqualTo("/this/got/requested")));
-            });
+            testClient.get("/this/got/requested?query");
+            verify(getRequestedFor(urlEqualTo("/this/got/requested")));
         }
 
-        @Test
+        @Test(expected=VerificationException.class)
         public void throwsVerificationExceptionOnUrlEqualsWhenPathShorter() {
-            assertThrows(VerificationException.class, () -> {
-                testClient.get("/this/got/requested?query");
-                verify(getRequestedFor(urlEqualTo("/this/got/requeste?query")));
-            });
+            testClient.get("/this/got/requested?query");
+            verify(getRequestedFor(urlEqualTo("/this/got/requeste?query")));
         }
 
-        @Test
+        @Test(expected=VerificationException.class)
         public void throwsVerificationExceptionOnUrlEqualsWhenExtraPathPresent() {
-            assertThrows(VerificationException.class, () -> {
-                testClient.get("/this/got/requested?query");
-                verify(getRequestedFor(urlEqualTo("/this/got/requested/?query")));
-            });
+            testClient.get("/this/got/requested?query");
+            verify(getRequestedFor(urlEqualTo("/this/got/requested/?query")));
         }
 
         @Test
@@ -103,20 +96,16 @@ public class VerificationAcceptanceTest {
             verify(getRequestedFor(urlPathEqualTo("/this/got/requested")));
         }
 
-        @Test
+        @Test(expected=VerificationException.class)
         public void throwsVerificationExceptionOnUrlPathEqualsWhenPathShorter() {
-            assertThrows(VerificationException.class, () -> {
-                testClient.get("/this/got/requested?query");
-                verify(getRequestedFor(urlPathEqualTo("/this/got/requeste")));
-            });
+            testClient.get("/this/got/requested?query");
+            verify(getRequestedFor(urlPathEqualTo("/this/got/requeste")));
         }
 
-        @Test
+        @Test(expected=VerificationException.class)
         public void throwsVerificationExceptionOnUrlPathEqualsWhenExtraPathPresent() {
-            assertThrows(VerificationException.class, () -> {
-                testClient.get("/this/got/requested?query");
-                verify(getRequestedFor(urlPathEqualTo("/this/got/requested/")));
-            });
+            testClient.get("/this/got/requested?query");
+            verify(getRequestedFor(urlPathEqualTo("/this/got/requested/")));
         }
 
         @Test
@@ -125,28 +114,22 @@ public class VerificationAcceptanceTest {
             verify(getRequestedFor(urlPathMatching("/(.*?)/got/.*")));
         }
 
-        @Test
+        @Test(expected=VerificationException.class)
         public void throwsVerificationExceptionOnUrlPathPatternWhenOnlyPrefixMatching() {
-            assertThrows(VerificationException.class, () -> {
-                testClient.get("/this/got/requested");
-                verify(getRequestedFor(urlPathMatching("/(.*?)/got/")));
-            });
+            testClient.get("/this/got/requested");
+            verify(getRequestedFor(urlPathMatching("/(.*?)/got/")));
         }
 
-        @Test
+        @Test(expected=VerificationException.class)
         public void throwsVerificationExceptionOnUrlPathPatternWhenOnlySuffixMatching() {
-            assertThrows(VerificationException.class, () -> {
-                testClient.get("/this/got/requested");
-                verify(getRequestedFor(urlPathMatching("/got/.*")));
-            });
+            testClient.get("/this/got/requested");
+            verify(getRequestedFor(urlPathMatching("/got/.*")));
         }
 
-        @Test
+        @Test(expected=VerificationException.class)
         public void throwsVerificationExceptionWhenNoMatch() {
-            assertThrows(VerificationException.class, () -> {
-                testClient.get("/this/got/requested");
-                verify(getRequestedFor(urlEqualTo("/this/did/not")));
-            });
+            testClient.get("/this/got/requested");
+            verify(getRequestedFor(urlEqualTo("/this/did/not")));
         }
 
         @Test
@@ -187,14 +170,12 @@ public class VerificationAcceptanceTest {
             assertThat(headers.getHeader("X-Thing").values().get(1), is("Two"));
         }
 
-        @Test
+        @Test(expected=VerificationException.class)
         public void throwsVerificationExceptionWhenHeadersDoNotMatch() {
-            assertThrows(VerificationException.class, () -> {
-                testClient.put("/to/modify", withHeader("Content-Type", "application/json"), withHeader("Encoding", "LATIN-1"));
-                verify(putRequestedFor(urlEqualTo("/to/modify"))
-                        .withHeader("Content-Type", equalTo("application/json"))
-                        .withHeader("Encoding", notMatching("LATIN-1")));
-            });
+            testClient.put("/to/modify", withHeader("Content-Type", "application/json"), withHeader("Encoding", "LATIN-1"));
+            verify(putRequestedFor(urlEqualTo("/to/modify"))
+                    .withHeader("Content-Type", equalTo("application/json"))
+                    .withHeader("Encoding", notMatching("LATIN-1")));
         }
 
         private static final String SAMPLE_JSON =
@@ -279,33 +260,27 @@ public class VerificationAcceptanceTest {
             verify(getRequestedFor(urlPathEqualTo("/spacey-query")).withQueryParam("param", equalTo("My Value")));
         }
 
-        @Test
+        @Test(expected=VerificationException.class)
         public void verifyIsFalseWithQueryParamNotMatched() {
-            assertThrows(VerificationException.class, () -> {
-                testClient.get("/query?param=my-value");
-                verify(getRequestedFor(urlPathEqualTo("/query")).withQueryParam("param", equalTo("wrong-value")));
-            });
+            testClient.get("/query?param=my-value");
+            verify(getRequestedFor(urlPathEqualTo("/query")).withQueryParam("param", equalTo("wrong-value")));
         }
 
-        @Test
+        @Test(expected=VerificationException.class)
         public void verifyIsFalseWhenExpectedQueryParamMissing() {
-            assertThrows(VerificationException.class, () -> {
-                testClient.get("/query");
-                verify(getRequestedFor(urlPathEqualTo("/query")).withQueryParam("param", equalTo("my-value")));
-            });
+            testClient.get("/query");
+            verify(getRequestedFor(urlPathEqualTo("/query")).withQueryParam("param", equalTo("my-value")));
         }
 
-        @Test
+        @Test(expected=VerificationException.class)
         public void resetErasesCounters() {
-            assertThrows(VerificationException.class, () -> {
-                testClient.get("/count/this");
-                testClient.get("/count/this");
-                testClient.get("/count/this");
+            testClient.get("/count/this");
+            testClient.get("/count/this");
+            testClient.get("/count/this");
 
-                WireMock.reset();
+            WireMock.reset();
 
-                verify(getRequestedFor(urlEqualTo("/count/this")));
-            });
+            verify(getRequestedFor(urlEqualTo("/count/this")));
         }
 
         @Test
@@ -330,20 +305,16 @@ public class VerificationAcceptanceTest {
             verify(lessThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
-        @Test
+        @Test(expected = VerificationException.class)
         public void doesNotVerifyLessThanCountWithEqualRequests() {
-            assertThrows(VerificationException.class, () -> {
-                getCountableRequests(5);
-                verify(lessThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
-            });
+            getCountableRequests(5);
+            verify(lessThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
-        @Test
+        @Test(expected = VerificationException.class)
         public void doesNotVerifyLessThanCountWithMoreRequests() {
-            assertThrows(VerificationException.class, () -> {
-                getCountableRequests(6);
-                verify(lessThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
-            });
+            getCountableRequests(6);
+            verify(lessThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
         @Test
@@ -358,20 +329,16 @@ public class VerificationAcceptanceTest {
             verify(lessThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
-        @Test
+        @Test(expected = VerificationException.class)
         public void doesNotVerifyLessThanOrExactlyCountWithMoreRequests() {
-            assertThrows(VerificationException.class, () -> {
-                getCountableRequests(6);
-                verify(lessThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
-            });
+            getCountableRequests(6);
+            verify(lessThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
-        @Test
+        @Test(expected = VerificationException.class)
         public void doesNotVerifyExactCountWithLessRequests() {
-            assertThrows(VerificationException.class, () -> {
-                getCountableRequests(4);
-                verify(exactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
-            });
+            getCountableRequests(4);
+            verify(exactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
         @Test
@@ -380,20 +347,16 @@ public class VerificationAcceptanceTest {
             verify(exactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
-        @Test
+        @Test(expected = VerificationException.class)
         public void doesNotVerifyExactCountWithMoreRequests() {
-            assertThrows(VerificationException.class, () -> {
-                getCountableRequests(6);
-                verify(exactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
-            });
+            getCountableRequests(6);
+            verify(exactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
-        @Test
+        @Test(expected = VerificationException.class)
         public void doesNotVerifyMoreThanOrExactlyCountWithLessRequests() {
-            assertThrows(VerificationException.class, () -> {
-                getCountableRequests(4);
-                verify(moreThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
-            });
+            getCountableRequests(4);
+            verify(moreThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
         @Test
@@ -408,20 +371,16 @@ public class VerificationAcceptanceTest {
             verify(moreThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
-        @Test
+        @Test(expected = VerificationException.class)
         public void doesNotVerifyMoreThanCountWithLessRequests() {
-            assertThrows(VerificationException.class, () -> {
-                getCountableRequests(4);
-                verify(moreThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
-            });
+            getCountableRequests(4);
+            verify(moreThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
-        @Test
+        @Test(expected = VerificationException.class)
         public void doesNotVerifyMoreThanCountWithEqualRequests() {
-            assertThrows(VerificationException.class, () -> {
-                getCountableRequests(5);
-                verify(moreThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
-            });
+            getCountableRequests(5);
+            verify(moreThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
         @Test
@@ -438,13 +397,11 @@ public class VerificationAcceptanceTest {
                     .withoutHeader("Accept"));
         }
 
-        @Test
+        @Test(expected=VerificationException.class)
         public void failsVerificationWhenAbsentHeaderPresent() {
-            assertThrows(VerificationException.class, () -> {
-                testClient.get("/without/another/header", withHeader("Content-Type", "application/json"));
-                verify(getRequestedFor(urlEqualTo("/without/another/header"))
-                        .withoutHeader("Content-Type"));
-            });
+            testClient.get("/without/another/header", withHeader("Content-Type", "application/json"));
+            verify(getRequestedFor(urlEqualTo("/without/another/header"))
+                    .withoutHeader("Content-Type"));
         }
 
         @Test
@@ -454,13 +411,11 @@ public class VerificationAcceptanceTest {
                     .withRequestBody(absent()));
         }
 
-        @Test
+        @Test(expected = VerificationException.class)
         public void failsVerificationWhenAbsentBodyPresent() throws Exception {
-            assertThrows(VerificationException.class, () -> {
-                testClient.post("/no/body", new StringEntity("not absent"));
-                verify(postRequestedFor(urlEqualTo("/no/body"))
-                        .withRequestBody(absent()));
-            });
+            testClient.post("/no/body", new StringEntity("not absent"));
+            verify(postRequestedFor(urlEqualTo("/no/body"))
+                    .withRequestBody(absent()));
         }
 
         @Test
@@ -813,18 +768,14 @@ public class VerificationAcceptanceTest {
             .disableRequestJournal(),
             false);
 
-        @Test
+        @Test(expected=RequestJournalDisabledException.class)
         public void verifyThrowsExceptionWhenVerificationAttemptedAndRequestJournalDisabled() {
-            assertThrows(RequestJournalDisabledException.class, () -> {
-                verify(getRequestedFor(urlEqualTo("/whatever")));
-            });
+            verify(getRequestedFor(urlEqualTo("/whatever")));
         }
 
-        @Test
+        @Test(expected=RequestJournalDisabledException.class)
         public void findAllThrowsExceptionWhenVerificationAttemptedAndRequestJournalDisabled() {
-            assertThrows(RequestJournalDisabledException.class, () -> {
-                findAll(getRequestedFor(urlEqualTo("/whatever")));
-            });
+            findAll(getRequestedFor(urlEqualTo("/whatever")));
         }
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -32,8 +32,8 @@ import com.github.tomakehurst.wiremock.verification.RequestJournalDisabledExcept
 import com.google.common.base.Optional;
 import org.apache.http.entity.StringEntity;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
@@ -52,8 +52,9 @@ import static com.github.tomakehurst.wiremock.verification.diff.JUnitStyleDiffRe
 import static java.lang.System.lineSeparator;
 import static org.apache.http.entity.ContentType.TEXT_PLAIN;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @RunWith(Enclosed.class)
 public class VerificationAcceptanceTest {
@@ -72,22 +73,28 @@ public class VerificationAcceptanceTest {
             verify(anyRequestedFor(urlEqualTo("/this/got/requested?query")));
         }
 
-        @Test(expected=VerificationException.class)
+        @Test
         public void throwsVerificationExceptionOnUrlEqualsWhenQueryMissing() {
-            testClient.get("/this/got/requested?query");
-            verify(getRequestedFor(urlEqualTo("/this/got/requested")));
+            assertThrows(VerificationException.class, () -> {
+                testClient.get("/this/got/requested?query");
+                verify(getRequestedFor(urlEqualTo("/this/got/requested")));
+            });
         }
 
-        @Test(expected=VerificationException.class)
+        @Test
         public void throwsVerificationExceptionOnUrlEqualsWhenPathShorter() {
-            testClient.get("/this/got/requested?query");
-            verify(getRequestedFor(urlEqualTo("/this/got/requeste?query")));
+            assertThrows(VerificationException.class, () -> {
+                testClient.get("/this/got/requested?query");
+                verify(getRequestedFor(urlEqualTo("/this/got/requeste?query")));
+            });
         }
 
-        @Test(expected=VerificationException.class)
+        @Test
         public void throwsVerificationExceptionOnUrlEqualsWhenExtraPathPresent() {
-            testClient.get("/this/got/requested?query");
-            verify(getRequestedFor(urlEqualTo("/this/got/requested/?query")));
+            assertThrows(VerificationException.class, () -> {
+                testClient.get("/this/got/requested?query");
+                verify(getRequestedFor(urlEqualTo("/this/got/requested/?query")));
+            });
         }
 
         @Test
@@ -96,16 +103,20 @@ public class VerificationAcceptanceTest {
             verify(getRequestedFor(urlPathEqualTo("/this/got/requested")));
         }
 
-        @Test(expected=VerificationException.class)
+        @Test
         public void throwsVerificationExceptionOnUrlPathEqualsWhenPathShorter() {
-            testClient.get("/this/got/requested?query");
-            verify(getRequestedFor(urlPathEqualTo("/this/got/requeste")));
+            assertThrows(VerificationException.class, () -> {
+                testClient.get("/this/got/requested?query");
+                verify(getRequestedFor(urlPathEqualTo("/this/got/requeste")));
+            });
         }
 
-        @Test(expected=VerificationException.class)
+        @Test
         public void throwsVerificationExceptionOnUrlPathEqualsWhenExtraPathPresent() {
-            testClient.get("/this/got/requested?query");
-            verify(getRequestedFor(urlPathEqualTo("/this/got/requested/")));
+            assertThrows(VerificationException.class, () -> {
+                testClient.get("/this/got/requested?query");
+                verify(getRequestedFor(urlPathEqualTo("/this/got/requested/")));
+            });
         }
 
         @Test
@@ -114,22 +125,28 @@ public class VerificationAcceptanceTest {
             verify(getRequestedFor(urlPathMatching("/(.*?)/got/.*")));
         }
 
-        @Test(expected=VerificationException.class)
+        @Test
         public void throwsVerificationExceptionOnUrlPathPatternWhenOnlyPrefixMatching() {
-            testClient.get("/this/got/requested");
-            verify(getRequestedFor(urlPathMatching("/(.*?)/got/")));
+            assertThrows(VerificationException.class, () -> {
+                testClient.get("/this/got/requested");
+                verify(getRequestedFor(urlPathMatching("/(.*?)/got/")));
+            });
         }
 
-        @Test(expected=VerificationException.class)
+        @Test
         public void throwsVerificationExceptionOnUrlPathPatternWhenOnlySuffixMatching() {
-            testClient.get("/this/got/requested");
-            verify(getRequestedFor(urlPathMatching("/got/.*")));
+            assertThrows(VerificationException.class, () -> {
+                testClient.get("/this/got/requested");
+                verify(getRequestedFor(urlPathMatching("/got/.*")));
+            });
         }
 
-        @Test(expected=VerificationException.class)
+        @Test
         public void throwsVerificationExceptionWhenNoMatch() {
-            testClient.get("/this/got/requested");
-            verify(getRequestedFor(urlEqualTo("/this/did/not")));
+            assertThrows(VerificationException.class, () -> {
+                testClient.get("/this/got/requested");
+                verify(getRequestedFor(urlEqualTo("/this/did/not")));
+            });
         }
 
         @Test
@@ -170,12 +187,14 @@ public class VerificationAcceptanceTest {
             assertThat(headers.getHeader("X-Thing").values().get(1), is("Two"));
         }
 
-        @Test(expected=VerificationException.class)
+        @Test
         public void throwsVerificationExceptionWhenHeadersDoNotMatch() {
-            testClient.put("/to/modify", withHeader("Content-Type", "application/json"), withHeader("Encoding", "LATIN-1"));
-            verify(putRequestedFor(urlEqualTo("/to/modify"))
-                    .withHeader("Content-Type", equalTo("application/json"))
-                    .withHeader("Encoding", notMatching("LATIN-1")));
+            assertThrows(VerificationException.class, () -> {
+                testClient.put("/to/modify", withHeader("Content-Type", "application/json"), withHeader("Encoding", "LATIN-1"));
+                verify(putRequestedFor(urlEqualTo("/to/modify"))
+                        .withHeader("Content-Type", equalTo("application/json"))
+                        .withHeader("Encoding", notMatching("LATIN-1")));
+            });
         }
 
         private static final String SAMPLE_JSON =
@@ -260,27 +279,33 @@ public class VerificationAcceptanceTest {
             verify(getRequestedFor(urlPathEqualTo("/spacey-query")).withQueryParam("param", equalTo("My Value")));
         }
 
-        @Test(expected=VerificationException.class)
+        @Test
         public void verifyIsFalseWithQueryParamNotMatched() {
-            testClient.get("/query?param=my-value");
-            verify(getRequestedFor(urlPathEqualTo("/query")).withQueryParam("param", equalTo("wrong-value")));
+            assertThrows(VerificationException.class, () -> {
+                testClient.get("/query?param=my-value");
+                verify(getRequestedFor(urlPathEqualTo("/query")).withQueryParam("param", equalTo("wrong-value")));
+            });
         }
 
-        @Test(expected=VerificationException.class)
+        @Test
         public void verifyIsFalseWhenExpectedQueryParamMissing() {
-            testClient.get("/query");
-            verify(getRequestedFor(urlPathEqualTo("/query")).withQueryParam("param", equalTo("my-value")));
+            assertThrows(VerificationException.class, () -> {
+                testClient.get("/query");
+                verify(getRequestedFor(urlPathEqualTo("/query")).withQueryParam("param", equalTo("my-value")));
+            });
         }
 
-        @Test(expected=VerificationException.class)
+        @Test
         public void resetErasesCounters() {
-            testClient.get("/count/this");
-            testClient.get("/count/this");
-            testClient.get("/count/this");
+            assertThrows(VerificationException.class, () -> {
+                testClient.get("/count/this");
+                testClient.get("/count/this");
+                testClient.get("/count/this");
 
-            WireMock.reset();
+                WireMock.reset();
 
-            verify(getRequestedFor(urlEqualTo("/count/this")));
+                verify(getRequestedFor(urlEqualTo("/count/this")));
+            });
         }
 
         @Test
@@ -305,16 +330,20 @@ public class VerificationAcceptanceTest {
             verify(lessThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
-        @Test(expected = VerificationException.class)
+        @Test
         public void doesNotVerifyLessThanCountWithEqualRequests() {
-            getCountableRequests(5);
-            verify(lessThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            assertThrows(VerificationException.class, () -> {
+                getCountableRequests(5);
+                verify(lessThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            });
         }
 
-        @Test(expected = VerificationException.class)
+        @Test
         public void doesNotVerifyLessThanCountWithMoreRequests() {
-            getCountableRequests(6);
-            verify(lessThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            assertThrows(VerificationException.class, () -> {
+                getCountableRequests(6);
+                verify(lessThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            });
         }
 
         @Test
@@ -329,16 +358,20 @@ public class VerificationAcceptanceTest {
             verify(lessThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
-        @Test(expected = VerificationException.class)
+        @Test
         public void doesNotVerifyLessThanOrExactlyCountWithMoreRequests() {
-            getCountableRequests(6);
-            verify(lessThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            assertThrows(VerificationException.class, () -> {
+                getCountableRequests(6);
+                verify(lessThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            });
         }
 
-        @Test(expected = VerificationException.class)
+        @Test
         public void doesNotVerifyExactCountWithLessRequests() {
-            getCountableRequests(4);
-            verify(exactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            assertThrows(VerificationException.class, () -> {
+                getCountableRequests(4);
+                verify(exactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            });
         }
 
         @Test
@@ -347,16 +380,20 @@ public class VerificationAcceptanceTest {
             verify(exactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
-        @Test(expected = VerificationException.class)
+        @Test
         public void doesNotVerifyExactCountWithMoreRequests() {
-            getCountableRequests(6);
-            verify(exactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            assertThrows(VerificationException.class, () -> {
+                getCountableRequests(6);
+                verify(exactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            });
         }
 
-        @Test(expected = VerificationException.class)
+        @Test
         public void doesNotVerifyMoreThanOrExactlyCountWithLessRequests() {
-            getCountableRequests(4);
-            verify(moreThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            assertThrows(VerificationException.class, () -> {
+                getCountableRequests(4);
+                verify(moreThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            });
         }
 
         @Test
@@ -371,16 +408,20 @@ public class VerificationAcceptanceTest {
             verify(moreThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
-        @Test(expected = VerificationException.class)
+        @Test
         public void doesNotVerifyMoreThanCountWithLessRequests() {
-            getCountableRequests(4);
-            verify(moreThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            assertThrows(VerificationException.class, () -> {
+                getCountableRequests(4);
+                verify(moreThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            });
         }
 
-        @Test(expected = VerificationException.class)
+        @Test
         public void doesNotVerifyMoreThanCountWithEqualRequests() {
-            getCountableRequests(5);
-            verify(moreThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            assertThrows(VerificationException.class, () -> {
+                getCountableRequests(5);
+                verify(moreThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+            });
         }
 
         @Test
@@ -397,11 +438,13 @@ public class VerificationAcceptanceTest {
                     .withoutHeader("Accept"));
         }
 
-        @Test(expected=VerificationException.class)
+        @Test
         public void failsVerificationWhenAbsentHeaderPresent() {
-            testClient.get("/without/another/header", withHeader("Content-Type", "application/json"));
-            verify(getRequestedFor(urlEqualTo("/without/another/header"))
-                    .withoutHeader("Content-Type"));
+            assertThrows(VerificationException.class, () -> {
+                testClient.get("/without/another/header", withHeader("Content-Type", "application/json"));
+                verify(getRequestedFor(urlEqualTo("/without/another/header"))
+                        .withoutHeader("Content-Type"));
+            });
         }
 
         @Test
@@ -411,11 +454,13 @@ public class VerificationAcceptanceTest {
                     .withRequestBody(absent()));
         }
 
-        @Test(expected = VerificationException.class)
+        @Test
         public void failsVerificationWhenAbsentBodyPresent() throws Exception {
-            testClient.post("/no/body", new StringEntity("not absent"));
-            verify(postRequestedFor(urlEqualTo("/no/body"))
-                    .withRequestBody(absent()));
+            assertThrows(VerificationException.class, () -> {
+                testClient.post("/no/body", new StringEntity("not absent"));
+                verify(postRequestedFor(urlEqualTo("/no/body"))
+                        .withRequestBody(absent()));
+            });
         }
 
         @Test
@@ -768,14 +813,18 @@ public class VerificationAcceptanceTest {
             .disableRequestJournal(),
             false);
 
-        @Test(expected=RequestJournalDisabledException.class)
+        @Test
         public void verifyThrowsExceptionWhenVerificationAttemptedAndRequestJournalDisabled() {
-            verify(getRequestedFor(urlEqualTo("/whatever")));
+            assertThrows(RequestJournalDisabledException.class, () -> {
+                verify(getRequestedFor(urlEqualTo("/whatever")));
+            });
         }
 
-        @Test(expected=RequestJournalDisabledException.class)
+        @Test
         public void findAllThrowsExceptionWhenVerificationAttemptedAndRequestJournalDisabled() {
-            findAll(getRequestedFor(urlEqualTo("/whatever")));
+            assertThrows(RequestJournalDisabledException.class, () -> {
+                findAll(getRequestedFor(urlEqualTo("/whatever")));
+            });
         }
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/WarDeploymentAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WarDeploymentAcceptanceTest.java
@@ -18,17 +18,14 @@ package com.github.tomakehurst.wiremock;
 import com.github.tomakehurst.wiremock.client.VerificationException;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.testsupport.Network;
-import com.github.tomakehurst.wiremock.testsupport.TestFiles;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.sampleWarRootDir;
@@ -36,18 +33,15 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class WarDeploymentAcceptanceTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
 	private Server jetty;
 	
 	private WireMockTestClient testClient;
 	
-	@Before
+	@BeforeEach
 	public void init() throws Exception {
         String webAppRootPath = sampleWarRootDir() + "/src/main/webapp";
 		WebAppContext context = new WebAppContext(webAppRootPath, "/wiremock");
@@ -81,7 +75,7 @@ public class WarDeploymentAcceptanceTest {
 		return port;
 	}
 
-	@After
+	@AfterEach
 	public void cleanup() throws Exception {
 		jetty.stop();
 		WireMock.configure();

--- a/src/test/java/com/github/tomakehurst/wiremock/WarDeploymentParameterAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WarDeploymentParameterAcceptanceTest.java
@@ -21,8 +21,8 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.sampleWarRootDir;
@@ -37,7 +37,7 @@ public class WarDeploymentParameterAcceptanceTest {
     private Server jetty;
     private WireMockTestClient testClient;
 
-    @After
+    @AfterEach
     public void cleanup() throws Exception {
         jetty.stop();
         WireMock.configure();

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockClientWithProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockClientWithProxyAcceptanceTest.java
@@ -17,16 +17,16 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.Options.DYNAMIC_PORT;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 
 public class WireMockClientWithProxyAcceptanceTest {
@@ -35,7 +35,7 @@ public class WireMockClientWithProxyAcceptanceTest {
 	private static WireMockTestClient testClient;
 	private static HttpProxyServer proxyServer;
 
-	@BeforeClass
+	@BeforeAll
 	public static void init() {
 		wireMockServer = new WireMockServer(DYNAMIC_PORT);
 		wireMockServer.start();
@@ -44,7 +44,7 @@ public class WireMockClientWithProxyAcceptanceTest {
 		testClient = new WireMockTestClient(wireMockServer.port());
 	}
 	
-	@AfterClass
+	@AfterAll
 	public static void stopServer() {
 		wireMockServer.stop();
 		proxyServer.stop();

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
@@ -29,11 +29,11 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -74,7 +74,7 @@ public class WireMockJUnitRuleTest {
         @Rule
         public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
-        @BeforeEach
+        @Before
         public void init() {
             WireMock.configureFor(wireMockRule.port());
         }
@@ -100,7 +100,7 @@ public class WireMockJUnitRuleTest {
         @Rule
         public WireMockClassRule instanceRule = classRule;
 
-        @BeforeEach
+        @Before
         public void init() {
             WireMock.configureFor(classRule.port());
         }

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
@@ -29,11 +29,11 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -74,7 +74,7 @@ public class WireMockJUnitRuleTest {
         @Rule
         public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
-        @Before
+        @BeforeEach
         public void init() {
             WireMock.configureFor(wireMockRule.port());
         }
@@ -100,7 +100,7 @@ public class WireMockJUnitRuleTest {
         @Rule
         public WireMockClassRule instanceRule = classRule;
 
-        @Before
+        @BeforeEach
         public void init() {
             WireMock.configureFor(classRule.port());
         }

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
@@ -19,15 +19,12 @@ import com.github.tomakehurst.wiremock.common.ProxySettings;
 import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -39,12 +36,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class WireMockServerTests {
 
-    @Rule
-    public final TemporaryFolder tempDir = new TemporaryFolder();
+    @TempDir
+    public File tempDir;
 
     @Test
     public void instantiationWithEmptyFileSource() throws IOException {
-        Options options = new WireMockConfiguration().dynamicPort().fileSource(new SingleRootFileSource(tempDir.getRoot()));
+        Options options = new WireMockConfiguration().dynamicPort().fileSource(new SingleRootFileSource(tempDir));
 
         WireMockServer wireMockServer = null;
         try {
@@ -111,9 +108,9 @@ public class WireMockServerTests {
     // https://github.com/tomakehurst/wiremock/issues/193
     @Test
     public void supportsRecordingProgrammaticallyWithoutHeaderMatching() {
-        WireMockServer wireMockServer = new WireMockServer(DYNAMIC_PORT, new SingleRootFileSource(tempDir.getRoot()), false, new ProxySettings("proxy.company.com", DYNAMIC_PORT));
+        WireMockServer wireMockServer = new WireMockServer(DYNAMIC_PORT, new SingleRootFileSource(tempDir), false, new ProxySettings("proxy.company.com", DYNAMIC_PORT));
         wireMockServer.start();
-        wireMockServer.enableRecordMappings(new SingleRootFileSource(tempDir.getRoot() + "/mappings"), new SingleRootFileSource(tempDir.getRoot() + "/__files"));
+        wireMockServer.enableRecordMappings(new SingleRootFileSource(tempDir + "/mappings"), new SingleRootFileSource(tempDir + "/__files"));
         wireMockServer.stubFor(get(urlEqualTo("/something")).willReturn(aResponse().withStatus(200)));
 
         WireMockTestClient client = new WireMockTestClient(wireMockServer.port());

--- a/src/test/java/com/github/tomakehurst/wiremock/XmlHandlingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/XmlHandlingAcceptanceTest.java
@@ -19,9 +19,9 @@ import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
@@ -38,7 +38,7 @@ public class XmlHandlingAcceptanceTest {
 
     WireMockTestClient client;
 
-    @Before
+    @BeforeEach
     public void init() {
         client = new WireMockTestClient(wm.port());
 

--- a/src/test/java/com/github/tomakehurst/wiremock/XmlHandlingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/XmlHandlingAcceptanceTest.java
@@ -19,9 +19,9 @@ import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import org.junit.Before;
 import org.junit.Rule;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
@@ -38,7 +38,7 @@ public class XmlHandlingAcceptanceTest {
 
     WireMockTestClient client;
 
-    @BeforeEach
+    @Before
     public void init() {
         client = new WireMockTestClient(wm.port());
 

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/AdminUriTemplateTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/AdminUriTemplateTest.java
@@ -16,9 +16,10 @@
 package com.github.tomakehurst.wiremock.admin;
 
 import com.github.tomakehurst.wiremock.admin.model.PathParams;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class AdminUriTemplateTest {
@@ -32,10 +33,12 @@ public class AdminUriTemplateTest {
         assertThat(pathParams.get("id"), is("11-22-33"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void throwsIllegalArgumentExceptionIfAttemptingParsingOnNonMatchingUrl() {
-        AdminUriTemplate template = new AdminUriTemplate("/things/{id}");
-        template.parse("/things/stuff/11-22-33");
+        assertThrows(IllegalArgumentException.class, () -> {
+            AdminUriTemplate template = new AdminUriTemplate("/things/{id}");
+            template.parse("/things/stuff/11-22-33");
+        });
     }
 
     @Test
@@ -80,9 +83,11 @@ public class AdminUriTemplateTest {
         assertThat(path, is("/things/stuff"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void throwsErrorWhenNotAllParametersAreBound() {
-        AdminUriTemplate template = new AdminUriTemplate("/things/{id}/otherthings/{subId}");
-        template.render(new PathParams().add("id", "123"));
+        assertThrows(IllegalArgumentException.class, () -> {
+            AdminUriTemplate template = new AdminUriTemplate("/things/{id}/otherthings/{subId}");
+            template.render(new PathParams().add("id", "123"));
+        });
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/LimitAndOffsetPaginatorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/LimitAndOffsetPaginatorTest.java
@@ -15,15 +15,16 @@
  */
 package com.github.tomakehurst.wiremock.admin;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
 
 import static com.google.common.primitives.Ints.asList;
 import static java.util.Collections.emptyList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LimitAndOffsetPaginatorTest {
 
@@ -87,14 +88,18 @@ public class LimitAndOffsetPaginatorTest {
         assertThat(result, is(asList(4, 5)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void rejectsNegativeLimit() {
-        new LimitAndOffsetPaginator<>(Collections.<Void>emptyList(), -1, 3);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new LimitAndOffsetPaginator<>(Collections.<Void>emptyList(), -1, 3);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void rejectsNegativeOffset() {
-        new LimitAndOffsetPaginator<>(Collections.<Void>emptyList(), 0, -10);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new LimitAndOffsetPaginator<>(Collections.<Void>emptyList(), 0, -10);
+        });
     }
 
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/OldEditStubMappingTaskTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/OldEditStubMappingTaskTest.java
@@ -23,8 +23,8 @@ import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
@@ -43,7 +43,7 @@ public class OldEditStubMappingTaskTest {
 
 	private OldEditStubMappingTask editStubMappingTask;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 
 		context = new Mockery();

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/RemoveStubMappingTaskTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/RemoveStubMappingTaskTest.java
@@ -23,8 +23,8 @@ import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
 
@@ -43,7 +43,7 @@ public class RemoveStubMappingTaskTest {
     private OldRemoveStubMappingTask removeStubMappingTask;
 
 
-    @Before
+    @BeforeEach
     public void setUp() {
 
         context = new Mockery();

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/SaveMappingsTaskTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/SaveMappingsTaskTest.java
@@ -23,8 +23,8 @@ import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import java.net.HttpURLConnection;
@@ -40,7 +40,7 @@ public class SaveMappingsTaskTest {
 
     private SaveMappingsTask saveMappingsTask;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         context = new Mockery();
         mockAdmin = context.mock(Admin.class);

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ClientAuthenticationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ClientAuthenticationAcceptanceTest.java
@@ -21,8 +21,8 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.security.*;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -33,6 +33,7 @@ import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 
@@ -42,7 +43,7 @@ public class ClientAuthenticationAcceptanceTest {
     private WireMock goodClient;
     private WireMock badClient;
 
-    @After
+    @AfterEach
     public void stopServer() {
         server.stop();
     }
@@ -81,21 +82,24 @@ public class ClientAuthenticationAcceptanceTest {
         goodClient.getServeEvents(); // Expect no exception thrown
     }
 
-    @Test(expected = NotAuthorisedException.class)
+    @Test
     public void throwsNotAuthorisedExceptionWhenWrongBasicCredentialsProvided() {
-        initialise(new BasicAuthenticator(
-                new BasicCredentials("user1", "password1"),
-                new BasicCredentials("user2", "password2")
-            ),
-            new ClientBasicAuthenticator("user1", "password1")
-        );
+        assertThrows(NotAuthorisedException.class, () -> {
+            initialise(new BasicAuthenticator(
+                            new BasicCredentials("user1", "password1"),
+                            new BasicCredentials("user2", "password2")
+                    ),
+                    new ClientBasicAuthenticator("user1", "password1")
+            );
 
-        badClient = WireMock.create()
-            .port(server.port())
-            .authenticator(new ClientBasicAuthenticator("user1", "wrong_password"))
-            .build();
+            badClient = WireMock.create()
+                    .port(server.port())
+                    .authenticator(new ClientBasicAuthenticator("user1", "wrong_password"))
+                    .build();
 
-        badClient.getServeEvents();
+            badClient.getServeEvents();
+
+        });
 
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/client/CountMatchingStrategyTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/CountMatchingStrategyTest.java
@@ -15,9 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.client;
 
-import org.junit.Test;
-
 import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CountMatchingStrategyTest {

--- a/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
@@ -32,7 +32,7 @@ package com.github.tomakehurst.wiremock.client;
 
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/com/github/tomakehurst/wiremock/client/RequestDelaySpecTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/RequestDelaySpecTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock.client;
 
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.global.RequestDelaySpec;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
@@ -34,7 +34,7 @@ import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.Charsets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
@@ -18,9 +18,9 @@ package com.github.tomakehurst.wiremock.client;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.Matchers.is;
@@ -32,7 +32,7 @@ public class WireMockClientAcceptanceTest {
 	private WireMockServer wireMockServer;
 	private WireMockTestClient testClient;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		wireMockServer = new WireMockServer(Options.DYNAMIC_PORT);
 		wireMockServer.start();
@@ -40,7 +40,7 @@ public class WireMockClientAcceptanceTest {
 		testClient = new WireMockTestClient(wireMockServer.port());
 	}
 	
-	@After
+	@AfterEach
 	public void stopServer() {
 		wireMockServer.stop();
 	}

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientWithProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientWithProxyAcceptanceTest.java
@@ -17,9 +17,9 @@ package com.github.tomakehurst.wiremock.client;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
@@ -35,7 +35,7 @@ public class WireMockClientWithProxyAcceptanceTest {
 	private static WireMockTestClient testClient;
 	private static HttpProxyServer proxyServer;
 
-	@BeforeClass
+	@BeforeAll
 	public static void init() {
 		wireMockServer = new WireMockServer(DYNAMIC_PORT);
 		wireMockServer.start();
@@ -44,7 +44,7 @@ public class WireMockClientWithProxyAcceptanceTest {
 		testClient = new WireMockTestClient(wireMockServer.port());
 	}
 	
-	@AfterClass
+	@AfterAll
 	public static void stopServer() {
 		wireMockServer.stop();
 		proxyServer.stop();

--- a/src/test/java/com/github/tomakehurst/wiremock/common/ArrayFunctionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/ArrayFunctionsTest.java
@@ -15,11 +15,11 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.common.ArrayFunctions.concat;
 import static com.github.tomakehurst.wiremock.common.ArrayFunctions.prepend;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class ArrayFunctionsTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/Base64EncoderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/Base64EncoderTest.java
@@ -15,10 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class Base64EncoderTest {
     public static final String INPUT = "1234";

--- a/src/test/java/com/github/tomakehurst/wiremock/common/ClasspathFileSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/ClasspathFileSourceTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -25,10 +25,10 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ClasspathFileSourceTest {
 
@@ -112,9 +112,9 @@ public class ClasspathFileSourceTest {
 
     @Test
     public void correctlyReportsExistence() {
-        assertTrue("Expected to exist", new ClasspathFileSource("filesource/subdir").exists());
-        assertTrue("Expected to exist", new ClasspathFileSource("META-INF/maven/com.google.guava").exists());
-        assertFalse("Expected not to exist", new ClasspathFileSource("not/exist").exists());
+        assertTrue(new ClasspathFileSource("filesource/subdir").exists(), "Expected to exist");
+        assertTrue(new ClasspathFileSource("META-INF/maven/com.google.guava").exists(), "Expected to exist");
+        assertFalse(new ClasspathFileSource("not/exist").exists(), "Expected not to exist");
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/common/ContentTypesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/ContentTypesTest.java
@@ -16,12 +16,12 @@
 package com.github.tomakehurst.wiremock.common;
 
 import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ContentTypesTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeOffsetTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeOffsetTest.java
@@ -16,13 +16,14 @@
 package com.github.tomakehurst.wiremock.common;
 
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.text.DateFormat;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DateTimeOffsetTest {
@@ -117,14 +118,18 @@ public class DateTimeOffsetTest {
         assertThat(ISO8601.format(finalDate), is("2018-04-19T12:01:01Z"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void throwsExceptionWhenUnparseableStringProvided() {
-        DateTimeOffset.fromString("101");
+        assertThrows(IllegalArgumentException.class, () -> {
+            DateTimeOffset.fromString("101");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void throwsExceptionWhenUnparseableUnitProvided() {
-        DateTimeOffset.fromString("101 squillions");
+        assertThrows(IllegalArgumentException.class, () -> {
+            DateTimeOffset.fromString("101 squillions");
+        });
     }
 
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeParserTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeParserTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeTruncationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeTruncationTest.java
@@ -15,8 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/JettySettingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/JettySettingsTest.java
@@ -16,11 +16,9 @@
 package com.github.tomakehurst.wiremock.common;
 
 import com.google.common.base.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JettySettingsTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/ListFunctionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/ListFunctionsTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -23,7 +23,7 @@ import static com.github.tomakehurst.wiremock.common.ListFunctions.splitByType;
 import static com.github.tomakehurst.wiremock.common.Pair.pair;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ListFunctionsTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/ProxySettingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/ProxySettingsTest.java
@@ -16,11 +16,12 @@
 package com.github.tomakehurst.wiremock.common;
 
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ProxySettingsTest {
 
@@ -52,9 +53,11 @@ public class ProxySettingsTest {
         assertThat(proxySettings.port(), is(PROXYVIA_PORT));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionIfPortIsNotRecognized(){
-        ProxySettings proxySettings = ProxySettings.fromString(PROXYVIA_URL+":80a");
+        assertThrows(IllegalArgumentException.class, () -> {
+            ProxySettings proxySettings = ProxySettings.fromString(PROXYVIA_URL + ":80a");
+        });
     }
 
     @Test
@@ -91,14 +94,18 @@ public class ProxySettingsTest {
         assertThat(proxySettings.port(), is(PROXYVIA_PORT));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowHttpsProtocol(){
-        ProxySettings proxySettings = ProxySettings.fromString("https://"+PROXYVIA_URL_WITH_PORT);
+        assertThrows(IllegalArgumentException.class, () -> {
+            ProxySettings proxySettings = ProxySettings.fromString("https://" + PROXYVIA_URL_WITH_PORT);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowExceptionIfUrlIsInvalid(){
-        ProxySettings proxySettings = ProxySettings.fromString("ul:invalid:80");
+        assertThrows(IllegalArgumentException.class, () -> {
+            ProxySettings proxySettings = ProxySettings.fromString("ul:invalid:80");
+        });
     }
 
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/common/SafeNamesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/SafeNamesTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock.common;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;

--- a/src/test/java/com/github/tomakehurst/wiremock/common/ServletContextFileSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/ServletContextFileSourceTest.java
@@ -15,8 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.*;
 import javax.servlet.descriptor.JspConfigDescriptor;
@@ -29,12 +29,13 @@ import static com.github.tomakehurst.wiremock.testsupport.TestFiles.filePath;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.fileNamed;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.hasExactlyIgnoringOrder;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ServletContextFileSourceTest {
     
     private ServletContextFileSource fileSource;
     
-    @Before
+    @BeforeEach
     public void init() {
         fileSource = new ServletContextFileSource(new MockServletContext(), "filesource");
     }
@@ -50,14 +51,18 @@ public class ServletContextFileSourceTest {
                 fileNamed("seven"), fileNamed("eight"), fileNamed("deepfile.json")));
     }
     
-    @Test(expected=UnsupportedOperationException.class)
+    @Test
     public void throwsUnsupportedExceptionWhenAttemptingToWrite() {
-        fileSource.writeTextFile("filename", "filecontents");
+        assertThrows(UnsupportedOperationException.class, () -> {
+            fileSource.writeTextFile("filename", "filecontents");
+        });
     }
     
-    @Test(expected=UnsupportedOperationException.class)
+    @Test
     public void throwsUnsupportedExceptionWhenAttemptingToCreate() {
-        fileSource.createIfNecessary();
+        assertThrows(UnsupportedOperationException.class, () -> {
+            fileSource.createIfNecessary();
+        });
     }
     
     

--- a/src/test/java/com/github/tomakehurst/wiremock/common/SingleRootFileSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/SingleRootFileSourceTest.java
@@ -16,9 +16,8 @@
 package com.github.tomakehurst.wiremock.common;
 
 import com.github.tomakehurst.wiremock.security.NotAuthorisedException;
-import com.github.tomakehurst.wiremock.testsupport.TestFiles;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,6 +30,7 @@ import static com.github.tomakehurst.wiremock.testsupport.TestFiles.filePath;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.fileNamed;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.hasExactlyIgnoringOrder;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SingleRootFileSourceTest {
@@ -61,75 +61,97 @@ public class SingleRootFileSourceTest {
         assertThat(Files.exists(fileAbsolutePath), is(true));
     }
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void listFilesRecursivelyThrowsExceptionWhenRootIsNotDir() {
-		SingleRootFileSource fileSource = new SingleRootFileSource("src/test/resources/filesource/one");
-		fileSource.listFilesRecursively();
-	}
+        assertThrows(RuntimeException.class, () -> {
+            SingleRootFileSource fileSource = new SingleRootFileSource("src/test/resources/filesource/one");
+            fileSource.listFilesRecursively();
+        });
+    }
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void writeThrowsExceptionWhenRootIsNotDir() {
-		SingleRootFileSource fileSource = new SingleRootFileSource("src/test/resources/filesource/one");
-		fileSource.writeTextFile("thing", "stuff");
-	}
+        assertThrows(RuntimeException.class, () -> {
+            SingleRootFileSource fileSource = new SingleRootFileSource("src/test/resources/filesource/one");
+            fileSource.writeTextFile("thing", "stuff");
+        });
+    }
 
-	@Test(expected = NotAuthorisedException.class)
+	@Test
 	public void writeTextFileThrowsExceptionWhenGivenRelativePathNotUnderRoot() {
-		SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
-		fileSource.writeTextFile("..", "stuff");
-	}
+        assertThrows(NotAuthorisedException.class, () -> {
+            SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
+            fileSource.writeTextFile("..", "stuff");
+        });
+    }
 
-    @Test(expected = NotAuthorisedException.class)
+    @Test
     public void writeTextFileThrowsExceptionWhenGivenAbsolutePathNotUnderRoot() {
-        SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
-        String badPath = Paths.get("..", "not-under-root").toAbsolutePath().toString();
-        fileSource.writeTextFile(badPath, "stuff");
+        assertThrows(NotAuthorisedException.class, () -> {
+            SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
+            String badPath = Paths.get("..", "not-under-root").toAbsolutePath().toString();
+            fileSource.writeTextFile(badPath, "stuff");
+        });
     }
 
-    @Test(expected = NotAuthorisedException.class)
+    @Test
     public void writeBinaryFileThrowsExceptionWhenGivenRelativePathNotUnderRoot() {
-        SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
-        fileSource.writeBinaryFile("..", "stuff".getBytes());
+        assertThrows(NotAuthorisedException.class, () -> {
+            SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
+            fileSource.writeBinaryFile("..", "stuff".getBytes());
+        });
     }
 
-    @Test(expected = NotAuthorisedException.class)
+    @Test
     public void writeBinaryFileThrowsExceptionWhenGivenAbsolutePathNotUnderRoot() {
-        SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
-        String badPath = Paths.get("..", "not-under-root").toAbsolutePath().toString();
-        fileSource.writeBinaryFile(badPath, "stuff".getBytes());
+        assertThrows(NotAuthorisedException.class, () -> {
+            SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
+            String badPath = Paths.get("..", "not-under-root").toAbsolutePath().toString();
+            fileSource.writeBinaryFile(badPath, "stuff".getBytes());
+        });
     }
 
-	@Test(expected = NotAuthorisedException.class)
+	@Test
 	public void deleteThrowsExceptionWhenGivenPathNotUnderRoot() {
-		SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
-        String badPath = Paths.get("..", "not-under-root").toAbsolutePath().toString();
-		fileSource.deleteFile(badPath);
-	}
+        assertThrows(NotAuthorisedException.class, () -> {
+            SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
+            String badPath = Paths.get("..", "not-under-root").toAbsolutePath().toString();
+            fileSource.deleteFile(badPath);
+        });
+    }
 
-	@Test(expected = NotAuthorisedException.class)
+	@Test
 	public void readBinaryFileThrowsExceptionWhenRelativePathIsOutsideRoot() {
-        SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
-        fileSource.getBinaryFileNamed("../illegal.file");
+        assertThrows(NotAuthorisedException.class, () -> {
+            SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
+            fileSource.getBinaryFileNamed("../illegal.file");
+        });
     }
 
-    @Test(expected = NotAuthorisedException.class)
+    @Test
     public void readTextFileThrowsExceptionWhenRelativePathIsOutsideRoot() {
-        SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
-        fileSource.getTextFileNamed("../illegal.file");
+        assertThrows(NotAuthorisedException.class, () -> {
+            SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
+            fileSource.getTextFileNamed("../illegal.file");
+        });
     }
 
-    @Test(expected = NotAuthorisedException.class)
+    @Test
     public void readBinaryFileThrowsExceptionWhenAbsolutePathIsOutsideRoot() throws Exception {
-        SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
-        String badPath = new File(ROOT_PATH,"../illegal.file").getCanonicalPath();
-        fileSource.getBinaryFileNamed(badPath);
+        assertThrows(NotAuthorisedException.class, () -> {
+            SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
+            String badPath = new File(ROOT_PATH, "../illegal.file").getCanonicalPath();
+            fileSource.getBinaryFileNamed(badPath);
+        });
     }
 
-    @Test(expected = NotAuthorisedException.class)
+    @Test
     public void readTextFileThrowsExceptionWhenAbsolutePathIsOutsideRoot() throws Exception {
-        SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
-        String badPath = new File(ROOT_PATH,"../illegal.file").getCanonicalPath();
-        fileSource.getTextFileNamed(badPath);
+        assertThrows(NotAuthorisedException.class, () -> {
+            SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
+            String badPath = new File(ROOT_PATH, "../illegal.file").getCanonicalPath();
+            fileSource.getTextFileNamed(badPath);
+        });
     }
 
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/TextFileTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/TextFileTest.java
@@ -16,21 +16,21 @@
 package com.github.tomakehurst.wiremock.common;
 
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class TextFileTest {
     @Test
     public void returnsPathToFileOnLinuxSystems() throws Exception {
-        assumeFalse("This test can only be run on non-Windows " +
-            "its behaviour is OS specific", SystemUtils.IS_OS_WINDOWS);
+        assumeFalse(SystemUtils.IS_OS_WINDOWS, "This test can only be run on non-Windows " +
+            "its behaviour is OS specific");
 
 
         TextFile textFile = new TextFile(new URI("file://home/bob/myfile.txt"));
@@ -42,9 +42,9 @@ public class TextFileTest {
 
     @Test
     public void returnsPathToFileOnWindowsSystems() throws Exception {
-        assumeTrue("This test can only be run on Windows " +
+        assumeTrue(SystemUtils.IS_OS_WINDOWS, "This test can only be run on Windows " +
                 "because File uses FileSystem in its constructor " +
-                "and its behaviour is OS specific", SystemUtils.IS_OS_WINDOWS);
+                "and its behaviour is OS specific");
 
         TextFile textFile = new TextFile(new URI("file:/C:/Users/bob/myfile.txt"));
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/UniqueFilenameGeneratorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/UniqueFilenameGeneratorTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.common;
 
 import com.github.tomakehurst.wiremock.http.QueryParameter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.List;

--- a/src/test/java/com/github/tomakehurst/wiremock/common/VeryShortIdGeneratorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/VeryShortIdGeneratorTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.matches;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/com/github/tomakehurst/wiremock/common/ssl/KeyStoreSettingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/ssl/KeyStoreSettingsTest.java
@@ -15,12 +15,13 @@
  */
 package com.github.tomakehurst.wiremock.common.ssl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.security.KeyStore;
 
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.*;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KeyStoreSettingsTest {
 
@@ -40,10 +41,12 @@ public class KeyStoreSettingsTest {
         assertNotNull(keyStore);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void failsWhenTrustStoreNotFound() {
-        KeyStoreSettings trustStoreSettings = new KeyStoreSettings("test-unknownstore", "", "jks");
-        trustStoreSettings.loadStore();
+        assertThrows(IllegalArgumentException.class, () -> {
+            KeyStoreSettings trustStoreSettings = new KeyStoreSettings("test-unknownstore", "", "jks");
+            trustStoreSettings.loadStore();
+        });
     }
 
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/common/ssl/KeyStoreSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/ssl/KeyStoreSourceTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.common.ssl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.security.Key;
 import java.security.KeyStore;

--- a/src/test/java/com/github/tomakehurst/wiremock/common/xml/XmlTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/xml/XmlTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.common.xml;
 
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalsMultiLine;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock.core;
 
 import com.google.common.base.Optional;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/com/github/tomakehurst/wiremock/crypto/InMemoryKeyStore.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/crypto/InMemoryKeyStore.java
@@ -18,12 +18,10 @@ package com.github.tomakehurst.wiremock.crypto;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.SignatureException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/ParametersTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/ParametersTest.java
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock.extension;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapperTest.java
@@ -19,7 +19,7 @@ import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.matching.MockRequest;
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -26,33 +26,28 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.LocalDate;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAdjusters;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static com.github.tomakehurst.wiremock.testsupport.NoFileSource.noFileSource;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ResponseTemplateTransformerTest {
 
     private ResponseTemplateTransformer transformer;
 
-    @Before
+    @BeforeEach
     public void setup() {
         transformer = new ResponseTemplateTransformer(true);
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/SystemKeyAuthorisorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/SystemKeyAuthorisorTest.java
@@ -16,10 +16,10 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
 import com.google.common.collect.ImmutableSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SystemKeyAuthorisorTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
@@ -16,7 +16,6 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
-import com.fasterxml.jackson.databind.util.ISO8601Utils;
 import com.github.jknack.handlebars.Options;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.common.LocalNotifier;
@@ -25,9 +24,8 @@ import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemp
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
 import com.google.common.collect.ImmutableMap;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -45,7 +43,7 @@ public class HandlebarsCurrentDateHelperTest {
     private HandlebarsCurrentDateHelper helper;
     private ResponseTemplateTransformer transformer;
 
-    @Before
+    @BeforeEach
     public void init() {
         helper = new HandlebarsCurrentDateHelper();
         transformer = new ResponseTemplateTransformer(true);

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsHelperTestBase.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsHelperTestBase.java
@@ -21,8 +21,8 @@ import com.github.jknack.handlebars.Options;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.RenderCache;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import org.hamcrest.Matcher;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,7 +37,7 @@ public abstract class HandlebarsHelperTestBase {
     protected ResponseTemplateTransformer transformer;
     protected RenderCache renderCache;
 
-    @Before
+    @BeforeEach
     public void initRenderCache() {
         transformer = new ResponseTemplateTransformer(true);
         renderCache = new RenderCache();
@@ -52,7 +52,7 @@ public abstract class HandlebarsHelperTestBase {
         try {
             assertThat((String) renderHelperValue(helper, content, pathExpression), expectation);
         } catch (final IOException e) {
-            Assert.fail(FAIL_GRACEFULLY_MSG);
+            Assertions.fail(FAIL_GRACEFULLY_MSG);
         }
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelperTest.java
@@ -24,10 +24,9 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -44,7 +43,7 @@ public class HandlebarsJsonPathHelperTest extends HandlebarsHelperTestBase {
 
     private HandlebarsJsonPathHelper helper;
 
-    @Before
+    @BeforeEach
     public void init() {
         helper = new HandlebarsJsonPathHelper();
         LocalNotifier.set(new ConsoleNotifier(true));

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsRandomValuesHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsRandomValuesHelperTest.java
@@ -23,8 +23,8 @@ import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemp
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -39,7 +39,7 @@ public class HandlebarsRandomValuesHelperTest {
     private HandlebarsRandomValuesHelper helper;
     private ResponseTemplateTransformer transformer;
 
-    @Before
+    @BeforeEach
     public void init() {
         helper = new HandlebarsRandomValuesHelper();
         transformer = new ResponseTemplateTransformer(true);

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsSoapHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsSoapHelperTest.java
@@ -18,8 +18,8 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -34,7 +34,7 @@ public class HandlebarsSoapHelperTest extends HandlebarsHelperTestBase {
     private HandlebarsSoapHelper helper;
     private ResponseTemplateTransformer transformer;
 
-    @Before
+    @BeforeEach
     public void init() {
         this.helper = new HandlebarsSoapHelper();
         this.transformer = new ResponseTemplateTransformer(true);

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsXPathHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsXPathHelperTest.java
@@ -17,8 +17,8 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -35,7 +35,7 @@ public class HandlebarsXPathHelperTest extends HandlebarsHelperTestBase {
 
     private HandlebarsXPathHelper helper;
 
-    @Before
+    @BeforeEach
     public void init() {
         helper = new HandlebarsXPathHelper();
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HostnameHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HostnameHelperTest.java
@@ -19,8 +19,8 @@ import com.github.jknack.handlebars.Options;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.common.LocalNotifier;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -34,7 +34,7 @@ public class HostnameHelperTest {
     private HostnameHelper helper;
     private String hostname;
 
-    @Before
+    @BeforeEach
     public void init() throws UnknownHostException {
         helper = new HostnameHelper();
         hostname = InetAddress.getLocalHost().getHostName();

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/MathsHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/MathsHelperTest.java
@@ -15,8 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
@@ -26,7 +26,7 @@ public class MathsHelperTest extends HandlebarsHelperTestBase {
 
     MathsHelper helper;
 
-    @Before
+    @BeforeEach
     public void init() {
         helper = new MathsHelper();
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
@@ -18,12 +18,11 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.github.jknack.handlebars.Options;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -37,7 +36,7 @@ public class ParseDateHelperTest {
 
     private ParseDateHelper helper;
 
-    @Before
+    @BeforeEach
     public void init() {
         helper = new ParseDateHelper();
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
@@ -18,9 +18,8 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 import com.github.jknack.handlebars.Options;
 import com.github.jknack.handlebars.Template;
 import com.github.jknack.handlebars.TagType;
-import com.github.jknack.handlebars.Context;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Map;
@@ -33,7 +32,7 @@ import static org.hamcrest.Matchers.*;
 public class ParseJsonHelperTest extends HandlebarsHelperTestBase {
     private ParseJsonHelper helper;
 
-    @Before
+    @BeforeEach
     public void init() {
         helper = new ParseJsonHelper();
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RegexExtractHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RegexExtractHelperTest.java
@@ -25,14 +25,14 @@ import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.common.LocalNotifier;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RegexExtractHelperTest extends HandlebarsHelperTestBase {
 
     private RegexExtractHelper helper;
 
-    @Before
+    @BeforeEach
     public void init() {
         helper = new RegexExtractHelper();
         LocalNotifier.set(new ConsoleNotifier(true));

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelperTest.java
@@ -21,17 +21,17 @@ import com.github.tomakehurst.wiremock.common.LocalNotifier;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.SystemKeyAuthoriser;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SystemValueHelperTest {
 
     private SystemValueHelper helper;
 
-    @Before
+    @BeforeEach
     public void init() {
         helper = new SystemValueHelper(new SystemKeyAuthoriser(ImmutableSet.of(".*")));
         LocalNotifier.set(new ConsoleNotifier(true));

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/TruncateDateTimeHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/TruncateDateTimeHelperTest.java
@@ -16,8 +16,8 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -31,7 +31,7 @@ public class TruncateDateTimeHelperTest extends HandlebarsHelperTestBase {
 
     private TruncateDateTimeHelper helper;
 
-    @Before
+    @BeforeEach
     public void init() {
         helper = new TruncateDateTimeHelper();
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/AdminRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/AdminRequestHandlerTest.java
@@ -21,9 +21,9 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.apache.http.entity.StringEntity;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.UnsupportedEncodingException;
 
@@ -37,12 +37,12 @@ public class AdminRequestHandlerTest {
     private WireMockServer wm;
     private WireMockTestClient client;
 
-    @Before
+    @BeforeEach
     public void init() {
         context = new Mockery();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         if (wm != null) {
             wm.stop();

--- a/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.node.IntNode;
 import com.github.tomakehurst.wiremock.common.Json;
 
 import org.apache.commons.codec.binary.Base64;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
@@ -20,24 +20,25 @@ import com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder;
 import com.google.common.base.Optional;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RunWith(JMock.class)
 public class ContentTypeHeaderTest {
 	
 	private Mockery context;
 	
-	@Before
+	@BeforeEach
 	public void init() {
 		context = new Mockery();
 	}
@@ -89,14 +90,16 @@ public class ContentTypeHeaderTest {
 		assertThat(contentTypeHeader.mimeTypePart(), is("text/xml"));
 	}
 
-	@Test(expected=NullPointerException.class)
+	@Test
 	public void throwsExceptionOnAttemptToSetNullHeaderValue() {
-		Request request = new MockRequestBuilder(context)
-			.withHeader("Content-Type", null)
-			.build();
-	
-        request.contentTypeHeader();
-	}
+        assertThrows(NullPointerException.class, () -> {
+            Request request = new MockRequestBuilder(context)
+                    .withHeader("Content-Type", null)
+                    .build();
+
+            request.contentTypeHeader();
+        });
+    }
 	
 	@Test
 	public void returnsNullFromMimeTypePartWhenContentTypeIsAbsent() {

--- a/src/test/java/com/github/tomakehurst/wiremock/http/CookieTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/CookieTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.http;
 
 import com.github.tomakehurst.wiremock.common.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalToJson;
 import static org.hamcrest.Matchers.hasItems;

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryAcceptsTrustedCertificatesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryAcceptsTrustedCertificatesTest.java
@@ -17,10 +17,8 @@ package com.github.tomakehurst.wiremock.http;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collection;
 import java.util.List;
@@ -30,12 +28,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.common.HttpClientUtils.getEntityAsStringAndCloseStream;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(Parameterized.class)
 public class HttpClientFactoryAcceptsTrustedCertificatesTest extends HttpClientFactoryCertificateVerificationTest {
 
-    @Parameters(name = "{index}: trusted={0}, certificateCN={1}, validCertificate={2}")
     public static Collection<Object[]> data() {
         return asList(new Object[][] {
                // trusted                     certificateCN validCertificate?
@@ -48,8 +44,11 @@ public class HttpClientFactoryAcceptsTrustedCertificatesTest extends HttpClientF
         });
     }
 
-    @Test
-    public void certificatesAreAccepted() throws Exception {
+    @MethodSource("data")
+    @ParameterizedTest(name = "{index}: trusted={0}, certificateCN={1}, validCertificate={2}")
+    public void certificatesAreAccepted(List<String> trustedHosts, String certificateCN, boolean validCertificate) throws Exception {
+
+        initHttpClientFactoryCertificateVerificationTest(trustedHosts, certificateCN, validCertificate);
 
         server.stubFor(get("/whatever").willReturn(aResponse().withBody("Hello World")));
 
@@ -60,11 +59,4 @@ public class HttpClientFactoryAcceptsTrustedCertificatesTest extends HttpClientF
         assertEquals("Hello World", result);
     }
 
-    public HttpClientFactoryAcceptsTrustedCertificatesTest(
-        List<String> trustedHosts,
-        String certificateCN,
-        boolean validCertificate
-    ) {
-        super(trustedHosts, certificateCN, validCertificate);
-    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
@@ -22,8 +22,8 @@ import com.github.tomakehurst.wiremock.crypto.InMemoryKeyStore;
 import com.github.tomakehurst.wiremock.crypto.Secret;
 import com.github.tomakehurst.wiremock.crypto.X509CertificateSpecification;
 import org.apache.http.client.HttpClient;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.File;
 import java.security.KeyPair;
@@ -43,23 +43,24 @@ public abstract class HttpClientFactoryCertificateVerificationTest {
 
     protected static final List<String> TRUST_NOBODY = emptyList();
 
-    private final List<String> trustedHosts;
-    private final String certificateCN;
-    private final boolean validCertificate;
+    private List<String> trustedHosts;
+    private String certificateCN;
+    private boolean validCertificate;
+
     protected WireMockServer server = null;
     protected HttpClient client;
 
-    protected HttpClientFactoryCertificateVerificationTest(
-        List<String> trustedHosts,
-        String certificateCN,
-        boolean validCertificate
+    public void initHttpClientFactoryCertificateVerificationTest(
+            List<String> trustedHosts,
+            String certificateCN,
+            boolean validCertificate
     ) {
         this.trustedHosts = trustedHosts;
         this.certificateCN = certificateCN;
         this.validCertificate = validCertificate;
     }
 
-    @Before
+    @BeforeEach
     public void startServerAndBuildClient() throws Exception {
 
         InMemoryKeyStore ks = new InMemoryKeyStore(JKS, new Secret("password"));
@@ -109,7 +110,7 @@ public abstract class HttpClientFactoryCertificateVerificationTest {
         );
     }
 
-    @After
+    @AfterEach
     public void stopServer() {
         if (server != null) {
             server.stop();

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeaderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeaderTest.java
@@ -16,11 +16,12 @@
 package com.github.tomakehurst.wiremock.http;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class HttpHeaderTest {
@@ -56,14 +57,18 @@ public class HttpHeaderTest {
         assertThat(header.containsValue("value72727"), is(false));
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void throwsExceptionWhenAttemptingToAccessFirstValueWhenAbsent() {
-        HttpHeader.absent("Something").firstValue();
+        assertThrows(IllegalStateException.class, () -> {
+            HttpHeader.absent("Something").firstValue();
+        });
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void throwsExceptionWhenAttemptingToAccessValuesWhenAbsent() {
-        HttpHeader.absent("Something").values();
+        assertThrows(IllegalStateException.class, () -> {
+            HttpHeader.absent("Something").values();
+        });
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeadersTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeadersTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.http;
 
 import com.github.tomakehurst.wiremock.common.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.*;

--- a/src/test/java/com/github/tomakehurst/wiremock/http/LogNormalTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/LogNormalTest.java
@@ -15,9 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class LogNormalTest {
 
     // To test properly we would need something like a normality test.

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
@@ -27,7 +27,7 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.security.KeyPair;
@@ -45,8 +45,7 @@ import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.core.StringStartsWith.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ProxyResponseRendererTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
@@ -23,8 +23,9 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -44,7 +45,7 @@ public class StubResponseRendererTest {
     private List<ResponseTransformer> responseTransformers;
     private StubResponseRenderer stubResponseRenderer;
 
-    @Before
+    @BeforeEach
     public void init() {
         context = new Mockery();
         fileSource = context.mock(FileSource.class);
@@ -53,7 +54,8 @@ public class StubResponseRendererTest {
         stubResponseRenderer = new StubResponseRenderer(fileSource, globalSettingsHolder, null, responseTransformers);
     }
 
-    @Test(timeout = TEST_TIMEOUT)
+    @Test
+    @Timeout(TEST_TIMEOUT)
     public void endpointFixedDelayShouldOverrideGlobalDelay() throws Exception {
         globalSettingsHolder.replaceWith(GlobalSettings.builder().fixedDelay(1000).build());
 
@@ -62,7 +64,8 @@ public class StubResponseRendererTest {
         assertThat(response.getInitialDelay(), is(100L));
     }
 
-    @Test(timeout = TEST_TIMEOUT)
+    @Test
+    @Timeout(TEST_TIMEOUT)
     public void globalFixedDelayShouldNotBeOverriddenIfNoEndpointDelaySpecified() throws Exception {
         globalSettingsHolder.replaceWith(GlobalSettings.builder().fixedDelay(1000).build());
 
@@ -71,7 +74,8 @@ public class StubResponseRendererTest {
         assertThat(response.getInitialDelay(), is(1000L));
     }
 
-    @Test(timeout = TEST_TIMEOUT)
+    @Test
+    @Timeout(TEST_TIMEOUT)
     public void shouldSetGlobalFixedDelayOnResponse() throws Exception {
         globalSettingsHolder.replaceWith(GlobalSettings.builder().fixedDelay(1000).build());
 
@@ -87,7 +91,8 @@ public class StubResponseRendererTest {
         assertThat(response.getInitialDelay(), is(2000L));
     }
 
-    @Test(timeout = TEST_TIMEOUT)
+    @Test
+    @Timeout(TEST_TIMEOUT)
     public void shouldSetEndpointDistributionDelayOnResponse() throws Exception {
         globalSettingsHolder.replaceWith(GlobalSettings.builder().delayDistribution(new DelayDistribution() {
             @Override
@@ -101,7 +106,8 @@ public class StubResponseRendererTest {
         assertThat(response.getInitialDelay(), is(123L));
     }
 
-    @Test(timeout = TEST_TIMEOUT)
+    @Test
+    @Timeout(TEST_TIMEOUT)
     public void shouldCombineFixedDelayDistributionDelay() throws Exception {
         globalSettingsHolder.replaceWith(GlobalSettings.builder().delayDistribution(new DelayDistribution() {
             @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/http/UniformDistributionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/UniformDistributionTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.http;
 
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CertificateGeneratingX509ExtendedKeyManagerChooseEngineServerAliasDefaultsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CertificateGeneratingX509ExtendedKeyManagerChooseEngineServerAliasDefaultsTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.http.ssl;
 
 import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.*;
 import javax.security.auth.x500.X500Principal;
@@ -28,8 +28,8 @@ import static java.lang.System.lineSeparator;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CertificateGeneratingX509ExtendedKeyManagerChooseEngineServerAliasTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CertificateGeneratingX509ExtendedKeyManagerChooseEngineServerAliasTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.http.ssl;
 
 import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.*;
 import java.io.FileInputStream;
@@ -30,7 +30,9 @@ import java.security.spec.RSAPublicKeySpec;
 
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.KEY_STORE_WITH_CA_PATH;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CertificateGeneratingX509ExtendedKeyManagerChooseServerAliasDefaultsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CertificateGeneratingX509ExtendedKeyManagerChooseServerAliasDefaultsTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.http.ssl;
 
 import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.*;
 import javax.security.auth.x500.X500Principal;
@@ -30,8 +30,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CompositeTrustManagerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CompositeTrustManagerTest.java
@@ -15,28 +15,19 @@
  */
 package com.github.tomakehurst.wiremock.http.ssl;
 
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.X509ExtendedTrustManager;
-import java.math.BigInteger;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.Principal;
-import java.security.PublicKey;
-import java.security.SignatureException;
-import java.security.cert.CertificateEncodingException;
+
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateExpiredException;
-import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
-import java.util.Date;
-import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
@@ -71,9 +62,9 @@ public class CompositeTrustManagerTest {
             trustManager1
         ));
 
-        CertificateException thrown = assertThrows(CertificateException.class, new ThrowingRunnable() {
+        CertificateException thrown = assertThrows(CertificateException.class, new Executable() {
             @Override
-            public void run() throws Throwable {
+            public void execute() throws Throwable {
                 compositeTrustManager.checkServerTrusted(chain, authType);
             }
         });
@@ -134,9 +125,9 @@ public class CompositeTrustManagerTest {
             trustManager2
         ));
 
-        CertificateException thrown = assertThrows(CertificateException.class, new ThrowingRunnable() {
+        CertificateException thrown = assertThrows(CertificateException.class, new Executable() {
             @Override
-            public void run() throws Throwable {
+            public void execute() throws Throwable {
                 compositeTrustManager.checkServerTrusted(chain, authType);
             }
         });

--- a/src/test/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServerTest.java
@@ -30,15 +30,15 @@ import com.github.tomakehurst.wiremock.verification.RequestJournal;
 import org.eclipse.jetty.server.ServerConnector;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(JMock.class)
@@ -49,7 +49,7 @@ public class JettyHttpServerTest {
     private StubRequestHandler stubRequestHandler;
     private JettyHttpServerFactory serverFactory = new JettyHttpServerFactory();
 
-    @Before
+    @BeforeEach
     public void init() {
         context = new Mockery();
         Admin admin = context.mock(Admin.class);

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/AbsentPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/AbsentPatternTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.matching;
 
 import com.github.tomakehurst.wiremock.common.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/AfterDateTimePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/AfterDateTimePatternTest.java
@@ -17,18 +17,16 @@ package com.github.tomakehurst.wiremock.matching;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAdjusters;
-
-import static java.time.temporal.ChronoUnit.DAYS;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AfterDateTimePatternTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/BeforeDateTimePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/BeforeDateTimePatternTest.java
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock.matching;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.DateTimeUnit;
 import com.github.tomakehurst.wiremock.common.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
@@ -31,8 +31,8 @@ import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BeforeDateTimePatternTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/BinaryEqualToPatternPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/BinaryEqualToPatternPatternTest.java
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock.matching;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.google.common.io.BaseEncoding;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/ContainsPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/ContainsPatternTest.java
@@ -16,12 +16,12 @@
 package com.github.tomakehurst.wiremock.matching;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ContainsPatternTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToDateTimePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToDateTimePatternTest.java
@@ -19,7 +19,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.DateTimeOffset;
 import com.github.tomakehurst.wiremock.common.DateTimeTruncation;
 import com.github.tomakehurst.wiremock.common.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -31,8 +31,8 @@ import static java.time.temporal.ChronoUnit.HOURS;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EqualToDateTimePatternTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToJsonTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToJsonTest.java
@@ -17,10 +17,8 @@ package com.github.tomakehurst.wiremock.matching;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
-import org.apache.commons.lang3.JavaVersion;
-import org.apache.commons.lang3.SystemUtils;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.apache.commons.lang3.JavaVersion.JAVA_1_8;
@@ -29,10 +27,10 @@ import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class EqualToJsonTest {
 
@@ -596,6 +594,6 @@ public class EqualToJsonTest {
     }
 
     private static void assumeJava8OrHigher() {
-        assumeThat(isJavaVersionAtLeast(JAVA_1_8), is(true));
+        assumeTrue(isJavaVersionAtLeast(JAVA_1_8));
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToPatternTest.java
@@ -18,11 +18,11 @@ package com.github.tomakehurst.wiremock.matching;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.JsonException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 public class EqualToPatternTest {

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -25,10 +25,10 @@ import com.google.common.collect.ImmutableSet;
 import org.hamcrest.Matchers;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xmlunit.diff.ComparisonType;
 
 import java.util.Locale;
@@ -40,7 +40,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.xmlunit.diff.ComparisonType.*;
 
 public class EqualToXmlPatternTest {
@@ -50,7 +50,7 @@ public class EqualToXmlPatternTest {
     @Rule
     public WireMockRule wm = new WireMockRule(options().dynamicPort());
 
-    @Before
+    @BeforeEach
     public void init() {
         context = new Mockery();
         LocalNotifier.set(new ConsoleNotifier(true));
@@ -60,7 +60,7 @@ public class EqualToXmlPatternTest {
         Locale.setDefault(Locale.ENGLISH);
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         LocalNotifier.set(null);
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/LogicalAndTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/LogicalAndTest.java
@@ -17,14 +17,14 @@ package com.github.tomakehurst.wiremock.matching;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LogicalAndTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/LogicalOrTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/LogicalOrTest.java
@@ -17,13 +17,13 @@ package com.github.tomakehurst.wiremock.matching;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LogicalOrTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchResultTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchResultTest.java
@@ -15,9 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import org.junit.Test;
-
 import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MatchResultTest {

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
@@ -23,9 +23,9 @@ import com.github.tomakehurst.wiremock.common.Notifier;
 import org.hamcrest.Matchers;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -33,14 +33,13 @@ import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalToJs
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MatchesJsonPathPatternTest {
 
     private Mockery context;
 
-    @Before
+    @BeforeEach
     public void init() {
         context = new Mockery();
     }
@@ -48,59 +47,59 @@ public class MatchesJsonPathPatternTest {
     @Test
     public void matchesABasicJsonPathWhenTheExpectedElementIsPresent() {
         StringValuePattern pattern = WireMock.matchingJsonPath("$.one");
-        assertTrue("Expected match when JSON attribute is present",
-            pattern.match("{ \"one\": 1 }").isExactMatch());
+        assertTrue(pattern.match("{ \"one\": 1 }").isExactMatch(),
+            "Expected match when JSON attribute is present");
     }
 
     @Test
     public void doesNotMatchABasicJsonPathWhenTheExpectedElementIsNotPresent() {
         StringValuePattern pattern = WireMock.matchingJsonPath("$.one");
-        assertFalse("Expected no match when JSON attribute is absent",
-            pattern.match("{ \"two\": 2 }").isExactMatch());
+        assertFalse(pattern.match("{ \"two\": 2 }").isExactMatch(),
+            "Expected no match when JSON attribute is absent");
     }
 
     @Test
     public void matchesOnJsonPathsWithFilters() {
         StringValuePattern pattern = WireMock.matchingJsonPath("$.numbers[?(@.number == '2')]");
 
-        assertTrue("Expected match when JSON attribute is present",
-            pattern.match("{ \"numbers\": [ {\"number\": 1}, {\"number\": 2} ]}")
-                .isExactMatch());
-        assertFalse("Expected no match when JSON attribute is absent",
-            pattern.match("{ \"numbers\": [{\"number\": 7} ]}")
-                .isExactMatch());
+        assertTrue(pattern.match("{ \"numbers\": [ {\"number\": 1}, {\"number\": 2} ]}")
+                .isExactMatch(),
+            "Expected match when JSON attribute is present");
+        assertFalse(pattern.match("{ \"numbers\": [{\"number\": 7} ]}")
+                .isExactMatch(),
+            "Expected no match when JSON attribute is absent");
     }
 
     @Test
     public void matchesOnJsonPathsWithRegexFilter() {
         StringValuePattern pattern = WireMock.matchingJsonPath("$.numbers[?(@.number =~ /2/i)]");
 
-        assertTrue("Expected match when JSON attribute is present",
-            pattern.match("{ \"numbers\": [ {\"number\": 1}, {\"number\": 2} ]}")
-                .isExactMatch());
-        assertFalse("Expected no match when JSON attribute is absent",
-            pattern.match("{ \"numbers\": [{\"number\": 7} ]}")
-                .isExactMatch());
+        assertTrue(pattern.match("{ \"numbers\": [ {\"number\": 1}, {\"number\": 2} ]}")
+                .isExactMatch(),
+            "Expected match when JSON attribute is present");
+        assertFalse(pattern.match("{ \"numbers\": [{\"number\": 7} ]}")
+                .isExactMatch(),
+            "Expected no match when JSON attribute is absent");
     }
 
     @Test
     public void matchesOnJsonPathsWithSizeFilter() {
         StringValuePattern pattern = WireMock.matchingJsonPath("$[?(@.numbers.size() == 2)]");
 
-        assertTrue("Expected match when JSON attribute is present",
-            pattern.match("{ \"numbers\": [ {\"number\": 1}, {\"number\": 2} ]}")
-                .isExactMatch());
-        assertFalse("Expected no match when JSON attribute is absent",
-            pattern.match("{ \"numbers\": [{\"number\": 7} ]}")
-                .isExactMatch());
+        assertTrue(pattern.match("{ \"numbers\": [ {\"number\": 1}, {\"number\": 2} ]}")
+                .isExactMatch(),
+            "Expected match when JSON attribute is present");
+        assertFalse(pattern.match("{ \"numbers\": [{\"number\": 7} ]}")
+                .isExactMatch(),
+            "Expected no match when JSON attribute is absent");
     }
 
     @Test
     public void matchesOnJsonPathsWithFiltersOnNestedObjects() {
         StringValuePattern pattern = WireMock.matchingJsonPath("$..thingOne[?(@.innerOne == 11)]");
-        assertTrue("Expected match",
-            pattern.match("{ \"things\": { \"thingOne\": { \"innerOne\": 11 }, \"thingTwo\": 2 }}")
-                .isExactMatch());
+        assertTrue(pattern.match("{ \"things\": { \"thingOne\": { \"innerOne\": 11 }, \"thingTwo\": 2 }}")
+                .isExactMatch(),
+            "Expected match");
     }
 
     @Test
@@ -108,7 +107,7 @@ public class MatchesJsonPathPatternTest {
         expectInfoNotification("Warning: JSON path expression '$.something' failed to match document 'Not a JSON document' because of error 'Expected to find an object with property ['something'] in path $ but found 'java.lang.String'. This is not a json object according to the JsonProvider: 'com.jayway.jsonpath.spi.json.JsonSmartJsonProvider'.'");
 
         StringValuePattern pattern = WireMock.matchingJsonPath("$.something");
-        assertFalse("Expected the match to fail", pattern.match("Not a JSON document").isExactMatch());
+        assertFalse(pattern.match("Not a JSON document").isExactMatch(), "Expected the match to fail");
     }
 
     @Test
@@ -116,7 +115,7 @@ public class MatchesJsonPathPatternTest {
         expectInfoNotification("Warning: JSON path expression '$.something' failed to match document '{ \"nothing\": 1 }' because of error 'No results for path: $['something']'");
 
         StringValuePattern pattern = WireMock.matchingJsonPath("$.something");
-        assertFalse("Expected the match to fail", pattern.match("{ \"nothing\": 1 }").isExactMatch());
+        assertFalse(pattern.match("{ \"nothing\": 1 }").isExactMatch(), "Expected the match to fail");
     }
 
     @Test
@@ -355,28 +354,32 @@ public class MatchesJsonPathPatternTest {
                 "}"));
     }
 
-    @Test(expected = JsonException.class)
+    @Test
     public void throwsSensibleErrorOnDeserialisationWhenPatternIsBadlyFormedWithMissingExpression() {
-        Json.read(
-            "{                                      \n" +
-                "    \"matchesJsonPath\": {              \n" +
-                "        \"express\": \"$..thing\",      \n" +
-                "        \"equalTo\": \"the value\"      \n" +
-                "    }                                   \n" +
-                "}",
-            StringValuePattern.class);
+        assertThrows(JsonException.class, () -> {
+            Json.read(
+                    "{                                      \n" +
+                            "    \"matchesJsonPath\": {              \n" +
+                            "        \"express\": \"$..thing\",      \n" +
+                            "        \"equalTo\": \"the value\"      \n" +
+                            "    }                                   \n" +
+                            "}",
+                    StringValuePattern.class);
+        });
     }
 
-    @Test(expected = JsonException.class)
+    @Test
     public void throwsSensibleErrorOnDeserialisationWhenPatternIsBadlyFormedWithBadValuePatternName() {
-        Json.read(
-            "{                                      \n" +
-                "    \"matchesJsonPath\": {              \n" +
-                "        \"expression\": \"$..thing\",   \n" +
-                "        \"badOperator\": \"the value\"  \n" +
-                "    }                                   \n" +
-                "}",
-            StringValuePattern.class);
+        assertThrows(JsonException.class, () -> {
+            Json.read(
+                    "{                                      \n" +
+                            "    \"matchesJsonPath\": {              \n" +
+                            "        \"expression\": \"$..thing\",   \n" +
+                            "        \"badOperator\": \"the value\"  \n" +
+                            "    }                                   \n" +
+                            "}",
+                    StringValuePattern.class);
+        });
     }
 
     @Test
@@ -435,7 +438,7 @@ public class MatchesJsonPathPatternTest {
         LocalNotifier.set(notifier);
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         LocalNotifier.set(null);
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
@@ -18,9 +18,8 @@ package com.github.tomakehurst.wiremock.matching;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.google.common.collect.ImmutableMap;
-import org.hamcrest.Matchers;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Collections;
@@ -28,9 +27,9 @@ import java.util.Collections;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalToJson;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MatchesXPathPatternTest {
 
@@ -44,7 +43,7 @@ public class MatchesXPathPatternTest {
         StringValuePattern pattern = WireMock.matchingXPath("//planet[@name='Earth']");
 
         MatchResult match = pattern.match(mySolarSystemXML);
-        assertTrue("Expected XPath match", match.isExactMatch());
+        assertTrue(match.isExactMatch(), "Expected XPath match");
         assertThat(match.getDistance(), is(0.0));
     }
 
@@ -57,7 +56,7 @@ public class MatchesXPathPatternTest {
         StringValuePattern pattern = WireMock.matchingXPath("//star[@name='alpha centauri']");
 
         MatchResult match = pattern.match(mySolarSystemXML);
-        assertFalse("Expected XPath non-match", match.isExactMatch());
+        assertFalse(match.isExactMatch(), "Expected XPath non-match");
         assertThat(match.getDistance(), is(1.0));
     }
 
@@ -70,7 +69,7 @@ public class MatchesXPathPatternTest {
         StringValuePattern pattern = WireMock.matchingXPath("//\\\\&&&&&");
 
         MatchResult match = pattern.match(mySolarSystemXML);
-        assertFalse("Expected XPath non-match", match.isExactMatch());
+        assertFalse(match.isExactMatch(), "Expected XPath non-match");
         assertThat(match.getDistance(), is(1.0));
     }
 
@@ -83,7 +82,7 @@ public class MatchesXPathPatternTest {
         StringValuePattern pattern = WireMock.matchingXPath("//star[@name='alpha centauri']");
 
         MatchResult match = pattern.match(mySolarSystemXML);
-        assertFalse("Expected XPath non-match", match.isExactMatch());
+        assertFalse(match.isExactMatch(), "Expected XPath non-match");
         assertThat(match.getDistance(), is(1.0));
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MultiValuePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MultiValuePatternTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock.matching;
 
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -25,9 +25,9 @@ import static com.github.tomakehurst.wiremock.http.HttpHeader.absent;
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static com.github.tomakehurst.wiremock.http.QueryParameter.queryParam;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MultiValuePatternTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilderTest.java
@@ -30,10 +30,11 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
 import static com.github.tomakehurst.wiremock.client.WireMock.absent;
@@ -41,12 +42,12 @@ import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToXml;
 import static com.google.common.collect.Maps.newLinkedHashMap;
 import static java.util.Arrays.asList;
-import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.isIn;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MultipartValuePatternBuilderTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternTest.java
@@ -33,15 +33,14 @@ package com.github.tomakehurst.wiremock.matching;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.google.common.collect.Maps.newLinkedHashMap;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MultipartValuePatternTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RegexValuePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RegexValuePatternTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock.matching;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.hamcrest.Matchers.instanceOf;

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
@@ -37,12 +37,10 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static com.google.common.collect.Maps.asMap;
-import static com.google.common.collect.Maps.newLinkedHashMap;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
@@ -20,7 +20,7 @@ import com.github.tomakehurst.wiremock.http.RequestMethod;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -28,8 +28,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.*;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RequestPatternTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/StringValuePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/StringValuePatternTest.java
@@ -22,7 +22,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.reflect.ClassPath;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/UrlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/UrlPatternTest.java
@@ -16,12 +16,12 @@
 package com.github.tomakehurst.wiremock.matching;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UrlPatternTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformerTest.java
@@ -16,11 +16,11 @@
 package com.github.tomakehurst.wiremock.recording;
 
 import com.github.tomakehurst.wiremock.http.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.responseDefinition;
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LoggedResponseDefinitionTransformerTest {
     private LoggedResponseDefinitionTransformer aTransformer() {

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/ProxiedServeEventFiltersTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/ProxiedServeEventFiltersTest.java
@@ -21,7 +21,7 @@ import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.MockRequest;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -33,8 +33,8 @@ import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProxiedServeEventFiltersTest {
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/RecordingStatusResultTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/RecordingStatusResultTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.recording;
 
 import com.github.tomakehurst.wiremock.common.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalToJson;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/RequestBodyAutomaticPatternFactoryTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/RequestBodyAutomaticPatternFactoryTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock.recording;
 
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.matching.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/RequestBodyEqualToJsonPatternFactoryTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/RequestBodyEqualToJsonPatternFactoryTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.recording;
 
 import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/RequestBodyPatternFactoryJsonDeserializerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/RequestBodyPatternFactoryJsonDeserializerTest.java
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock.recording;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static org.hamcrest.Matchers.instanceOf;

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformerTest.java
@@ -19,13 +19,13 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RequestPatternTransformerTest {
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/ResponseDefinitionBodyMatcherDeserializerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/ResponseDefinitionBodyMatcherDeserializerTest.java
@@ -17,11 +17,11 @@ package com.github.tomakehurst.wiremock.recording;
 
 import com.github.tomakehurst.wiremock.common.Json;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ResponseDefinitionBodyMatcherDeserializerTest {
     @Test
@@ -38,7 +38,7 @@ public class ResponseDefinitionBodyMatcherDeserializerTest {
         for (String input : testCases.keySet()) {
             Long expected = testCases.get(input);
             Long actual = ResponseDefinitionBodyMatcherDeserializer.parseFilesize(input);
-            assertEquals("Failed with " + input, expected, actual);
+            assertEquals(expected, actual, "Failed with " + input);
         }
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/ResponseDefinitionBodyMatcherTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/ResponseDefinitionBodyMatcherTest.java
@@ -17,10 +17,10 @@ package com.github.tomakehurst.wiremock.recording;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResponseDefinitionBodyMatcherTest {
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessorTest.java
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock.recording;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotOutputFormatterTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotOutputFormatterTest.java
@@ -15,11 +15,12 @@
  */
 package com.github.tomakehurst.wiremock.recording;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.recording.SnapshotOutputFormatter.FULL;
 import static com.github.tomakehurst.wiremock.recording.SnapshotOutputFormatter.IDS;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SnapshotOutputFormatterTest {
     @Test
@@ -27,9 +28,11 @@ public class SnapshotOutputFormatterTest {
         assertEquals(FULL, SnapshotOutputFormatter.fromString(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void fromStringWithInvalidFormat() {
-        SnapshotOutputFormatter.fromString("invalid output format");
+        assertThrows(IllegalArgumentException.class, () -> {
+            SnapshotOutputFormatter.fromString("invalid output format");
+        });
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotRecordResultDeserialiserTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotRecordResultDeserialiserTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock.recording;
 
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractorTest.java
@@ -21,8 +21,8 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
@@ -36,7 +36,7 @@ public class SnapshotStubMappingBodyExtractorTest {
     private SnapshotStubMappingBodyExtractor bodyExtractor;
     private Mockery context;
 
-    @Before
+    @BeforeEach
     public void init() {
         context = new Mockery();
         filesSource = context.mock(FileSource.class, "filesFileSource");

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGeneratorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGeneratorTest.java
@@ -25,7 +25,7 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import org.jmock.Mockery;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern;
 import static com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder.aRequest;

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessorTest.java
@@ -20,7 +20,7 @@ import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingTransformerRunnerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingTransformerRunnerTest.java
@@ -21,11 +21,11 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.GlobalStubMappingTransformer;
 import com.github.tomakehurst.wiremock.testsupport.NonGlobalStubMappingTransformer;
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SnapshotStubMappingTransformerRunnerTest {
     private final StubMapping stubMapping = WireMock.get("/").build();

--- a/src/test/java/com/github/tomakehurst/wiremock/servlet/AlternativeServletContainerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/servlet/AlternativeServletContainerTest.java
@@ -20,9 +20,9 @@ import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
@@ -35,7 +35,7 @@ public class AlternativeServletContainerTest {
     public WireMockRule wm = new WireMockRule(options().httpServerFactory(new AltHttpServerFactory()));
     WireMockTestClient client;
 
-    @Before
+    @BeforeEach
     public void init() {
         client = new WireMockTestClient(wm.port());
         WireMock.configureFor(wm.port());

--- a/src/test/java/com/github/tomakehurst/wiremock/servlet/BodyChunkerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/servlet/BodyChunkerTest.java
@@ -15,10 +15,11 @@
  */
 package com.github.tomakehurst.wiremock.servlet;
 
-import org.junit.Test;
-
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BodyChunkerTest {

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -35,7 +35,7 @@ import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
 import com.github.tomakehurst.wiremock.security.Authenticator;
 import com.google.common.base.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
@@ -48,7 +48,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CommandLineOptionsTest {
 
@@ -155,10 +156,12 @@ public class CommandLineOptionsTest {
         assertThat(options.httpsSettings().keyManagerPassword(), is("keymanpass"));
     }
 
-	@Test(expected=Exception.class)
+	@Test
 	public void throwsExceptionWhenPortNumberSpecifiedWithoutNumber() {
-		new CommandLineOptions("--port");
-	}
+        assertThrows(Exception.class, () -> {
+            new CommandLineOptions("--port");
+        });
+    }
 
     @Test
     public void returnsCorrecteyParsedBindAddress(){
@@ -179,10 +182,12 @@ public class CommandLineOptionsTest {
         assertThat(options.proxyHostHeader(), is("someotherhost.com:8080"));
     }
 
-    @Test(expected=Exception.class)
+    @Test
 	public void throwsExceptionWhenProxyAllSpecifiedWithoutUrl() {
-		new CommandLineOptions("--proxy-all");
-	}
+        assertThrows(Exception.class, () -> {
+            new CommandLineOptions("--proxy-all");
+        });
+    }
 
 	@Test
 	public void returnsBrowserProxyingEnabledWhenOptionSet() {
@@ -332,9 +337,11 @@ public class CommandLineOptionsTest {
         assertThat(options.jettySettings().getStopTimeout().isPresent(), is(false));
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void preventsRecordingWhenRequestJournalDisabled() {
-        new CommandLineOptions("--no-request-journal", "--record-mappings");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new CommandLineOptions("--no-request-journal", "--record-mappings");
+        });
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSourceTest.java
@@ -22,10 +22,9 @@ import com.github.tomakehurst.wiremock.stubbing.InMemoryStubMappings;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.google.common.io.Files;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.util.List;
@@ -37,36 +36,36 @@ import static com.google.common.base.Charsets.UTF_8;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class JsonFileMappingsSourceTest {
 
-    @Rule
-    public final TemporaryFolder tempDir = new TemporaryFolder();
+    @TempDir
+    public File tempDir;
 
     InMemoryStubMappings stubMappings;
     JsonFileMappingsSource source;
 	File stubMappingFile;
 
-    @Before
+    @BeforeEach
 	public void init() throws Exception {
 		stubMappings = new InMemoryStubMappings();
 	}
 
 	private void configureWithMultipleMappingFile() throws Exception {
-		stubMappingFile = tempDir.newFile("multi.json");
+		stubMappingFile = File.createTempFile("multi.json", null, tempDir);
 		Files.copy(new File(filePath("multi-stub/multi.json")), stubMappingFile);
 		load();
 	}
 
 	private void configureWithSingleMappingFile() throws Exception {
-    	stubMappingFile = tempDir.newFile("single.json");
+		stubMappingFile = File.createTempFile("single.json", null, tempDir);
 		Files.copy(new File(filePath("multi-stub/single.json")), stubMappingFile);
 		load();
 	}
 
 	private void load() {
-		source = new JsonFileMappingsSource(new SingleRootFileSource(tempDir.getRoot()));
+		source = new JsonFileMappingsSource(new SingleRootFileSource(tempDir));
 		source.loadMappingsInto(stubMappings);
 	}
 
@@ -90,12 +89,12 @@ public class JsonFileMappingsSourceTest {
 
 	@Test
 	public void stubMappingFilesAreWrittenWithInsertionIndex() throws Exception {
-	    JsonFileMappingsSource source = new JsonFileMappingsSource(new SingleRootFileSource(tempDir.getRoot()));
+	    JsonFileMappingsSource source = new JsonFileMappingsSource(new SingleRootFileSource(tempDir));
 
         StubMapping stub = get("/saveable").willReturn(ok()).build();
         source.save(stub);
 
-        File savedFile = tempDir.getRoot().listFiles()[0];
+        File savedFile = tempDir.listFiles()[0];
         String savedStub = Files.toString(savedFile, UTF_8);
 
         assertThat(savedStub, containsString("\"insertionIndex\" : 0"));

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/ProxySettingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/ProxySettingsTest.java
@@ -16,16 +16,19 @@
 package com.github.tomakehurst.wiremock.standalone;
 
 import com.github.tomakehurst.wiremock.common.ProxySettings;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ProxySettingsTest {
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void throwsExceptionWhenHostPartNotSpecified() {
-        ProxySettings.fromString(":8090");
+        assertThrows(IllegalArgumentException.class, () -> {
+            ProxySettings.fromString(":8090");
+        });
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
@@ -27,8 +27,8 @@ import com.github.tomakehurst.wiremock.verification.VerificationResult;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Collections;
@@ -51,7 +51,7 @@ public class AdminRequestHandlerTest {
 
     private AdminRequestHandler handler;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		context = new Mockery();
         admin = context.mock(Admin.class);

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryMappingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryMappingsTest.java
@@ -21,9 +21,9 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -45,7 +45,7 @@ public class InMemoryMappingsTest {
     private Mockery context;
     private Notifier notifier;
 
-    @Before
+    @BeforeEach
     public void init() {
         mappings = new InMemoryStubMappings();
         context = new Mockery();
@@ -53,7 +53,7 @@ public class InMemoryMappingsTest {
         notifier = context.mock(Notifier.class);
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         LocalNotifier.set(null);
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappingsTest.java
@@ -17,8 +17,8 @@ package com.github.tomakehurst.wiremock.stubbing;
 
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -29,13 +29,13 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class InMemoryStubMappingsTest {
 
 	private InMemoryStubMappings inMemoryStubMappings;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		inMemoryStubMappings = new InMemoryStubMappings();
 	}

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
@@ -16,10 +16,10 @@
 package com.github.tomakehurst.wiremock.stubbing;
 
 import com.github.tomakehurst.wiremock.common.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class JsonTest {

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
@@ -22,16 +22,16 @@ import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.responseDefinition;
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static com.github.tomakehurst.wiremock.http.ResponseDefinition.copyOf;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResponseDefinitionTest {
 
@@ -65,7 +65,7 @@ public class ResponseDefinitionTest {
     public void copyPreservesConfiguredFlag() {
         ResponseDefinition response = ResponseDefinition.notConfigured();
         ResponseDefinition copiedResponse = copyOf(response);
-        assertFalse("Should be not configured", copiedResponse.wasConfigured());
+        assertFalse(copiedResponse.wasConfigured(), "Should be not configured");
     }
 
     private static final String STRING_BODY =

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ScenariosTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ScenariosTest.java
@@ -15,19 +15,14 @@
  */
 package com.github.tomakehurst.wiremock.stubbing;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -35,7 +30,7 @@ public class ScenariosTest {
 
     Scenarios scenarios;
 
-    @Before
+    @BeforeEach
     public void init() {
         scenarios = new Scenarios();
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/SortedConcurrentMappingSetTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/SortedConcurrentMappingSetTest.java
@@ -20,8 +20,8 @@ import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 
@@ -36,7 +36,7 @@ public class SortedConcurrentMappingSetTest {
 	
 	private SortedConcurrentMappingSet mappingSet;
 	
-	@Before
+	@BeforeEach
 	public void init() {
 		mappingSet = new SortedConcurrentMappingSet();
 	}

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -26,14 +26,11 @@ import com.github.tomakehurst.wiremock.verification.VerificationResult;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.*;
 
 import static com.github.tomakehurst.wiremock.common.Gzip.gzip;
@@ -59,7 +56,7 @@ public class StubMappingJsonRecorderTest {
 
 	private Mockery context;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		context = new Mockery();
 		mappingsFileSource = context.mock(FileSource.class, "mappingsFileSource");
@@ -597,7 +594,7 @@ public class StubMappingJsonRecorderTest {
             int i = headerLine.indexOf(':');
 
             if (i <= 0) {
-                Assert.fail("Invalid header expected line: " + headerLine);
+                Assertions.fail("Invalid header expected line: " + headerLine);
             }
 
             Collection<String> params = new ArrayList<>();

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.stubbing;
 
 import com.github.tomakehurst.wiremock.common.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubRequestHandlerTest.java
@@ -32,8 +32,8 @@ import com.github.tomakehurst.wiremock.verification.RequestJournal;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Collections;
@@ -58,7 +58,7 @@ public class StubRequestHandlerTest {
 
 	private StubRequestHandler requestHandler;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		context = new Mockery();
         stubServer = context.mock(StubServer.class);

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/Assumptions.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/Assumptions.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock.testsupport;
 
 import org.apache.commons.lang3.SystemUtils;
 
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class Assumptions {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MappingJsonSamples.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MappingJsonSamples.java
@@ -15,8 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.testsupport;
 
-import com.github.tomakehurst.wiremock.common.Encoding;
-
 import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
 
 public class MappingJsonSamples {

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMatchers.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMatchers.java
@@ -17,7 +17,6 @@ package com.github.tomakehurst.wiremock.testsupport;
 
 import com.github.tomakehurst.wiremock.common.TextFile;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
-import com.github.tomakehurst.wiremock.matching.EqualToXmlPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPattern;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
@@ -27,7 +26,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
-import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.*;
 import org.hamcrest.core.IsEqual;
 import org.skyscreamer.jsonassert.JSONAssert;

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/InMemoryRequestJournalTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/InMemoryRequestJournalTest.java
@@ -18,8 +18,8 @@ package com.github.tomakehurst.wiremock.verification;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.google.common.base.Optional;
 import org.jmock.Mockery;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -33,7 +33,7 @@ public class InMemoryRequestJournalTest {
 
     private ServeEvent serveEvent1, serveEvent2, serveEvent3;
 
-    @Before
+    @BeforeEach
     public void createTestRequests() {
         Mockery context = new Mockery();
         serveEvent1 = ServeEvent.of(createFrom(aRequest(context, "log1").withUrl("/logging1").build()), null);

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
@@ -25,8 +25,8 @@ import com.github.tomakehurst.wiremock.http.Cookie;
 import com.google.common.collect.ImmutableMap;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -41,8 +41,9 @@ import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
 import static com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder.aRequest;
 import static com.github.tomakehurst.wiremock.verification.LoggedRequest.createFrom;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @RunWith(JMock.class)
 public class LoggedRequestTest {
@@ -52,7 +53,7 @@ public class LoggedRequestTest {
 
     private Mockery context;
 
-    @Before
+    @BeforeEach
     public void init() {
         context = new Mockery();
         System.out.println(TimeZone.getDefault());

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedResponseTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedResponseTest.java
@@ -31,12 +31,13 @@
 package com.github.tomakehurst.wiremock.verification;
 
 import com.github.tomakehurst.wiremock.http.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LoggedResponseTest {
     private static String ISO_8859_1_RESPONSE_BODY = "köttfärssås";

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/NearMissCalculatorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/NearMissCalculatorTest.java
@@ -25,8 +25,8 @@ import com.github.tomakehurst.wiremock.stubbing.StubMappings;
 import com.google.common.base.Function;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -34,7 +34,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.*;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern;
-import static com.github.tomakehurst.wiremock.matching.WeightedMatchResult.weight;
 import static com.github.tomakehurst.wiremock.verification.NearMissCalculator.NEAR_MISS_COUNT;
 import static com.google.common.collect.FluentIterable.from;
 import static org.hamcrest.Matchers.is;
@@ -50,7 +49,7 @@ public class NearMissCalculatorTest {
     RequestJournal requestJournal;
     Scenarios scenarios;
 
-    @Before
+    @BeforeEach
     public void init() {
         context = new Mockery();
 

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/NearMissTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/NearMissTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock.verification;
 
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/diff/DiffTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/diff/DiffTest.java
@@ -19,7 +19,7 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.ValueMatcher;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.*;

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/diff/PlainTextDiffRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/diff/PlainTextDiffRendererTest.java
@@ -21,8 +21,8 @@ import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
 import com.github.tomakehurst.wiremock.matching.ValueMatcher;
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -35,14 +35,13 @@ import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern;
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.file;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalsMultiLine;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PlainTextDiffRendererTest {
 
     PlainTextDiffRenderer diffRenderer;
 
-    @Before
+    @BeforeEach
     public void init() {
         diffRenderer = new PlainTextDiffRenderer(Collections.<String, RequestMatcherExtension>singletonMap("my-custom-matcher", new MyCustomMatcher()));
     }

--- a/src/test/java/ignored/Examples.java
+++ b/src/test/java/ignored/Examples.java
@@ -17,9 +17,7 @@ package ignored;
 
 import com.github.tomakehurst.wiremock.AcceptanceTestBase;
 import com.github.tomakehurst.wiremock.client.VerificationException;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
-import com.github.tomakehurst.wiremock.common.DateTimeTruncation;
 import com.github.tomakehurst.wiremock.common.DateTimeUnit;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -31,7 +29,6 @@ import com.github.tomakehurst.wiremock.extension.requestfilter.StubRequestFilter
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
@@ -40,19 +37,19 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.common.DateTimeTruncation.*;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Examples extends AcceptanceTestBase {
@@ -151,17 +148,21 @@ public class Examples extends AcceptanceTestBase {
                         .withBody(new byte[]{1, 2, 3, 4})));
     }
 
-    @Test(expected=VerificationException.class)
+    @Test
     public void verifyAtLeastOnce() {
-        verify(postRequestedFor(urlEqualTo("/verify/this"))
-                .withHeader("Content-Type", equalTo("text/xml")));
+        assertThrows(VerificationException.class, () -> {
+            verify(postRequestedFor(urlEqualTo("/verify/this"))
+                    .withHeader("Content-Type", equalTo("text/xml")));
 
-        verify(3, postRequestedFor(urlEqualTo("/3/of/these")));
+            verify(3, postRequestedFor(urlEqualTo("/3/of/these")));
+        });
     }
 
-    @Test(expected=VerificationException.class)
+    @Test
     public void verifyWithoutHeader() {
-        verify(putRequestedFor(urlEqualTo("/without/header")).withoutHeader("Content-Type"));
+        assertThrows(VerificationException.class, () -> {
+            verify(putRequestedFor(urlEqualTo("/without/header")).withoutHeader("Content-Type"));
+        });
     }
 
     @Test

--- a/src/test/java/ignored/JUnit5ProxyTest.java
+++ b/src/test/java/ignored/JUnit5ProxyTest.java
@@ -8,14 +8,14 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JUnit5ProxyTest {
 
@@ -26,12 +26,12 @@ public class JUnit5ProxyTest {
             .useSystemProperties() // This must be enabled for auto-configuration of proxy settings to work
             .build();
 
-    @Before
+    @BeforeEach
     public void init() {
         JvmProxyConfigurer.configureFor(wm);
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         JvmProxyConfigurer.restorePrevious();
     }

--- a/src/test/java/ignored/ManyUnmatchedRequestsTest.java
+++ b/src/test/java/ignored/ManyUnmatchedRequestsTest.java
@@ -17,9 +17,9 @@ package ignored;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -35,7 +35,7 @@ public class ManyUnmatchedRequestsTest {
 
     WireMockTestClient client;
 
-    @Before
+    @BeforeEach
     public void init() {
         client = new WireMockTestClient(wm.port());
     }

--- a/src/test/java/ignored/MassiveNearMissTest.java
+++ b/src/test/java/ignored/MassiveNearMissTest.java
@@ -19,9 +19,9 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +37,7 @@ public class MassiveNearMissTest {
 
     WireMockTestClient client;
 
-    @Before
+    @BeforeEach
     public void setup() {
         client = new WireMockTestClient(wm.port());
     }

--- a/src/test/java/ignored/NearMissExampleTest.java
+++ b/src/test/java/ignored/NearMissExampleTest.java
@@ -19,9 +19,9 @@ import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.apache.http.entity.StringEntity;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
@@ -45,7 +45,7 @@ public class NearMissExampleTest {
 
     WireMockTestClient client;
 
-    @Before
+    @BeforeEach
     public void init() {
         client = new WireMockTestClient(wm.port());
     }

--- a/src/test/java/ignored/SingleUnmatchedRequestTest.java
+++ b/src/test/java/ignored/SingleUnmatchedRequestTest.java
@@ -17,9 +17,9 @@ package ignored;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -35,7 +35,7 @@ public class SingleUnmatchedRequestTest {
 
     WireMockTestClient client;
 
-    @Before
+    @BeforeEach
     public void init() {
         client = new WireMockTestClient(wm.port());
     }

--- a/src/test/java/ignored/VeryLongAsynchronousDelayAcceptanceTest.java
+++ b/src/test/java/ignored/VeryLongAsynchronousDelayAcceptanceTest.java
@@ -25,12 +25,9 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 

--- a/src/test/java/ignored/WireMockRuleFailThenPass.java
+++ b/src/test/java/ignored/WireMockRuleFailThenPass.java
@@ -15,9 +15,9 @@
  */
 package ignored;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WireMockRuleFailThenPass {
 


### PR DESCRIPTION
This MR converts the project tests from JUnit 4 to JUnit 5, except where we're explicitly testing JUnit 4 compatibility.

Conversion was started using https://docs.openrewrite.org/tutorials/migrate-from-junit-4-to-junit-5;
Expanded by hand mostly to convert WireMockRule usage to WireMockExtension.

Not ready yet, thought to gather feedback on whether this has a chance of getting merged before I continue.

Any feedback appreciated!