### PR TITLE
Delegate WireMockExtension.url(String) to WireMockServer

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -26,8 +26,6 @@ import org.junit.platform.commons.support.AnnotationSupport;
 
 import java.util.Optional;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 public class WireMockExtension extends DslWrapper implements ParameterResolver, BeforeEachCallback, BeforeAllCallback, AfterEachCallback, AfterAllCallback {
 
     private static final Options DEFAULT_OPTIONS = WireMockConfiguration.options().dynamicPort();
@@ -178,6 +176,10 @@ public class WireMockExtension extends DslWrapper implements ParameterResolver, 
 
     public String baseUrl() {
         return wireMockServer.baseUrl();
+    }
+    
+    public String url(String path) {
+        return wireMockServer.url(path);
     }
 
     public static class Builder {

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionFailOnUnmatchedTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionFailOnUnmatchedTest.java
@@ -62,7 +62,7 @@ public class JUnitJupiterExtensionFailOnUnmatchedTest {
 
         extension.stubFor(get("/found").willReturn(ok()));
 
-        try (CloseableHttpResponse response = client.execute(new HttpGet(extension.baseUrl() + "/not-found"))) {
+        try (CloseableHttpResponse response = client.execute(new HttpGet(extension.url("/not-found")))) {
             assertThat(response.getStatusLine().getStatusCode(), is(404));
         }
 
@@ -79,7 +79,7 @@ public class JUnitJupiterExtensionFailOnUnmatchedTest {
 
         extension.stubFor(get("/found").willReturn(ok()));
 
-        try (CloseableHttpResponse response = client.execute(new HttpGet(extension.baseUrl() + "/not-found"))) {
+        try (CloseableHttpResponse response = client.execute(new HttpGet(extension.url("/not-found")))) {
             assertThat(response.getStatusLine().getStatusCode(), is(404));
         }
 


### PR DESCRIPTION
(Final unsolicited MR, I promise :heart: )

In migrating both my own projects and [all project tests](https://github.com/wiremock/wiremock/pull/1616), I found that for [programmatic use](http://wiremock.org/docs/junit-jupiter/) there's a frequent need to compose URLs to instances of `WireMockExtension`. Since `WireMockExtension` does not expose the underlying `WireMockServer`, one is then forced to compose URLs by calling `baseUrl()` and appending/formatting the suffix. For such a common use case I think there's value in creating a direct delegate method to do the same.

As seen in `JUnitJupiterExtensionFailOnUnmatchedTest` this simplifies the URL composition, and reduces the need for `baseUrl()`. I understand it's not desirable to have delegates to all methods in `WireMockServer`, but for such a common use case I think it's warranted to make the development experience easier.

If you feel any different no problem to close the MR; I figured it's easier to get across the point in an MR rather than starting a separate issue for the discussion first.

