### PR TITLE
Fix admin requests with empty body to avoid response code 411

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -499,8 +499,10 @@ public class HttpAdminClient implements Admin {
     ClassicRequestBuilder requestBuilder =
         ClassicRequestBuilder.create(requestSpec.method().getName()).setUri(url);
 
-    requestBuilder.setEntity(
-        jsonStringEntity(Optional.ofNullable(requestBody).map(Json::write).orElse("")));
+    if (requestSpec.method().hasEntity()) {
+      requestBuilder.setEntity(
+          jsonStringEntity(Optional.ofNullable(requestBody).map(Json::write).orElse("")));
+    }
 
     String responseBodyString = safelyExecuteRequest(url, requestBuilder.build());
 

--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -47,6 +47,7 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.verification.*;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -445,20 +446,14 @@ public class HttpAdminClient implements Admin {
 
   private String postJsonAssertOkAndReturnBody(String url, String json) {
     HttpPost post = new HttpPost(url);
-    if (json != null) {
-      post.setEntity(jsonStringEntity(json));
-    }
-
+    post.setEntity(jsonStringEntity(Optional.ofNullable(json).orElse("")));
     return safelyExecuteRequest(url, post);
   }
 
   private String putJsonAssertOkAndReturnBody(String url, String json) {
-    HttpPut post = new HttpPut(url);
-    if (json != null) {
-      post.setEntity(jsonStringEntity(json));
-    }
-
-    return safelyExecuteRequest(url, post);
+    HttpPut put = new HttpPut(url);
+    put.setEntity(jsonStringEntity(Optional.ofNullable(json).orElse("")));
+    return safelyExecuteRequest(url, put);
   }
 
   protected String getJsonAssertOkAndReturnBody(String url) {
@@ -504,9 +499,8 @@ public class HttpAdminClient implements Admin {
     ClassicRequestBuilder requestBuilder =
         ClassicRequestBuilder.create(requestSpec.method().getName()).setUri(url);
 
-    if (requestBody != null) {
-      requestBuilder.setEntity(jsonStringEntity(Json.write(requestBody)));
-    }
+    requestBuilder.setEntity(
+        jsonStringEntity(Optional.ofNullable(requestBody).map(Json::write).orElse("")));
 
     String responseBodyString = safelyExecuteRequest(url, requestBuilder.build());
 

--- a/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
@@ -17,11 +17,14 @@ package com.github.tomakehurst.wiremock.client;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.admin.model.GetScenariosResult;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import java.util.List;
 import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 public class HttpAdminClientTest {
@@ -29,14 +32,14 @@ public class HttpAdminClientTest {
 
   @Test
   public void returnsOptionsWhenCallingGetOptions() {
-    HttpAdminClient client = new HttpAdminClient("localhost", 8080);
-    assertThat(client.getOptions().portNumber(), is(8080));
-    assertThat(client.getOptions().bindAddress(), is("localhost"));
+    var client = new HttpAdminClient("localhost", 8080);
+    assertThat(client.getOptions().portNumber()).isEqualTo(8080);
+    assertThat(client.getOptions().bindAddress()).isEqualTo("localhost");
   }
 
   @Test
   public void shouldSendEmptyRequestForResetToDefaultMappings() {
-    WireMockServer server = new WireMockServer(options().dynamicPort());
+    var server = new WireMockServer(options().dynamicPort());
     server.start();
     server.addStubMapping(
         server.stubFor(
@@ -44,12 +47,13 @@ public class HttpAdminClientTest {
                 .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
                 .willReturn(ok())));
     var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
+
     client.resetToDefaultMappings();
   }
 
   @Test
   public void shouldSendEmptyRequestForResetAll() {
-    WireMockServer server = new WireMockServer(options().dynamicPort());
+    var server = new WireMockServer(options().dynamicPort());
     server.start();
     server.addStubMapping(
         server.stubFor(
@@ -57,6 +61,22 @@ public class HttpAdminClientTest {
                 .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
                 .willReturn(ok())));
     var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
+
     client.resetAll();
+  }
+
+  @Test
+  public void shouldNotSendEntityForGetAllScenarios() {
+    var server = new WireMockServer(options().dynamicPort());
+    server.start();
+    var expectedResponse = new GetScenariosResult(List.of(Scenario.inStartedState("scn1")));
+    server.addStubMapping(
+        server.stubFor(
+            get(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/scenarios"))
+                .withHeader(HttpHeaders.CONTENT_LENGTH, absent())
+                .willReturn(jsonResponse(expectedResponse, HttpStatus.SC_OK))));
+    var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
+
+    assertThat(client.getAllScenarios()).usingRecursiveComparison().isEqualTo(expectedResponse);
   }
 }


### PR DESCRIPTION
Changed admin client to add empty response entity for HTTP requests without body to have proper Content-Length header set in every case. Closes #1729