### PR TITLE
Enable reproducible builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,6 +153,11 @@ allprojects {
     }
   }
 
+  tasks.withType(AbstractArchiveTask).configureEach {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+  }
+
   ext {
     runningOnCI = System.getenv('CI') == 'true'
 


### PR DESCRIPTION
To ensure that this project can be correctly reproduced by an
independent build of the project, we should enable reproducible builds
in Gradle, across all projects.
