### PR TITLE
Return an Bad Request when invalid `since` parameter is provided

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/admin/Conversions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/Conversions.java
@@ -16,6 +16,8 @@
 package com.github.tomakehurst.wiremock.admin;
 
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+import com.github.tomakehurst.wiremock.common.Errors;
+import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
 
 import java.text.ParseException;
@@ -35,7 +37,7 @@ public class Conversions {
                 new ISO8601DateFormat().parse(parameter.firstValue()) :
                 null;
         } catch (ParseException e) {
-            throw new IllegalArgumentException(parameter.firstValue() + " is not a valid ISO8601 date");
+            throw new InvalidInputException(Errors.validation(parameter.key(), parameter.firstValue() + " is not a valid ISO8601 date"));
         }
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/LimitAndSinceDatePaginator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/LimitAndSinceDatePaginator.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.admin;
 
+import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.google.common.base.Predicate;

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/GetAllRequestsTask.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/GetAllRequestsTask.java
@@ -19,12 +19,15 @@ import com.github.tomakehurst.wiremock.admin.AdminTask;
 import com.github.tomakehurst.wiremock.admin.LimitAndSinceDatePaginator;
 import com.github.tomakehurst.wiremock.admin.model.GetServeEventsResult;
 import com.github.tomakehurst.wiremock.admin.model.PathParams;
+import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 
+import static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.jsonResponse;
 import static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.responseDefinition;
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 public class GetAllRequestsTask implements AdminTask {
@@ -32,12 +35,18 @@ public class GetAllRequestsTask implements AdminTask {
     @Override
     public ResponseDefinition execute(Admin admin, Request request, PathParams pathParams) {
         GetServeEventsResult serveEventsResult = admin.getServeEvents();
-        GetServeEventsResult result = new GetServeEventsResult(
-            LimitAndSinceDatePaginator.fromRequest(
-                serveEventsResult.getRequests(),
-                request
-            ),
-            serveEventsResult.isRequestJournalDisabled()
+        LimitAndSinceDatePaginator paginator;
+        try {
+             paginator = LimitAndSinceDatePaginator.fromRequest(
+                    serveEventsResult.getRequests(),
+                    request
+            );
+        } catch (InvalidInputException e) {
+            return jsonResponse(e.getErrors(), HTTP_BAD_REQUEST);
+        }
+
+        GetServeEventsResult result = new GetServeEventsResult(paginator,
+                serveEventsResult.isRequestJournalDisabled()
         );
 
         return responseDefinition()

--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -249,6 +249,19 @@ public class AdminApiTest extends AcceptanceTestBase {
     }
 
     @Test
+    public void getLoggedRequestsWithInvalidSinceDateReturnsBadRequest() throws Exception {
+        WireMockResponse response = testClient.get("/__admin/requests?since=foo");
+
+        assertThat(response.statusCode(), is(400));
+        assertThat(response.firstHeader("Content-Type"), is("application/json"));
+        JsonVerifiable check = JsonAssertion.assertThat(response.content());
+        JsonVerifiable error = check.field("errors").elementWithIndex(0);
+        error.field("code").isEqualTo(10);
+        error.field("source").field("pointer").isEqualTo("since");
+        error.field("title").isEqualTo("foo is not a valid ISO8601 date");
+    }
+
+    @Test
     public void getLoggedRequestsWithLimitLargerThanResults() throws Exception {
         for (int i = 1; i <= 3; i++) {
             testClient.get("/received-request/" + i);

--- a/src/test/resources/frozen/do-not-use-junit4
+++ b/src/test/resources/frozen/do-not-use-junit4
@@ -84,6 +84,8 @@ Method <com.github.tomakehurst.wiremock.AdminApiTest.getLoggedRequestById()> has
 Method <com.github.tomakehurst.wiremock.AdminApiTest.getLoggedRequestById()> is annotated with <org.junit.Test> in (AdminApiTest.java:0)
 Method <com.github.tomakehurst.wiremock.AdminApiTest.getLoggedRequests()> has annotation member of type <org.junit.Test$None> in (AdminApiTest.java:0)
 Method <com.github.tomakehurst.wiremock.AdminApiTest.getLoggedRequests()> is annotated with <org.junit.Test> in (AdminApiTest.java:0)
+Method <com.github.tomakehurst.wiremock.AdminApiTest.getLoggedRequestsWithInvalidSinceDateReturnsBadRequest()> has annotation member of type <org.junit.Test$None> in (AdminApiTest.java:0)
+Method <com.github.tomakehurst.wiremock.AdminApiTest.getLoggedRequestsWithInvalidSinceDateReturnsBadRequest()> is annotated with <org.junit.Test> in (AdminApiTest.java:0)
 Method <com.github.tomakehurst.wiremock.AdminApiTest.getLoggedRequestsWithLimit()> has annotation member of type <org.junit.Test$None> in (AdminApiTest.java:0)
 Method <com.github.tomakehurst.wiremock.AdminApiTest.getLoggedRequestsWithLimit()> is annotated with <org.junit.Test> in (AdminApiTest.java:0)
 Method <com.github.tomakehurst.wiremock.AdminApiTest.getLoggedRequestsWithLimitAndSinceDate()> has annotation member of type <org.junit.Test$None> in (AdminApiTest.java:0)


### PR DESCRIPTION
As noted in #1595, we currently cause an Internal Server Error when an
invalid date is provided to the admin `/requests` API.

Instead of using the runtime exception `IllegalArgumentException`, which
is less nice to try-catch, we can use a checked exception
`ValidationException` which can then be mapped to a
`ValidationErrorResult` that can be serialised and returned to the
caller as a Bad Request.

Closes #1595.
