### PR TITLE
Convert string body to json body if the value of content-type header contains 'json'.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.*;
+import com.github.tomakehurst.wiremock.matching.ContainsPattern;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.util.List;
@@ -262,6 +263,23 @@ public class ResponseDefinitionBuilder {
   }
 
   private boolean isJsonBody() {
+    if (jsonBody != null) {
+        return true;
+    }
+    if(headers == null || stringBody == null) {
+        return false;
+    }
+    HttpHeader contentTypeHeader = headers.stream()
+        .filter(header -> header.keyEquals(ContentTypeHeader.KEY)).findFirst().orElse(null);
+    if(contentTypeHeader != null) {
+        boolean isJson = contentTypeHeader.hasValueMatching(new ContainsPattern("json"));
+        if(isJson) {
+            try {
+                jsonBody = Json.node(stringBody);
+            } catch (Exception e) {
+            }
+        }
+    }
     return jsonBody != null;
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
@@ -157,4 +157,69 @@ public class ResponseDefinitionBuilderTest {
         equalTo(new HttpHeaders(newArrayList(new HttpHeader("header", "value")))));
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
   }
+
+   @Test 
+    public void proxyResponseDefinitionWithJsonContentType1() {
+        ResponseDefinition originalResponseDefinition = ResponseDefinitionBuilder.responseDefinition()
+                .withStatus(200)
+                .withStatusMessage("OK")
+                .withBody("{\"data\": \"Hello, world\" }")
+                .withHeader("content-type", "application/json")
+                .build();
+        assertThat(originalResponseDefinition.getJsonBody(),
+        		equalTo(Json.node("{\"data\": \"Hello, world\" }")));
+        
+        originalResponseDefinition = ResponseDefinitionBuilder.responseDefinition()
+                .withStatus(200)
+                .withStatusMessage("OK")
+                .withBody("{}")
+                .withHeader("content-type", "application/json")
+                .build();
+        assertThat(originalResponseDefinition.getJsonBody(),
+        		equalTo(Json.node("{}")));
+    }
+    
+    @Test 
+    public void proxyResponseDefinitionWithJsonContentType2() {
+        ResponseDefinition originalResponseDefinition = ResponseDefinitionBuilder.responseDefinition()
+                .withStatus(200)
+                .withStatusMessage("OK")
+                .withBody("[{\"data\": 23}]")
+                .withHeader("content-type", "application/json")
+                .build();
+        assertThat(originalResponseDefinition.getJsonBody(), 
+        		equalTo(Json.node("[{\"data\": 23}]")));
+        
+        originalResponseDefinition = ResponseDefinitionBuilder.responseDefinition()
+                .withStatus(200)
+                .withStatusMessage("OK")
+                .withBody("[]")
+                .withHeader("content-type", "application/json")
+                .build();
+        assertThat(originalResponseDefinition.getJsonBody(), equalTo(Json.node("[]")));
+    }
+
+    
+    @Test 
+    public void proxyResponseDefinitionWithJsonContentType3() {
+        ResponseDefinition originalResponseDefinition = ResponseDefinitionBuilder.responseDefinition()
+                .withStatus(200)
+                .withStatusMessage("OK")
+                .withBody("Hello,world!")
+                .withHeader("content-type", "application/json")
+                .build();
+        assertThat(originalResponseDefinition.getJsonBody(), equalTo(null));
+        assertThat(originalResponseDefinition.getBody(), equalTo("Hello,world!"));
+    }
+    
+    @Test 
+    public void proxyResponseDefinitionWithJsonContentType4() {
+        ResponseDefinition originalResponseDefinition = ResponseDefinitionBuilder.responseDefinition()
+                .withStatus(200)
+                .withStatusMessage("OK")
+                .withBody("{}")
+                .build();
+        assertThat(originalResponseDefinition.getJsonBody(), equalTo(null));
+        assertThat(originalResponseDefinition.getBody(), equalTo("{}"));
+    }
 }


### PR DESCRIPTION
Try to convert string body to json body if the value of content-type header contains 'json'. 
It will solve the Enhancement #1399: On record save JSON data as jsonBody.