### PR TITLE
fix for bug 1012 - Wiremock recorder space before the Target URL

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -124,7 +124,7 @@ public class ResponseDefinition {
         this.fixedDelayMilliseconds = fixedDelayMilliseconds;
         this.delayDistribution = delayDistribution;
         this.chunkedDribbleDelay = chunkedDribbleDelay;
-        this.proxyBaseUrl = proxyBaseUrl;
+        this.proxyBaseUrl = proxyBaseUrl == null ? null : proxyBaseUrl.trim();
         this.proxyUrlPrefixToRemove = proxyUrlPrefixToRemove;
         this.fault = fault;
         this.transformers = transformers;

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ResponseDefinitionTest.java
@@ -51,4 +51,39 @@ public class ResponseDefinitionTest {
 
         assertThat(response.getProxyUrl(), equalTo("http://my.proxy.url"));
     }
+
+    @Test
+    public void getProxyUrlGivesBackTheProxyUrlWhenProxiedUrlBeginWithWhiteSpace() {
+        ResponseDefinition response = ResponseDefinitionBuilder.responseDefinition()
+                .proxiedFrom(" http://my.proxy.url")
+                .build();
+
+        response.setOriginalRequest(MockRequest.mockRequest().url("/path"));
+
+        assertThat(response.getProxyUrl(), equalTo("http://my.proxy.url/path"));
+    }
+
+    @Test
+    public void getProxyUrlGivesBackTheProxyUrlWhenProxiedUrlEndWithWhiteSpace() {
+        ResponseDefinition response = ResponseDefinitionBuilder.responseDefinition()
+                .proxiedFrom("http://my.proxy.url ")
+                .build();
+
+        response.setOriginalRequest(MockRequest.mockRequest().url("/path"));
+
+        assertThat(response.getProxyUrl(), equalTo("http://my.proxy.url/path"));
+
+    }
+
+    @Test
+    public void getProxyUrlGivesBackTheProxyUrlWhenProxiedFromUrlNull() {
+        ResponseDefinition response = ResponseDefinitionBuilder.responseDefinition()
+                .build();
+
+        response.setOriginalRequest(MockRequest.mockRequest().url("/path"));
+
+        assertThat(response.getProxyUrl(), equalTo("null/path"));
+
+    }
+
 }


### PR DESCRIPTION
This pull request is created to fix the issue mentioned in https://github.com/wiremock/wiremock/issues/1012.

Issue:
When using the wiremock recoder __admin/recorder/, if there's a space before the Target URL in the URL box, wiremock throws the IllegalArgumentException error.

Code change:
Trimmed the proxyBaseUrl in ResponseDefinition.java as below:
this.proxyBaseUrl = proxyBaseUrl == null ? null : proxyBaseUrl.trim();

Unit tests added.
 