### PR TITLE
Extract a HttpClient4Factory for tests ahead of the Apache HttpClient 5 migration

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/BindAddressTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/BindAddressTest.java
@@ -30,7 +30,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 
 import com.github.tomakehurst.wiremock.common.HttpClientUtils;
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.RequestBuilder;
@@ -47,7 +47,7 @@ public class BindAddressTest {
     private String nonBindAddress;
     private WireMockServer wireMockServer;
 
-    final HttpClient client = HttpClientFactory.createClient();
+    final HttpClient client = HttpClient4Factory.createClient();
 
     @Before
     public void prepare() throws Exception {

--- a/src/test/java/com/github/tomakehurst/wiremock/Http2AcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/Http2AcceptanceTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock;
 
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -65,7 +65,7 @@ public class Http2AcceptanceTest {
 
     @Test
     public void supportsHttp1_1Connections() throws Exception {
-        CloseableHttpClient client = HttpClientFactory.createClient();
+        CloseableHttpClient client = HttpClient4Factory.createClient();
 
         wm.stubFor(get("/thing").willReturn(ok("HTTP/1.1 response")));
 

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpsAcceptanceTest.java
@@ -20,7 +20,7 @@ import com.github.tomakehurst.wiremock.common.FatalStartupException;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.http.Fault;
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import com.google.common.io.Resources;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.http.HttpResponse;
@@ -103,7 +103,7 @@ public class HttpsAcceptanceTest {
         wireMockServer = new WireMockServer(config);
         wireMockServer.start();
         WireMock.configureFor("https", "localhost", wireMockServer.httpsPort());
-        httpClient = HttpClientFactory.createClient();
+        httpClient = HttpClient4Factory.createClient();
 
         stubFor(get(urlEqualTo("/https-test")).willReturn(aResponse().withStatus(200).withBody("HTTPS content")));
 
@@ -323,7 +323,7 @@ public class HttpsAcceptanceTest {
         wireMockServer.start();
         WireMock.configureFor("https", "localhost", wireMockServer.httpsPort());
 
-        httpClient = HttpClientFactory.createClient();
+        httpClient = HttpClient4Factory.createClient();
     }
 
     private void startServerWithKeystore(String keystorePath, String keystorePassword, String keyManagerPassword) {
@@ -338,7 +338,7 @@ public class HttpsAcceptanceTest {
         wireMockServer.start();
         WireMock.configureFor(wireMockServer.port());
 
-        httpClient = HttpClientFactory.createClient();
+        httpClient = HttpClient4Factory.createClient();
     }
 
     private void startServerWithKeystore(String keystorePath) {

--- a/src/test/java/com/github/tomakehurst/wiremock/JvmProxyConfigAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/JvmProxyConfigAcceptanceTest.java
@@ -1,6 +1,6 @@
 package com.github.tomakehurst.wiremock;
 
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import com.github.tomakehurst.wiremock.http.JvmProxyConfigurer;
 import com.google.common.io.ByteStreams;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -47,7 +47,7 @@ public class JvmProxyConfigAcceptanceTest {
 
     @Test
     public void configuresHttpsProxyingOnlyFromAWireMockServer() throws Exception {
-        CloseableHttpClient httpClient = HttpClientFactory.createClient();
+        CloseableHttpClient httpClient = HttpClient4Factory.createClient();
 
         wireMockServer = new WireMockServer(wireMockConfig().dynamicPort().enableBrowserProxying(true));
         wireMockServer.start();

--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock;
 
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -37,7 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
 
-    HttpClient httpClient = HttpClientFactory.createClient();
+    HttpClient httpClient = HttpClient4Factory.createClient();
 
     @Test
     public void acceptsAMultipartRequestContainingATextAndAFilePart() throws Exception {

--- a/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
@@ -26,7 +26,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ProxySettings;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
@@ -249,7 +249,7 @@ public class ProxyAcceptanceTest {
         target.register(head(urlPathEqualTo(path)).willReturn(ok().withHeader("Content-Length", "4")));
         proxy.register(any(anyUrl()).willReturn(aResponse().proxiedFrom(targetServiceBaseUrl)));
 
-        CloseableHttpClient httpClient = HttpClientFactory.createClient();
+        CloseableHttpClient httpClient = HttpClient4Factory.createClient();
         HttpHead request = new HttpHead(proxyingService.baseUrl() + path);
         try (CloseableHttpResponse response = httpClient.execute(request)) {
             assertThat(response.getStatusLine().getStatusCode(), is(200));
@@ -265,7 +265,7 @@ public class ProxyAcceptanceTest {
         target.register(head(urlPathEqualTo(path)).willReturn(ok().withHeader("Content-Length", "4")));
         proxy.register(any(anyUrl()).willReturn(aResponse().proxiedFrom(targetServiceBaseUrl)));
 
-        CloseableHttpClient httpClient = HttpClientFactory.createClient();
+        CloseableHttpClient httpClient = HttpClient4Factory.createClient();
         HttpHead request = new HttpHead(proxyingService.baseUrl() + path);
         try (CloseableHttpResponse response = httpClient.execute(request)) {
             assertThat(response.getStatusLine().getStatusCode(), is(200));

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDelayAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDelayAcceptanceTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.core.Options;
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.UrlPattern;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
@@ -60,7 +60,7 @@ public class ResponseDelayAcceptanceTest {
 
     @Before
     public void init() {
-        httpClient = HttpClientFactory.createClient(SOCKET_TIMEOUT_MILLISECONDS);
+        httpClient = HttpClient4Factory.createClient(SOCKET_TIMEOUT_MILLISECONDS);
         testClient = new WireMockTestClient(wireMockRule.port());
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDelayAsynchronousAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDelayAsynchronousAcceptanceTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.base.Stopwatch;
 import org.apache.http.HttpResponse;
@@ -91,7 +91,7 @@ public class ResponseDelayAsynchronousAcceptanceTest {
             requests.add(new Callable<TimedHttpResponse>() {
                 @Override
                 public TimedHttpResponse call() throws Exception {
-                    CloseableHttpResponse response = HttpClientFactory
+                    CloseableHttpResponse response = HttpClient4Factory
                         .createClient(SOCKET_TIMEOUT_MILLISECONDS)
                         .execute(new HttpGet(String.format("http://localhost:%d/delayed", wireMockRule.port())));
 

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDribbleAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDribbleAcceptanceTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock;
 
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
@@ -53,7 +53,7 @@ public class ResponseDribbleAcceptanceTest {
     @Before
     public void init() throws IOException {
         stubFor(get("/warmup").willReturn(ok()));
-        httpClient = HttpClientFactory.createClient(SOCKET_TIMEOUT_MILLISECONDS);
+        httpClient = HttpClient4Factory.createClient(SOCKET_TIMEOUT_MILLISECONDS);
         // Warm up the server
         httpClient.execute(new HttpGet(String.format("http://localhost:%d/warmup", wireMockRule.port())));
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/TransferEncodingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/TransferEncodingAcceptanceTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.core.Options;
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.apache.commons.lang3.StringUtils;
@@ -119,7 +119,7 @@ public class TransferEncodingAcceptanceTest {
             .willReturn(ok("stuff")
                     .withHeader("Content-Length", "1234")));
 
-        CloseableHttpClient httpClient = HttpClientFactory.createClient();
+        CloseableHttpClient httpClient = HttpClient4Factory.createClient();
         HttpGet request = new HttpGet(wm.baseUrl() + path);
         try (final CloseableHttpResponse response = httpClient.execute(request)) {
             assertThat(response.getFirstHeader("Content-Length").getValue(), is("1234"));
@@ -135,7 +135,7 @@ public class TransferEncodingAcceptanceTest {
             .willReturn(ok("stuff")
                     .withHeader("Content-Length", "1234")));
 
-        CloseableHttpClient httpClient = HttpClientFactory.createClient();
+        CloseableHttpClient httpClient = HttpClient4Factory.createClient();
         HttpGet request = new HttpGet(wm.baseUrl() + path);
         try (CloseableHttpResponse response = httpClient.execute(request)) {
             assertThat(response.getFirstHeader("Content-Length").getValue(), is("1234"));

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestListener;
 import com.github.tomakehurst.wiremock.http.Response;
@@ -287,7 +287,7 @@ public class WireMockJUnitRuleTest {
         public void exposesHttpsOnly() throws Exception {
             wireMockRule.stubFor(any(anyUrl()).willReturn(ok()));
 
-            HttpClient client = HttpClientFactory.createClient();
+            HttpClient client = HttpClient4Factory.createClient();
 
             HttpGet request = new HttpGet("https://localhost:" + wireMockRule.httpsPort() + "/anything");
             HttpResponse response = client.execute(request);

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpClient4Factory.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpClient4Factory.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2011 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http;
+
+import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
+import com.github.tomakehurst.wiremock.common.ProxySettings;
+import com.github.tomakehurst.wiremock.http.ssl.HostVerifyingSSLSocketFactory;
+import com.github.tomakehurst.wiremock.http.ssl.SSLContextBuilder;
+import com.github.tomakehurst.wiremock.http.ssl.TrustEverythingStrategy;
+import com.github.tomakehurst.wiremock.http.ssl.TrustSelfSignedStrategy;
+import com.github.tomakehurst.wiremock.http.ssl.TrustSpecificHostsStrategy;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.*;
+import org.apache.http.config.SocketConfig;
+import org.apache.http.conn.ConnectionKeepAliveStrategy;
+import org.apache.http.conn.socket.LayeredConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.NoConnectionReuseStrategy;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.ProxyAuthenticationStrategy;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.TextUtils;
+
+import javax.net.ssl.SSLContext;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableEntryException;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+import static com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings.NO_STORE;
+import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
+import static com.github.tomakehurst.wiremock.common.ProxySettings.NO_PROXY;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.*;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+/**
+ * Intended to facilitate the migration to Apache Http Client 5.x only; allows us to keep the test interfaces the same.
+ */
+public class HttpClient4Factory {
+
+    public static final int DEFAULT_MAX_CONNECTIONS = 50;
+    public static final int DEFAULT_TIMEOUT = 30000;
+
+    private static final ConnectionKeepAliveStrategy NO_KEEP_ALIVE = new ConnectionKeepAliveStrategy() {
+        @Override
+        public long getKeepAliveDuration(HttpResponse response, HttpContext context) {
+            return 0;
+        }
+    };
+
+    public static CloseableHttpClient createClient(
+            int maxConnections,
+            int timeoutMilliseconds,
+            ProxySettings proxySettings,
+            KeyStoreSettings trustStoreSettings,
+            boolean trustSelfSignedCertificates,
+            final List<String> trustedHosts,
+            boolean useSystemProperties) {
+
+        HttpClientBuilder builder = HttpClientBuilder.create()
+                .disableAuthCaching()
+                .disableAutomaticRetries()
+                .disableCookieManagement()
+                .disableRedirectHandling()
+                .disableContentCompression()
+                .setMaxConnTotal(maxConnections)
+                .setMaxConnPerRoute(maxConnections)
+                .setDefaultRequestConfig(RequestConfig.custom().setStaleConnectionCheckEnabled(true).build())
+                .setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(timeoutMilliseconds).build())
+                .setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE)
+                .setKeepAliveStrategy(NO_KEEP_ALIVE);
+
+        if (useSystemProperties) {
+            builder.useSystemProperties();
+        }
+
+        if (proxySettings != NO_PROXY) {
+            HttpHost proxyHost = new HttpHost(proxySettings.host(), proxySettings.port());
+            builder.setProxy(proxyHost);
+            if(!isEmpty(proxySettings.getUsername()) && !isEmpty(proxySettings.getPassword())) {
+                builder.setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy());
+                BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                credentialsProvider.setCredentials(
+                        new AuthScope(proxySettings.host(), proxySettings.port()),
+                        new UsernamePasswordCredentials(proxySettings.getUsername(), proxySettings.getPassword()));
+                builder.setDefaultCredentialsProvider(credentialsProvider);
+            }
+        }
+
+        final SSLContext sslContext = buildSslContext(trustStoreSettings, trustSelfSignedCertificates, trustedHosts);
+        LayeredConnectionSocketFactory sslSocketFactory = buildSslConnectionSocketFactory(sslContext);
+        builder.setSSLSocketFactory(sslSocketFactory);
+
+        return builder.build();
+	}
+
+    private static LayeredConnectionSocketFactory buildSslConnectionSocketFactory(final SSLContext sslContext) {
+        final String[] supportedProtocols = split(System.getProperty("https.protocols"));
+        final String[] supportedCipherSuites = split(System.getProperty("https.cipherSuites"));
+
+        return new SSLConnectionSocketFactory(
+            new HostVerifyingSSLSocketFactory(sslContext.getSocketFactory()),
+            supportedProtocols,
+            supportedCipherSuites,
+            new NoopHostnameVerifier() // using Java's hostname verification
+        );
+    }
+
+    /**
+     * Copied from {@link HttpClientBuilder#split(String)} which is not
+     * the same as {@link org.apache.commons.lang3.StringUtils#split(String)}
+      */
+    private static String[] split(final String s) {
+        if (TextUtils.isBlank(s)) {
+            return null;
+        }
+        return s.split(" *, *");
+    }
+
+    private static SSLContext buildSslContext(
+        KeyStoreSettings trustStoreSettings,
+        boolean trustSelfSignedCertificates,
+        List<String> trustedHosts
+    ) {
+        if (trustStoreSettings != NO_STORE) {
+            return buildSSLContextWithTrustStore(trustStoreSettings, trustSelfSignedCertificates, trustedHosts);
+        } else if (trustSelfSignedCertificates) {
+            return buildAllowAnythingSSLContext();
+        } else {
+            try {
+                return SSLContextBuilder.create().loadTrustMaterial(new TrustSpecificHostsStrategy(trustedHosts)).build();
+            } catch (NoSuchAlgorithmException | KeyManagementException e) {
+                return throwUnchecked(e, null);
+            }
+        }
+    }
+
+    public static CloseableHttpClient createClient(
+            int maxConnections,
+            int timeoutMilliseconds,
+            ProxySettings proxySettings,
+            KeyStoreSettings trustStoreSettings,
+            boolean useSystemProperties) {
+        return createClient(maxConnections, timeoutMilliseconds, proxySettings, trustStoreSettings, true, Collections.<String>emptyList(), useSystemProperties);
+    }
+
+    private static SSLContext buildSSLContextWithTrustStore(KeyStoreSettings trustStoreSettings, boolean trustSelfSignedCertificates, List<String> trustedHosts) {
+        try {
+            KeyStore trustStore = trustStoreSettings.loadStore();
+            SSLContextBuilder sslContextBuilder = SSLContextBuilder.create()
+                    .loadKeyMaterial(trustStore, trustStoreSettings.password().toCharArray());
+            if (trustSelfSignedCertificates) {
+                sslContextBuilder.loadTrustMaterial(new TrustSelfSignedStrategy());
+            } else if (containsCertificate(trustStore)) {
+                sslContextBuilder.loadTrustMaterial(trustStore, new TrustSpecificHostsStrategy(trustedHosts));
+            } else {
+                sslContextBuilder.loadTrustMaterial(new TrustSpecificHostsStrategy(trustedHosts));
+            }
+            return sslContextBuilder
+                    .build();
+        } catch (Exception e) {
+            return throwUnchecked(e, SSLContext.class);
+        }
+    }
+
+    private static boolean containsCertificate(KeyStore trustStore) throws KeyStoreException {
+        Enumeration<String> aliases = trustStore.aliases();
+        while (aliases.hasMoreElements()) {
+            String alias = aliases.nextElement();
+            try {
+                if (trustStore.getEntry(alias, null) instanceof KeyStore.TrustedCertificateEntry) {
+                    return true;
+                }
+            } catch (NoSuchAlgorithmException | UnrecoverableEntryException e) {
+                // ignore
+            }
+        }
+        return false;
+    }
+
+    private static SSLContext buildAllowAnythingSSLContext() {
+        try {
+            return SSLContextBuilder.create().loadTrustMaterial(new TrustEverythingStrategy()).build();
+        } catch (Exception e) {
+            return throwUnchecked(e, null);
+        }
+    }
+
+    public static CloseableHttpClient createClient(int maxConnections, int timeoutMilliseconds) {
+        return createClient(maxConnections, timeoutMilliseconds, NO_PROXY, NO_STORE, true);
+    }
+
+	public static CloseableHttpClient createClient(int timeoutMilliseconds) {
+		return createClient(DEFAULT_MAX_CONNECTIONS, timeoutMilliseconds);
+	}
+
+    public static CloseableHttpClient createClient(ProxySettings proxySettings) {
+        return createClient(DEFAULT_MAX_CONNECTIONS, DEFAULT_TIMEOUT, proxySettings, NO_STORE, true);
+    }
+
+    public static CloseableHttpClient createClient() {
+      return createClient(DEFAULT_TIMEOUT);
+    }
+
+    public static HttpUriRequest getHttpRequestFor(RequestMethod method, String url) {
+        notifier().info("Proxying: " + method + " " + url);
+
+        if (method.equals(GET))
+            return new HttpGet(url);
+        else if (method.equals(POST))
+            return new HttpPost(url);
+        else if (method.equals(PUT))
+            return new HttpPut(url);
+        else if (method.equals(DELETE))
+            return new HttpDelete(url);
+        else if (method.equals(HEAD))
+            return new HttpHead(url);
+        else if (method.equals(OPTIONS))
+            return new HttpOptions(url);
+        else if (method.equals(TRACE))
+            return new HttpTrace(url);
+        else if (method.equals(PATCH))
+            return new HttpPatch(url);
+        else
+            return new GenericHttpUriRequest(method.toString(), url);
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
@@ -98,7 +98,7 @@ public abstract class HttpClientFactoryCertificateVerificationTest {
         clientTrustStore.saveAs(clientTrustStoreFile);
         KeyStoreSettings clientTrustStoreSettings = new KeyStoreSettings(clientTrustStoreFile.getAbsolutePath(), "password", "jks");
 
-        client = HttpClientFactory.createClient(
+        client = HttpClient4Factory.createClient(
                 1000,
                 5 * 1000 * 60,
                 NO_PROXY,

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionDeclarativeTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionDeclarativeTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.junit5;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -36,7 +36,7 @@ public class JUnitJupiterExtensionDeclarativeTest {
 
     @BeforeEach
     void init() {
-        client = HttpClientFactory.createClient();
+        client = HttpClient4Factory.createClient();
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionDeclarativeWithRandomHttpsPortParameterTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionDeclarativeWithRandomHttpsPortParameterTest.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.junit5;
 
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -34,7 +34,7 @@ public class JUnitJupiterExtensionDeclarativeWithRandomHttpsPortParameterTest {
 
     @BeforeEach
     void init() {
-        client = HttpClientFactory.createClient();
+        client = HttpClient4Factory.createClient();
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionFailOnUnmatchedTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionFailOnUnmatchedTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.junit5;
 
 import com.github.tomakehurst.wiremock.client.VerificationException;
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -43,7 +43,7 @@ public class JUnitJupiterExtensionFailOnUnmatchedTest {
 
     @BeforeEach
     void init() {
-        client = HttpClientFactory.createClient();
+        client = HttpClient4Factory.createClient();
 
         context = new Mockery();
         extensionContext = context.mock(ExtensionContext.class);

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionJvmProxyDeclarativeTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionJvmProxyDeclarativeTest.java
@@ -1,6 +1,6 @@
 package com.github.tomakehurst.wiremock.junit5;
 
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -19,7 +19,7 @@ public class JUnitJupiterExtensionJvmProxyDeclarativeTest {
 
     @BeforeEach
     void init() {
-        client = HttpClientFactory.createClient();
+        client = HttpClient4Factory.createClient();
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionJvmProxyNonStaticProgrammaticTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionJvmProxyNonStaticProgrammaticTest.java
@@ -1,6 +1,6 @@
 package com.github.tomakehurst.wiremock.junit5;
 
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -27,7 +27,7 @@ public class JUnitJupiterExtensionJvmProxyNonStaticProgrammaticTest {
 
     @BeforeEach
     void init() {
-        client = HttpClientFactory.createClient();
+        client = HttpClient4Factory.createClient();
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionJvmProxyStaticProgrammaticTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionJvmProxyStaticProgrammaticTest.java
@@ -1,6 +1,6 @@
 package com.github.tomakehurst.wiremock.junit5;
 
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -27,7 +27,7 @@ public class JUnitJupiterExtensionJvmProxyStaticProgrammaticTest {
 
     @BeforeEach
     void init() {
-        client = HttpClientFactory.createClient();
+        client = HttpClient4Factory.createClient();
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionNonStaticMultiInstanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionNonStaticMultiInstanceTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.junit5;
 
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -53,7 +53,7 @@ public class JUnitJupiterExtensionNonStaticMultiInstanceTest {
 
     @BeforeEach
     void init() {
-        client = HttpClientFactory.createClient();
+        client = HttpClient4Factory.createClient();
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionStaticMultiInstanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionStaticMultiInstanceTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.junit5;
 
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -53,7 +53,7 @@ public class JUnitJupiterExtensionStaticMultiInstanceTest {
 
     @BeforeEach
     void init() {
-        client = HttpClientFactory.createClient();
+        client = HttpClient4Factory.createClient();
     }
 
     @Test

--- a/src/test/java/ignored/VeryLongAsynchronousDelayAcceptanceTest.java
+++ b/src/test/java/ignored/VeryLongAsynchronousDelayAcceptanceTest.java
@@ -17,7 +17,7 @@ package ignored;
 
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.HttpClient4Factory;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -55,7 +55,7 @@ public class VeryLongAsynchronousDelayAcceptanceTest {
 
         wireMockRule.addStubMapping(Json.read(json, StubMapping.class));
 
-        CloseableHttpResponse response = HttpClientFactory.createClient(50, 120000)
+        CloseableHttpResponse response = HttpClient4Factory.createClient(50, 120000)
             .execute(RequestBuilder
             .post("http://localhost:" + wireMockRule.port() + "/faulty/1/path/path")
             .setEntity(new StringEntity("<xml>permissions</xml>"))


### PR DESCRIPTION
This way we can migrate src/main to Apache HttpClient 5.x (#1619) while still testing with Apache Httpclient 4.