### PR TITLE
Bump JMock to 2.12 and reduce or replace usage where possible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,12 +91,7 @@ dependencies {
 
     testCompile "org.hamcrest:hamcrest-core:2.2"
     testCompile "org.hamcrest:hamcrest-library:2.2"
-    testCompile("org.jmock:jmock:2.5.1") {
-        exclude group: "junit", module: "junit-dep"
-        exclude group: "org.hamcrest", module: "hamcrest-core"
-        exclude group: "org.hamcrest", module: "hamcrest-library"
-    }
-    testCompile("org.jmock:jmock-junit4:2.5.1") {
+    testCompile("org.jmock:jmock-junit5:2.12.0") {
         exclude group: "junit", module: "junit-dep"
         exclude group: "org.hamcrest", module: "hamcrest-core"
         exclude group: "org.hamcrest", module: "hamcrest-library"

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/OldEditStubMappingTaskTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/OldEditStubMappingTaskTest.java
@@ -22,21 +22,21 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import org.jmock.Expectations;
-import org.jmock.Mockery;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
 
 import static com.github.tomakehurst.wiremock.stubbing.StubMapping.buildJsonStringFor;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class OldEditStubMappingTaskTest {
 
 	private static final StubMapping MOCK_MAPPING = new StubMapping(null, new ResponseDefinition());
 
-	private Mockery context;
+	private JUnit5Mockery context = new JUnit5Mockery();
 	private Admin mockAdmin;
 
 	private Request mockRequest;
@@ -46,7 +46,6 @@ public class OldEditStubMappingTaskTest {
 	@Before
 	public void setUp() {
 
-		context = new Mockery();
 		mockAdmin = context.mock(Admin.class);
 		mockRequest = context.mock(Request.class);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/RemoveStubMappingTaskTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/RemoveStubMappingTaskTest.java
@@ -22,21 +22,21 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import org.jmock.Expectations;
-import org.jmock.Mockery;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
 
 import static com.github.tomakehurst.wiremock.stubbing.StubMapping.buildJsonStringFor;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class RemoveStubMappingTaskTest {
 
     private static final StubMapping MOCK_MAPPING = new StubMapping(null, new ResponseDefinition());
 
-    private Mockery context;
+    private JUnit5Mockery context = new JUnit5Mockery();
     private Admin mockAdmin;
 
     private Request mockRequest;
@@ -46,7 +46,6 @@ public class RemoveStubMappingTaskTest {
     @Before
     public void setUp() {
 
-        context = new Mockery();
         mockAdmin = context.mock(Admin.class);
         mockRequest = context.mock(Request.class);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/SaveMappingsTaskTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/SaveMappingsTaskTest.java
@@ -21,20 +21,19 @@ import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JMock;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.net.HttpURLConnection;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
-@RunWith(JMock.class)
 public class SaveMappingsTaskTest {
-    private Mockery context;
+
+    private JUnit5Mockery context = new JUnit5Mockery();
     private Admin mockAdmin;
     private Request mockRequest;
 
@@ -42,7 +41,6 @@ public class SaveMappingsTaskTest {
 
     @Before
     public void setUp() {
-        context = new Mockery();
         mockAdmin = context.mock(Admin.class);
         mockRequest = context.mock(Request.class);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/http/AdminRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/AdminRequestHandlerTest.java
@@ -19,30 +19,23 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.apache.http.entity.StringEntity;
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.UnsupportedEncodingException;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class AdminRequestHandlerTest {
-    private Mockery context;
+
     private WireMockServer wm;
     private WireMockTestClient client;
 
-    @Before
-    public void init() {
-        context = new Mockery();
-    }
-
-    @After
+    @AfterEach
     public void cleanup() {
         if (wm != null) {
             wm.stop();
@@ -51,7 +44,7 @@ public class AdminRequestHandlerTest {
 
     @Test
     public void shouldLogInfoOnRequest() throws UnsupportedEncodingException {
-        final Notifier notifier = context.mock(Notifier.class);
+        final Notifier notifier = mock(Notifier.class);
         wm = new WireMockServer(options().dynamicPort().notifier(notifier));
         wm.start();
         client = new WireMockTestClient(wm.port());
@@ -73,16 +66,13 @@ public class AdminRequestHandlerTest {
                 "    }\n" +
                 "}";
 
-        context.checking(new Expectations() {{
-            one(notifier).info(with(allOf(
-                    containsString("Admin request received:\n127.0.0.1 - POST /mappings\n"),
-                    containsString(postHeaderABCName + ": [" + postHeaderABCValue + "]\n"),
-                    containsString(postBody))));
-        }});
 
         client.post("/__admin/mappings", new StringEntity(postBody),
                 withHeader(postHeaderABCName, postHeaderABCValue));
 
-        context.assertIsSatisfied();
+        verify(notifier).info(contains("Admin request received:\n127.0.0.1 - POST /mappings\n"));
+        verify(notifier).info(contains(postHeaderABCName + ": [" + postHeaderABCValue + "]\n"));
+        verify(notifier).info(contains(postBody));
     }
+
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
@@ -18,29 +18,21 @@ package com.github.tomakehurst.wiremock.http;
 import com.github.tomakehurst.wiremock.common.Strings;
 import com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder;
 import com.google.common.base.Optional;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JMock;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.jmock.junit5.JUnit5Mockery;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@RunWith(JMock.class)
 public class ContentTypeHeaderTest {
 	
-	private Mockery context;
-	
-	@Before
-	public void init() {
-		context = new Mockery();
-	}
+	private JUnit5Mockery context = new JUnit5Mockery();
 
 	@Test
 	public void returnsMimeTypeAndCharsetWhenBothPresent() {
@@ -89,13 +81,11 @@ public class ContentTypeHeaderTest {
 		assertThat(contentTypeHeader.mimeTypePart(), is("text/xml"));
 	}
 
-	@Test(expected=NullPointerException.class)
+	@Test
 	public void throwsExceptionOnAttemptToSetNullHeaderValue() {
-		Request request = new MockRequestBuilder(context)
-			.withHeader("Content-Type", null)
-			.build();
-	
-        request.contentTypeHeader();
+		assertThrows(NullPointerException.class, ()-> new MockRequestBuilder(context)
+				.withHeader("Content-Type", null)
+				.build());
 	}
 	
 	@Test

--- a/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
@@ -15,42 +15,33 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
 import com.github.tomakehurst.wiremock.global.GlobalSettingsHolder;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JMock;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
-@RunWith(JMock.class)
 public class StubResponseRendererTest {
     private static final int TEST_TIMEOUT = 500;
 
-    private Mockery context;
-    private FileSource fileSource;
     private GlobalSettingsHolder globalSettingsHolder;
     private List<ResponseTransformer> responseTransformers;
     private StubResponseRenderer stubResponseRenderer;
 
     @Before
     public void init() {
-        context = new Mockery();
-        fileSource = context.mock(FileSource.class);
         globalSettingsHolder = new GlobalSettingsHolder();
         responseTransformers = new ArrayList<>();
-        stubResponseRenderer = new StubResponseRenderer(fileSource, globalSettingsHolder, null, responseTransformers);
+        stubResponseRenderer = new StubResponseRenderer(null, globalSettingsHolder, null, responseTransformers);
     }
 
     @Test(timeout = TEST_TIMEOUT)

--- a/src/test/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServerTest.java
@@ -28,38 +28,33 @@ import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.github.tomakehurst.wiremock.security.NoAuthenticator;
 import com.github.tomakehurst.wiremock.verification.RequestJournal;
 import org.eclipse.jetty.server.ServerConnector;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JMock;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 
-@RunWith(JMock.class)
 public class JettyHttpServerTest {
 
-    private Mockery context;
     private AdminRequestHandler adminRequestHandler;
     private StubRequestHandler stubRequestHandler;
     private JettyHttpServerFactory serverFactory = new JettyHttpServerFactory();
 
     @Before
     public void init() {
-        context = new Mockery();
-        Admin admin = context.mock(Admin.class);
+        Admin admin = mock(Admin.class);
 
         adminRequestHandler = new AdminRequestHandler(AdminRoutes.defaults(), admin, new BasicResponseRenderer(), new NoAuthenticator(), false, Collections.<RequestFilter>emptyList());
-        stubRequestHandler = new StubRequestHandler(context.mock(StubServer.class),
-                context.mock(ResponseRenderer.class),
+        stubRequestHandler = new StubRequestHandler(mock(StubServer.class),
+                mock(ResponseRenderer.class),
                 admin,
                 Collections.<String, PostServeAction>emptyMap(),
-                context.mock(RequestJournal.class),
+                mock(RequestJournal.class),
                 Collections.<RequestFilter>emptyList(),
                 false
         );

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionFailOnUnmatchedTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionFailOnUnmatchedTest.java
@@ -21,7 +21,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jmock.Expectations;
-import org.jmock.Mockery;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JUnitJupiterExtensionFailOnUnmatchedTest {
 
-    Mockery context;
+    JUnit5Mockery context = new JUnit5Mockery();
     CloseableHttpClient client;
     ExtensionContext extensionContext;
 
@@ -45,7 +45,6 @@ public class JUnitJupiterExtensionFailOnUnmatchedTest {
     void init() {
         client = HttpClientFactory.createClient();
 
-        context = new Mockery();
         extensionContext = context.mock(ExtensionContext.class);
         context.checking(new Expectations() {{
             oneOf(extensionContext).getElement(); will(returnValue(Optional.empty()));

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -24,7 +24,7 @@ import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
 import com.google.common.collect.ImmutableSet;
 import org.hamcrest.Matchers;
 import org.jmock.Expectations;
-import org.jmock.Mockery;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -45,14 +45,13 @@ import static org.xmlunit.diff.ComparisonType.*;
 
 public class EqualToXmlPatternTest {
 
-    private Mockery context;
+    private JUnit5Mockery context = new JUnit5Mockery();
 
     @Rule
     public WireMockRule wm = new WireMockRule(options().dynamicPort());
 
     @Before
     public void init() {
-        context = new Mockery();
         LocalNotifier.set(new ConsoleNotifier(true));
 
         // We assert English XML parser error messages in this test. So we set our default locale to English to make
@@ -306,7 +305,7 @@ public class EqualToXmlPatternTest {
     private void expectInfoNotification(final String message) {
         final Notifier notifier = context.mock(Notifier.class);
         context.checking(new Expectations() {{
-            one(notifier).info(with(containsString(message)));
+            oneOf(notifier).info(with(containsString(message)));
         }});
         LocalNotifier.set(notifier);
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
@@ -22,28 +22,27 @@ import com.github.tomakehurst.wiremock.common.LocalNotifier;
 import com.github.tomakehurst.wiremock.common.Notifier;
 import org.hamcrest.Matchers;
 import org.jmock.Expectations;
-import org.jmock.Mockery;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToDateTime;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalToJson;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class MatchesJsonPathPatternTest {
 
-    private Mockery context;
-
-    @Before
-    public void init() {
-        context = new Mockery();
-    }
+    private JUnit5Mockery context = new JUnit5Mockery();
 
     @Test
     public void matchesABasicJsonPathWhenTheExpectedElementIsPresent() {
@@ -430,7 +429,7 @@ public class MatchesJsonPathPatternTest {
     private void expectInfoNotification(final String message) {
         final Notifier notifier = context.mock(Notifier.class);
         context.checking(new Expectations() {{
-            one(notifier).info(message);
+            oneOf(notifier).info(message);
         }});
         LocalNotifier.set(notifier);
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractorTest.java
@@ -19,26 +19,22 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JMock;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
-@RunWith(JMock.class)
 public class SnapshotStubMappingBodyExtractorTest {
     private FileSource filesSource;
     private SnapshotStubMappingBodyExtractor bodyExtractor;
-    private Mockery context;
+    private JUnit5Mockery context = new JUnit5Mockery();
 
     @Before
     public void init() {
-        context = new Mockery();
         filesSource = context.mock(FileSource.class, "filesFileSource");
         bodyExtractor = new SnapshotStubMappingBodyExtractor(filesSource);
     }
@@ -50,7 +46,7 @@ public class SnapshotStubMappingBodyExtractorTest {
             .build();
         context.checking(new Expectations() {{
             // ignore arguments because this test is only for checking stub mapping changes
-            one(filesSource).writeBinaryFile(with(any(String.class)), with(any(byte[].class)));
+            oneOf(filesSource).writeBinaryFile(with(any(String.class)), with(any(byte[].class)));
         }});
         bodyExtractor.extractInPlace(stubMapping);
         assertThat(stubMapping.getResponse().getBodyFileName(), is("foo-" + stubMapping.getId() + ".txt"));
@@ -97,7 +93,7 @@ public class SnapshotStubMappingBodyExtractorTest {
 
     private void setFileExpectations(final String filename, final String body) {
         context.checking(new Expectations() {{
-            one(filesSource).writeBinaryFile(
+            oneOf(filesSource).writeBinaryFile(
                 with(equal(filename)),
                 with(equal(body.getBytes()))
             );

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGeneratorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGeneratorTest.java
@@ -24,13 +24,13 @@ import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import org.jmock.Mockery;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.Test;
 
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern;
 import static com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder.aRequest;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class SnapshotStubMappingGeneratorTest {
     @Test
@@ -71,7 +71,7 @@ public class SnapshotStubMappingGeneratorTest {
     private static ServeEvent serveEvent() {
         return new ServeEvent(
             null,
-            LoggedRequest.createFrom(aRequest(new Mockery()).build()),
+            LoggedRequest.createFrom(aRequest(new JUnit5Mockery()).build()),
             null,
             null,
             LoggedResponse.from(Response.notConfigured()),

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
@@ -19,17 +19,18 @@ import com.github.tomakehurst.wiremock.admin.AdminRoutes;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.requestfilter.RequestFilter;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
-import com.github.tomakehurst.wiremock.http.*;
+import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
+import com.github.tomakehurst.wiremock.http.BasicResponseRenderer;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.Response;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.security.NoAuthenticator;
 import com.github.tomakehurst.wiremock.testsupport.MockHttpResponder;
 import com.github.tomakehurst.wiremock.verification.VerificationResult;
 import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JMock;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.Collections;
 
@@ -40,12 +41,11 @@ import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.new
 import static com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder.aRequest;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalToJson;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
-@RunWith(JMock.class)
 public class AdminRequestHandlerTest {
-	private Mockery context;
+	private JUnit5Mockery context = new JUnit5Mockery();
 	private Admin admin;
     private MockHttpResponder httpResponder;
 
@@ -53,7 +53,6 @@ public class AdminRequestHandlerTest {
 
 	@Before
 	public void init() {
-		context = new Mockery();
         admin = context.mock(Admin.class);
         httpResponder = new MockHttpResponder();
 
@@ -69,7 +68,7 @@ public class AdminRequestHandlerTest {
                 .build();
 
         context.checking(new Expectations() {{
-            one(admin).saveMappings();
+            oneOf(admin).saveMappings();
         }});
 
         handler.handle(request, httpResponder);
@@ -86,7 +85,7 @@ public class AdminRequestHandlerTest {
 			.build();
 		
 		context.checking(new Expectations() {{
-			one(admin).resetAll();
+			oneOf(admin).resetAll();
 		}});
 
         handler.handle(request, httpResponder);
@@ -103,7 +102,7 @@ public class AdminRequestHandlerTest {
 				.build();
 
 		context.checking(new Expectations() {{
-			one(admin).resetRequests();
+			oneOf(admin).resetRequests();
 		}});
 
         handler.handle(request, httpResponder);

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryMappingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryMappingsTest.java
@@ -16,15 +16,12 @@
 package com.github.tomakehurst.wiremock.stubbing;
 
 import com.github.tomakehurst.wiremock.common.LocalNotifier;
-import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JMock;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
@@ -35,22 +32,17 @@ import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.new
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder.aRequest;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
-@RunWith(JMock.class)
 public class InMemoryMappingsTest {
 
     private InMemoryStubMappings mappings;
-    private Mockery context;
-    private Notifier notifier;
+    private JUnit5Mockery context = new JUnit5Mockery();
 
     @Before
     public void init() {
         mappings = new InMemoryStubMappings();
-        context = new Mockery();
-
-        notifier = context.mock(Notifier.class);
     }
 
     @After

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -24,16 +24,11 @@ import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder;
 import com.github.tomakehurst.wiremock.verification.VerificationResult;
 import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JMock;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.*;
 
 import static com.github.tomakehurst.wiremock.common.Gzip.gzip;
@@ -49,7 +44,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.skyscreamer.jsonassert.JSONCompareMode.STRICT_ORDER;
 
-@RunWith(JMock.class)
 public class StubMappingJsonRecorderTest {
 
 	private StubMappingJsonRecorder listener;
@@ -57,11 +51,10 @@ public class StubMappingJsonRecorderTest {
 	private FileSource filesFileSource;
     private Admin admin;
 
-	private Mockery context;
+	private JUnit5Mockery context = new JUnit5Mockery();
 
 	@Before
 	public void init() {
-		context = new Mockery();
 		mappingsFileSource = context.mock(FileSource.class, "mappingsFileSource");
 		filesFileSource = context.mock(FileSource.class, "filesFileSource");
         admin = context.mock(Admin.class);
@@ -90,9 +83,9 @@ public class StubMappingJsonRecorderTest {
 	public void writesMappingFileAndCorrespondingBodyFileOnRequest() {
 		context.checking(new Expectations() {{
 		    allowing(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(0)));
-			one(mappingsFileSource).writeTextFile(with(equal("mapping-recorded-content-1$2!3.json")),
+			oneOf(mappingsFileSource).writeTextFile(with(equal("mapping-recorded-content-1$2!3.json")),
 					with(equalToJson(SAMPLE_REQUEST_MAPPING, STRICT_ORDER)));
-			one(filesFileSource).writeBinaryFile(with(equal("body-recorded-content-1$2!3.txt")),
+			oneOf(filesFileSource).writeBinaryFile(with(equal("body-recorded-content-1$2!3.txt")),
                     with(equal("Recorded body content".getBytes(UTF_8))));
 		}});
 
@@ -130,9 +123,9 @@ public class StubMappingJsonRecorderTest {
 	public void addsResponseHeaders() {
 	    context.checking(new Expectations() {{
 	        allowing(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(0)));
-            one(mappingsFileSource).writeTextFile(with(equal("mapping-headered-content-1$2!3.json")),
+            oneOf(mappingsFileSource).writeTextFile(with(equal("mapping-headered-content-1$2!3.json")),
                     with(equalToJson(SAMPLE_REQUEST_MAPPING_WITH_HEADERS, STRICT_ORDER)));
-            one(filesFileSource).writeBinaryFile("body-headered-content-1$2!3.txt", "Recorded body content".getBytes(UTF_8));
+            oneOf(filesFileSource).writeBinaryFile("body-headered-content-1$2!3.txt", "Recorded body content".getBytes(UTF_8));
         }});
 
         Request request = new MockRequestBuilder(context)
@@ -206,7 +199,7 @@ public class StubMappingJsonRecorderTest {
     public void includesBodyInRequestPatternIfInRequest() {
         context.checking(new Expectations() {{
             allowing(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(0)));
-            one(mappingsFileSource).writeTextFile(
+            oneOf(mappingsFileSource).writeTextFile(
                     with(any(String.class)),
                     with(equalToJson(SAMPLE_REQUEST_MAPPING_WITH_BODY, STRICT_ORDER)));
             ignoring(filesFileSource);
@@ -263,10 +256,10 @@ public class StubMappingJsonRecorderTest {
 
         context.checking(new Expectations() {{
             allowing(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(0)));
-            one(mappingsFileSource).writeTextFile(
+            oneOf(mappingsFileSource).writeTextFile(
                     with(any(String.class)),
                     with(equalToJson(SAMPLE_REQUEST_MAPPING_WITH_REQUEST_HEADERS_1, STRICT_ORDER)));
-            one(mappingsFileSource).writeTextFile(
+            oneOf(mappingsFileSource).writeTextFile(
                     with(any(String.class)),
                     with(equalToJson(SAMPLE_REQUEST_MAPPING_WITH_REQUEST_HEADERS_2, STRICT_ORDER)));
             ignoring(filesFileSource);
@@ -311,7 +304,7 @@ public class StubMappingJsonRecorderTest {
     public void matchesBodyOnEqualToJsonIfJsonInRequestContentTypeHeader() {
         context.checking(new Expectations() {{
             allowing(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(0)));
-            one(mappingsFileSource).writeTextFile(
+            oneOf(mappingsFileSource).writeTextFile(
                     with(any(String.class)),
                     with(equalToJson(SAMPLE_REQUEST_MAPPING_WITH_JSON_BODY, STRICT_ORDER)));
             ignoring(filesFileSource);
@@ -347,7 +340,7 @@ public class StubMappingJsonRecorderTest {
     public void matchesBodyOnEqualToXmlIfXmlInRequestContentTypeHeader() {
         context.checking(new Expectations() {{
             allowing(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(0)));
-            one(mappingsFileSource).writeTextFile(
+            oneOf(mappingsFileSource).writeTextFile(
                     with(any(String.class)),
                     with(equalToJson(SAMPLE_REQUEST_MAPPING_WITH_XML_BODY, STRICT_ORDER)));
             ignoring(filesFileSource);
@@ -383,9 +376,9 @@ public class StubMappingJsonRecorderTest {
         context.checking(new Expectations() {{
             allowing(admin).countRequestsMatching(with(any(RequestPattern.class)));
             will(returnValue(VerificationResult.withCount(0)));
-            one(mappingsFileSource).writeTextFile(with(equal("mapping-gzipped-content-1$2!3.json")),
+            oneOf(mappingsFileSource).writeTextFile(with(equal("mapping-gzipped-content-1$2!3.json")),
                     with(equalToJson(GZIP_REQUEST_MAPPING)));
-            one(filesFileSource).writeBinaryFile(with(equal("body-gzipped-content-1$2!3.txt")),
+            oneOf(filesFileSource).writeBinaryFile(with(equal("body-gzipped-content-1$2!3.txt")),
                     with(equal("Recorded body content".getBytes(UTF_8))));
         }});
 
@@ -460,7 +453,7 @@ public class StubMappingJsonRecorderTest {
         context.checking(new Expectations() {{
             allowing(admin).countRequestsMatching(with(any(RequestPattern.class)));
             will(returnValue(VerificationResult.withCount(0)));
-            one(mappingsFileSource).writeTextFile(
+            oneOf(mappingsFileSource).writeTextFile(
                     with("mapping-multipart-content-1$2!3.json"),
                     with(equalToJson(MULTIPART_REQUEST_MAPPING, STRICT_ORDER)));
             ignoring(filesFileSource);
@@ -524,7 +517,7 @@ public class StubMappingJsonRecorderTest {
             allowing(mappingsFileSource).writeTextFile(
                 with(Expectations.<String>anything()),
                 with(Expectations.<String>anything()));
-            one(filesFileSource).writeBinaryFile(
+            oneOf(filesFileSource).writeBinaryFile(
                 with(containsString("body-my_oddly__named_file-url")),
                 with(any(byte[].class)));
         }});
@@ -554,7 +547,7 @@ public class StubMappingJsonRecorderTest {
             allowing(mappingsFileSource).writeTextFile(
                 with(Expectations.<String>anything()),
                 with(Expectations.<String>anything()));
-            one(filesFileSource).writeBinaryFile(
+            oneOf(filesFileSource).writeBinaryFile(
                 with(endsWith("." + expectedExension)),
                 with(any(byte[].class)));
         }});

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubRequestHandlerTest.java
@@ -30,11 +30,9 @@ import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.github.tomakehurst.wiremock.verification.RequestJournal;
 import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JMock;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.Collections;
 
@@ -43,13 +41,12 @@ import static com.github.tomakehurst.wiremock.http.Response.response;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder.aRequest;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
-@RunWith(JMock.class)
 public class StubRequestHandlerTest {
 
-	private Mockery context;
+	private JUnit5Mockery context = new JUnit5Mockery();
 	private StubServer stubServer;
 	private ResponseRenderer responseRenderer;
 	private MockHttpResponder httpResponder;
@@ -60,7 +57,6 @@ public class StubRequestHandlerTest {
 
 	@Before
 	public void init() {
-		context = new Mockery();
         stubServer = context.mock(StubServer.class);
 		responseRenderer = context.mock(ResponseRenderer.class);
 		httpResponder = new MockHttpResponder();
@@ -105,7 +101,7 @@ public class StubRequestHandlerTest {
 		context.checking(new Expectations() {{
 			allowing(stubServer).serveStubFor(request); will(returnValue(
                 ServeEvent.of(LoggedRequest.createFrom(request), ResponseDefinition.notConfigured())));
-			one(listener).requestReceived(with(equal(request)), with(any(Response.class)));
+			oneOf(listener).requestReceived(with(equal(request)), with(any(Response.class)));
             allowing(responseRenderer).render(with(any(ServeEvent.class)));
                 will(returnValue(new Response.Builder().build()));
 		}});

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
@@ -15,12 +15,18 @@
  */
 package com.github.tomakehurst.wiremock.testsupport;
 
-import com.github.tomakehurst.wiremock.http.*;
-import java.util.Collection;
+import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
+import com.github.tomakehurst.wiremock.http.Cookie;
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
+import com.github.tomakehurst.wiremock.http.QueryParameter;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
 import org.jmock.Expectations;
-import org.jmock.Mockery;
+import org.jmock.junit5.JUnit5Mockery;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -32,7 +38,7 @@ import static com.google.common.collect.Sets.newLinkedHashSet;
 
 public class MockRequestBuilder {
 
-	private final Mockery context;
+	private JUnit5Mockery context;
 	private String url = "/";
 	private RequestMethod method = GET;
 	private String clientIp = "x.x.x.x";
@@ -46,20 +52,20 @@ public class MockRequestBuilder {
 	private boolean browserProxyRequest = false;
 	private String mockName;
 
-	public MockRequestBuilder(Mockery context) {
+	public MockRequestBuilder(JUnit5Mockery context) {
 		this.context = context;
 	}
 
-	public MockRequestBuilder(Mockery context, String mockName) {
+	public MockRequestBuilder(JUnit5Mockery context, String mockName) {
 		this.mockName = mockName;
 		this.context = context;
 	}
 
-	public static MockRequestBuilder aRequest(Mockery context) {
+	public static MockRequestBuilder aRequest(JUnit5Mockery context) {
 		return new MockRequestBuilder(context);
 	}
 
-	public static MockRequestBuilder aRequest(Mockery context, String mockName) {
+	public static MockRequestBuilder aRequest(JUnit5Mockery context, String mockName) {
 		return new MockRequestBuilder(context, mockName);
 	}
 

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/InMemoryRequestJournalTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/InMemoryRequestJournalTest.java
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.verification;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.google.common.base.Optional;
 import org.jmock.Mockery;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,8 +27,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.matching.RequestPattern.everything;
 import static com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder.aRequest;
 import static com.github.tomakehurst.wiremock.verification.LoggedRequest.createFrom;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class InMemoryRequestJournalTest {
 
@@ -35,7 +36,7 @@ public class InMemoryRequestJournalTest {
 
     @Before
     public void createTestRequests() {
-        Mockery context = new Mockery();
+        JUnit5Mockery context = new JUnit5Mockery();
         serveEvent1 = ServeEvent.of(createFrom(aRequest(context, "log1").withUrl("/logging1").build()), null);
         serveEvent2 = ServeEvent.of(createFrom(aRequest(context, "log2").withUrl("/logging2").build()), null);
         serveEvent3 = ServeEvent.of(createFrom(aRequest(context, "log3").withUrl("/logging3").build()), null);
@@ -55,7 +56,7 @@ public class InMemoryRequestJournalTest {
 
     @Test
     public void resettingTheJournalClearsAllEntries() throws Exception {
-        Mockery context = new Mockery();
+        JUnit5Mockery context = new JUnit5Mockery();
         LoggedRequest loggedRequest = createFrom(aRequest(context)
                 .withUrl("/for/logging")
                 .build());

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
@@ -18,16 +18,13 @@ package com.github.tomakehurst.wiremock.verification;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.common.Dates;
 import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.http.Cookie;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-
-import com.github.tomakehurst.wiremock.http.Cookie;
 import com.google.common.collect.ImmutableMap;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JMock;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
@@ -42,19 +39,20 @@ import static com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder.aRe
 import static com.github.tomakehurst.wiremock.verification.LoggedRequest.createFrom;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
-@RunWith(JMock.class)
 public class LoggedRequestTest {
 
     public static final String REQUEST_BODY = "some text 形声字形聲字";
     public static final String REQUEST_BODY_AS_BASE64 = "c29tZSB0ZXh0IOW9ouWjsOWtl+W9ouiBsuWtlw==";
 
-    private Mockery context;
+    private JUnit5Mockery context = new JUnit5Mockery();
 
     @Before
     public void init() {
-        context = new Mockery();
         System.out.println(TimeZone.getDefault());
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/NearMissCalculatorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/NearMissCalculatorTest.java
@@ -24,7 +24,7 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.stubbing.StubMappings;
 import com.google.common.base.Function;
 import org.jmock.Expectations;
-import org.jmock.Mockery;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,15 +34,14 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.*;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern;
-import static com.github.tomakehurst.wiremock.matching.WeightedMatchResult.weight;
 import static com.github.tomakehurst.wiremock.verification.NearMissCalculator.NEAR_MISS_COUNT;
 import static com.google.common.collect.FluentIterable.from;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class NearMissCalculatorTest {
 
-    private Mockery context;
+    private JUnit5Mockery context = new JUnit5Mockery();
 
     NearMissCalculator nearMissCalculator;
 
@@ -52,7 +51,6 @@ public class NearMissCalculatorTest {
 
     @Before
     public void init() {
-        context = new Mockery();
 
         stubMappings = context.mock(StubMappings.class);
         requestJournal = context.mock(RequestJournal.class);


### PR DESCRIPTION
As mentioned in https://github.com/wiremock/wiremock/pull/1616#issuecomment-932739854, the use of such an old version of JMock blocks adoption of JUnit5.
In addition [it seems JMock only rarely does new releases](https://github.com/jmock-developers/jmock-library/issues/228), even when there are critical fixes.
Taken together these two plead for both updating to the latest currently available version, as well as reducing the dependency on JMock.

`MockRequestBuilder` and the Expectation checking it does is the biggest hurdle in dropping JMock completely already.