### PR TITLE
add admin API endpoints to set specfic scenario states.

### DIFF
--- a/docs-v2/_docs/stateful-behaviour.md
+++ b/docs-v2/_docs/stateful-behaviour.md
@@ -142,7 +142,21 @@ The state of all configured scenarios can be reset back to
 `Scenario.START` either by calling `WireMock.resetAllScenarios()` in
 Java, or posting an empty request to `http://<host>:<port>/__admin/scenarios/reset`.
 
+## Working with specific scenarios
 
+### Getting a specific scenario state
+The state of a specific scenario can be retrieved for a specific state.
+The state of a specific scenario can be retrieved for a specific state `WireMock.getScenarioState(String scenarioName)` in Java, or sending a HTTP.GET request to `http://<host>:<port>/__admin/scenario/state?scenarioName=name`.
 
+### Setting a specific scenario state
+The state of a specific scenario can be set to a specific state.
+This can be achived by calling `Wiremock.setScenarioState(String scenarioName, String scenarioState)` in Java, or posting an request with JsonBody (see below) to `http://<host>:<port>/__admin/scenario/state`.
 
+JsonBody:
 
+```json
+{
+    "scenarioName": "name",
+    "scenarioState": "stateName"
+}
+```

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -390,6 +390,16 @@ public class WireMockServer implements Container, Stubbing, Admin {
   }
 
   @Override
