### PR TITLE
Add missing `description` to the slim JAR's generated POM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,6 @@ allprojects {
 
     pomInfo = {
       name 'WireMock'
-      description 'A web service test double for all occasions'
       url 'http://wiremock.org'
       scm {
         connection 'https://github.com/wiremock/wiremock.git'
@@ -350,6 +349,7 @@ publishing {
       artifact testJar
 
       pom.withXml {
+        asNode().appendNode('description', 'A web service test double for all occasions')
         asNode().children().last() + pomInfo
       }
     }


### PR DESCRIPTION
It's unclear as to why this is no longer working, but as it's currently
blocking the release being published, we'll resolve it for now.
