### PR TITLE
Fixes #1647 by dereferencing wireMockServer after stopping.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -119,9 +119,10 @@ public class WireMockExtension extends DslWrapper implements ParameterResolver, 
     }
 
     private void stopServerIfRunning() {
-        if (wireMockServer.isRunning()) {
+        if (wireMockServer != null && wireMockServer.isRunning()) {
             wireMockServer.stop();
         }
+        wireMockServer = null;
     }
 
     private boolean parameterIsWireMockRuntimeInfo(ParameterContext parameterContext) {


### PR DESCRIPTION
Fixes #1647 by dereferencing wireMockServer after stopping.