### PR TITLE
Publish test results from forks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -56,18 +56,3 @@ jobs:
         path: |
           wiremock-webhooks-extension/build/reports/tests/test
           wiremock-webhooks-extension/build/test-results/test
-
-  publish-test-results:
-    name: "Publish Unit Test Results"
-    needs: build
-    runs-on: ubuntu-latest
-    # the build job might be skipped, we don't need to run this job then
-    if: success() || failure()
-
-    steps:
-    - name: Download Artifacts
-      uses: actions/download-artifact@v2
-    - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action/composite@v1
-      with:
-        files: '**/*.xml'

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,0 +1,37 @@
+name: Publish Test Results
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  unit-test-results:
+    name: Unit Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+    - name: Download and Extract Artifacts
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      run: |
+         mkdir -p artifacts && cd artifacts
+
+         artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+         gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+         do
+           IFS=$'\t' read name url <<< "$artifact"
+           gh api $url > "$name.zip"
+           unzip -d "$name" "$name.zip"
+         done
+
+    - name: Publish Unit Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v1
+      with:
+        commit: ${{ github.event.workflow_run.head_sha }}
+        event_file: artifacts/Event File/event.json
+        event_name: ${{ github.event.workflow_run.event }}
+        files: "artifacts/**/*.xml"


### PR DESCRIPTION
Improvement on #1629 , as forks were failing to publish.

As per: https://github.com/marketplace/actions/publish-unit-test-results#support-fork-repositories-and-dependabot-branches