+  public void setScenarioState(ScenarioStateParam scenarioStateParam) {
+    wireMockApp.setScenarioState(scenarioStateParam);
+  }
+
+  @Override
+  public String getScenarioState(String scenarioName) {
+    return wireMockApp.getScenarioState(scenarioName);
+  }
+
+  @Override
   public void resetMappings() {
     wireMockApp.resetMappings();
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
@@ -81,6 +81,8 @@ public class AdminRoutes {
 
     router.add(GET, "/scenarios", GetAllScenariosTask.class);
     router.add(POST, "/scenarios/reset", ResetScenariosTask.class);
+    router.add(GET, "/scenario/state", GetScenarioTask.class);
+    router.add(POST, "/scenario/state", SetScenarioTask.class);
 
     router.add(GET, "/requests", GetAllRequestsTask.class);
     router.add(DELETE, "/requests", ResetRequestsTask.class);

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/model/ScenarioStateParam.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/model/ScenarioStateParam.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Wilfried Kohl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.admin.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ScenarioStateParam {
+
+  private String scenarioName;
+  private String scenarioState;
+
+  @JsonCreator
+  public ScenarioStateParam(
+      @JsonProperty("scenarioName") String scenarioName,
+      @JsonProperty("scenarioState") String scenarioState) {
+    this.scenarioName = scenarioName;
+    this.scenarioState = scenarioState;
+  }
+
+  public String getScenarioName() {
+    return this.scenarioName;
+  }
+
+  public String getScenarioState() {
+    return this.scenarioState;
+  }
+
+  public void setScenarioName(String scenarioName) {
+    this.scenarioName = scenarioName;
+  }
+
+  public void setScenarioState(String scenarioState) {
+    this.scenarioState = scenarioState;
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/GetScenarioTask.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/GetScenarioTask.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021 Wilfried Kohl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.admin.tasks;
+
+import com.github.tomakehurst.wiremock.admin.AdminTask;
+import com.github.tomakehurst.wiremock.admin.model.PathParams;
+import com.github.tomakehurst.wiremock.common.Errors;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.http.QueryParameter;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+
+public class GetScenarioTask implements AdminTask {
+  @Override
+  public ResponseDefinition execute(Admin admin, Request request, PathParams pathParams) {
+
+    QueryParameter scenarioNameQueryParameter = request.queryParameter("scenarioName");
+    if (!scenarioNameQueryParameter.isSingleValued()
+        || !scenarioNameQueryParameter.isPresent()
+        || scenarioNameQueryParameter.firstValue().equals("")) {
+      return ResponseDefinition.badRequest(
+          Errors.validation(
+              "/__admin/scenario/state",
+              "scenarioName is not present, contains more than one value or the value is empty"));
+    }
+
+    try {
+      String stateValue = admin.getScenarioState(scenarioNameQueryParameter.firstValue());
+      return ResponseDefinition.okForJson(stateValue);
+    } catch (AssertionError e) {
+      return ResponseDefinition.notFound(e.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/SetScenarioTask.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/SetScenarioTask.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2021 Wilfried Kohl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.admin.tasks;
+
+import com.github.tomakehurst.wiremock.admin.AdminTask;
+import com.github.tomakehurst.wiremock.admin.model.PathParams;
+import com.github.tomakehurst.wiremock.admin.model.ScenarioStateParam;
+import com.github.tomakehurst.wiremock.common.Errors;
+import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.common.JsonException;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+
+public class SetScenarioTask implements AdminTask {
+  @Override
+  public ResponseDefinition execute(Admin admin, Request request, PathParams pathParams) {
+
+    try {
+      ScenarioStateParam scenarioStateParam =
+          Json.read(request.getBodyAsString(), ScenarioStateParam.class);
+      if (scenarioStateParam.getScenarioName() == null
+          || scenarioStateParam.getScenarioName().isEmpty()) {
+        return ResponseDefinition.badRequest(
+            Errors.validation("/__admin/scenario/state", "scenarioName is null or empty"));
+      }
+      if (scenarioStateParam.getScenarioState() == null
+          || scenarioStateParam.getScenarioState().isEmpty()) {
+        return ResponseDefinition.badRequest(
+            Errors.validation("/__admin/scenario/state", "scenarioState is null or empty"));
+      }
+      try {
+        admin.setScenarioState(scenarioStateParam);
+      } catch (AssertionError e) {
+        return ResponseDefinition.notFound(e.getMessage());
+      }
+      return ResponseDefinition.okEmptyJson();
+    } catch (JsonException e) {
+      return ResponseDefinition.badRequest(
+          Errors.validation("/__admin/scenario/state", e.toString()));
+    }
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -196,6 +196,23 @@ public class HttpAdminClient implements Admin {
   }
 
   @Override
+  public void setScenarioState(ScenarioStateParam scenarioStateParam) {
+    executeRequest(
+        adminRoutes.requestSpecForTask(SetScenarioTask.class), scenarioStateParam, Void.class);
+  }
+
+  @Override
+  public String getScenarioState(String scenarioName) {
+    QueryParams queryParams = QueryParams.single("scenarioName", scenarioName);
+    return executeRequest(
+        adminRoutes.requestSpecForTask(GetScenarioTask.class),
+        PathParams.empty(),
+        queryParams,
+        null,
+        String.class);
+  }
+
+  @Override
   public void resetMappings() {
     executeRequest(adminRoutes.requestSpecForTask(ResetStubMappingsTask.class));
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -22,6 +22,7 @@ import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.HttpHeaders.LOCATION;
 
 import com.github.tomakehurst.wiremock.admin.model.ListStubMappingsResult;
+import com.github.tomakehurst.wiremock.admin.model.ScenarioStateParam;
 import com.github.tomakehurst.wiremock.admin.model.ServeEventQuery;
 import com.github.tomakehurst.wiremock.admin.model.SingleStubMappingResult;
 import com.github.tomakehurst.wiremock.common.*;
@@ -366,6 +367,14 @@ public class WireMock {
 
   public void resetScenarios() {
     admin.resetScenarios();
+  }
+
+  public String getScenarioState(String scenarioName) {
+    return admin.getScenarioState(scenarioName);
+  }
+
+  public void setScenarioState(String scenarioName, String scenarioState) {
+    admin.setScenarioState(new ScenarioStateParam(scenarioName, scenarioState));
   }
 
   public static List<Scenario> getAllScenarios() {

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
@@ -52,6 +52,10 @@ public interface Admin {
 
   void resetToDefaultMappings();
 
+  void setScenarioState(ScenarioStateParam scenarioStateParam);
+
+  String getScenarioState(String scenarioName);
+
   GetServeEventsResult getServeEvents();
 
   GetServeEventsResult getServeEvents(ServeEventQuery query);

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -308,6 +308,17 @@ public class WireMockApp implements StubServer, Admin {
   }
 
   @Override
+  public void setScenarioState(ScenarioStateParam scenarioStateParam) {
+    stubMappings.setScenarioState(
+        scenarioStateParam.getScenarioName(), scenarioStateParam.getScenarioState());
+  }
+
+  @Override
+  public String getScenarioState(String scenarioName) {
+    return stubMappings.getScenarioState(scenarioName);
+  }
+
+  @Override
   public void resetMappings() {
     mappingsSaver.removeAll();
     stubMappings.reset();

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -224,6 +224,10 @@ public class ResponseDefinition {
     return new ResponseDefinition(HTTP_NOT_FOUND, (byte[]) null);
   }
 
+  public static ResponseDefinition notFound(String body) {
+    return new ResponseDefinition(HTTP_NOT_FOUND, body.getBytes());
+  }
+
   public static ResponseDefinition ok() {
     return new ResponseDefinition(HTTP_OK, (byte[]) null);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/junit/DslWrapper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/DslWrapper.java
@@ -81,6 +81,16 @@ public class DslWrapper implements Admin, Stubbing {
   }
 
   @Override
+  public void setScenarioState(ScenarioStateParam param) {
+    admin.setScenarioState(param);
+  }
+
+  @Override
+  public String getScenarioState(String scenarioName) {
+    return admin.getScenarioState(scenarioName);
+  }
+
+  @Override
   public void resetMappings() {
     admin.resetMappings();
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappings.java
@@ -185,6 +185,29 @@ public class InMemoryStubMappings implements StubMappings {
   }
 
   @Override
+  public void setScenarioState(String scenarioName, String scenarioState) {
+    if (scenarios.getByName(scenarioName) == null) {
+      throw new AssertionError(String.format("Scenario '%s' was not found", scenarioName));
+    }
+    if (!scenarios.getByName(scenarioName).getPossibleStates().contains(scenarioState)) {
+      throw new AssertionError(
+          String.format(
+              "Scenario '%s' does not have definitions for the state '%s'",
+              scenarioName, scenarioState));
+    }
+    scenarios.setScenarioState(scenarioName, scenarioState);
+  }
+
+  @Override
+  public String getScenarioState(String scenarioName) {
+    Scenario scenario = scenarios.getByName(scenarioName);
+    if (scenario == null) {
+      throw new AssertionError(String.format("Scenario '%s' was not found", scenarioName));
+    }
+    return scenario.getState();
+  }
+
+  @Override
   public List<StubMapping> getAll() {
     return ImmutableList.copyOf(mappings);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/Scenarios.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/Scenarios.java
@@ -105,6 +105,21 @@ public class Scenarios {
             }));
   }
 
+  public void setScenarioState(String scenarioName, String scenarioState) {
+    scenarioMap.putAll(
+        Maps.transformValues(
+            scenarioMap,
+            new Function<Scenario, Scenario>() {
+              @Override
+              public Scenario apply(Scenario input) {
+                if (input.getName().equals(scenarioName)) {
+                  return input.setState(scenarioState);
+                }
+                return input;
+              }
+            }));
+  }
+
   public void clear() {
     scenarioMap.clear();
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappings.java
@@ -35,6 +35,10 @@ public interface StubMappings {
 
   void resetScenarios();
 
+  void setScenarioState(String name, String state);
+
+  String getScenarioState(String scenarioName);
+
   List<StubMapping> getAll();
 
   Optional<StubMapping> get(UUID id);

--- a/src/main/resources/swagger/wiremock-admin-api.json
+++ b/src/main/resources/swagger/wiremock-admin-api.json
@@ -1815,6 +1815,46 @@
       "responses": {"200": {"description": "Successfully saved"}},
       "tags": ["Stub Mappings"]
     }},
+    "/__admin/scenario/state": {
+      "post": {
+        "summary": "Set State of a specific scenario",
+        "requestBody": {"content": {"application/json": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "scenarioName": {"type": "string"},
+              "scenarioState": {"type": "string"}
+            }
+          },
+          "example": {
+            "scenarioName": "static-scenario",
+            "scenarioState": "state"
+          }
+        }}},
+        "responses": {
+          "200": {"description": "Successful"},
+          "400": {"description": "Error parsing the parameters"},
+          "404": {"description": "Scenario was not found"}
+        },
+        "tags": ["Scenarios"]
+      },
+      "get": {
+        "summary": "Get State of a specific scenario",
+        "responses": {
+          "200": {"description": "Successful"},
+          "400": {"description": "Error parsing the parameters"},
+          "404": {"description": "Scenario was not found"}
+        },
+        "parameters": [{
+          "schema": {"type": "string"},
+          "in": "query",
+          "name": "scenarioName",
+          "description": "The name of the Scenario",
+          "example": "scenario-name"
+        }],
+        "tags": ["Scenarios"]
+      }
+    },
     "/__admin/mappings/{stubMappingId}": {
       "get": {
         "summary": "Get stub mapping by ID",

--- a/src/main/resources/swagger/wiremock-admin-api.yaml
+++ b/src/main/resources/swagger/wiremock-admin-api.yaml
@@ -483,6 +483,50 @@ paths:
       responses:
         '200':
           description: Successfully reset
+  /__admin/scenario/state:
+    get:
+      summary: Get the state of a specific scenario
+      tags:
+         - Scenarios
+      responses:
+        '200':
+          description: Successful
+        '400': 
+            description: Error parsing the parameters
+        '404': 
+            description: Scenario was not found
+      parameters:
+        - in: query 
+          name: scenarioName
+          schema: 
+            type: "string"
+          description: The name of the Scenario
+          example: "scenario-name"
+
+    post:
+      summary: Set the state of a scenario
+      tags:
+         - Scenarios
+      responses:
+        '200':
+          description: Successful
+        '400': 
+            description: Error parsing the parameters
+        '404': 
+            description: Scenario was not found
+      requestBody: 
+        content:
+            application/json:
+              schema:
+                type: object
+                properties: 
+                  scenarioName:
+                    type: string
+                  newScenarioState:
+                    type: string
+              example: 
+                scenarioName: "static-scenario"
+                scenarioState: "state"
 
   /__admin/settings:
     post:


### PR DESCRIPTION
## description 
This PR adds two admin endpoints:
### get the current state of a scenario: 
GET `__admin/scenario/state?stateName=scenario-name`
### set the current state of a scenario 
POST `__admin/scenario/state`
Body: 
```json
{ 
"scenarioName": "scenario-name",
"scenarioState": "scenario-state"
}
```

### further notes 
This allows setting a scenario to any state without knowing the current state. 
The workaround discussed in PR https://github.com/wiremock/wiremock/pull/1079 and issue https://github.com/wiremock/wiremock/issues/847 only allows resetting the scenario if you know the current state. 
Also, I do not think that it is the ideal usage to create additional "control mappings" to  achieve `__admin` functionality, therefore here is an alternative proposal. 
In contrast to PR https://github.com/wiremock/wiremock/pull/1079 this PR not just allows resetting a scenario, you can also switch to an intermediate or final state of a scenario. 

Would also enable PR:
https://github.com/wiremock/wiremock/pull/1079
and also fix issue
https://github.com/wiremock/wiremock/issues/847
(when setting scenario state in POST-Request to "Started") 


### Discussion 
If this PR is correct according to the Contribution Rules, please let me know, so I can fix it. 
If the API changes are not desirable (e.g. a path parameter would be nicer for the "state-name" in the GET request), please let me know. 
