### PR TITLE
docs: Fix example Gradle configuration

### DIFF
--- a/docs-v2/_docs/download-and-installation.md
+++ b/docs-v2/_docs/download-and-installation.md
@@ -74,25 +74,25 @@ Java 7 standalone (deprecated):
 Java 8:
 
 ```groovy
-testImplementation "com.github.tomakehurst:wiremock:{{ site.wiremock_version }}"
+testImplementation "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
 ```
 
 Java 8 standalone:
 
 ```groovy
-testImplementation "com.github.tomakehurst:wiremock-standalone:{{ site.wiremock_version }}"
+testImplementation "com.github.tomakehurst:wiremock-jre8-standalone:{{ site.wiremock_version }}"
 ```
 
 Java 7 (deprecated):
 
 ```groovy
-testImplementation "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
+testImplementation "com.github.tomakehurst:wiremock:2.27.2"
 ```
 
 Java 7 standalone (deprecated):
 
 ```groovy
-testImplementation "com.github.tomakehurst:wiremock-jre8-standalone:{{ site.wiremock_version }}"
+testImplementation "com.github.tomakehurst:wiremock-standalone:2.27.2"
 ```
 
 ## Direct download


### PR DESCRIPTION
Currently, the instructions for using WireMock with Gradle are incorrect. The Java 8 and deprecated Java 7 artifacts are swapped, and the deprecated Java 7 artifact uses the current version (when it should end at 2.27.2). 

This PR corrects this, so the Gradle instructions match the Maven instructions. 

Please let me know if there is anything else I need to do (like running the `gen-docs.sh` script?), or if this PR is otherwise unacceptable for some reason. 

I know this is a small thing, but I've seen people pull in the old Java 7 artifact when copy-pasting from here on a new project. 