### PR TITLE
Speed up contentTypeHeader, getHeader

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -174,37 +174,28 @@ public class WireMockHttpServletRequestAdapter implements Request {
   @SuppressWarnings("unchecked")
   @Override
   public String getHeader(String key) {
-    List<String> headerNames = list(request.getHeaderNames());
-    for (String currentKey : headerNames) {
-      if (currentKey.equalsIgnoreCase(key)) {
-        return request.getHeader(currentKey);
-      }
-    }
-
-    return null;
+    return request.getHeader(key); // case-insensitive per javadoc
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public HttpHeader header(String key) {
-    List<String> headerNames = list(request.getHeaderNames());
-    for (String currentKey : headerNames) {
-      if (currentKey.equalsIgnoreCase(key)) {
-        List<String> valueList = list(request.getHeaders(currentKey));
-        if (valueList.isEmpty()) {
-          return HttpHeader.empty(key);
-        }
-
-        return new HttpHeader(key, valueList);
+    if (request.getHeader(key) == null) {
+      return HttpHeader.absent(key);
+    } else {
+      List<String> valueList = list(request.getHeaders(key));
+      if (valueList.isEmpty()) {
+        return HttpHeader.empty(key);
       }
-    }
 
-    return HttpHeader.absent(key);
+      return new HttpHeader(key, valueList);
+    }
   }
 
   @Override
   public ContentTypeHeader contentTypeHeader() {
-    return getHeaders().getContentTypeHeader();
+    String firstValue = getHeader(ContentTypeHeader.KEY);
+    return firstValue == null ? ContentTypeHeader.absent() : new ContentTypeHeader(firstValue);
   }
 
   @Override


### PR DESCRIPTION
## Summary
Speeds up `contentTypeHeader` and `getHeader` by avoiding intermediate `HashSet`s, `Enumeration`s, and `ArrayList`s.

## Details
21% of CPU time in my benchmark is spent in `WireMockHttpServletRequestAdapter.contentTypeHeader`. Current implementation creates multiple intermediate collections of _all_ the header names in order to fish out the case-insensitive version of the single header we're interested in.

Per the [servlet 3 javadocs](https://github.com/javaee/servlet-spec/blob/3.1.0/src/main/java/javax/servlet/http/HttpServletRequest.java#L171-L172), `getHeader(String)` is case-insensitive and should be able to get us what we need directly. I've verified that jetty 9's behavior seems to conform to the spec.

![Screen Shot 2022-01-07 at 8 32 34 PM](https://user-images.githubusercontent.com/663139/148626455-c2c73667-8872-4611-9165-206dba8d4ddd.png)

![Screen Shot 2022-01-07 at 8 22 45 PM](https://user-images.githubusercontent.com/663139/148626452-9392eba7-3f57-453b-a95f-04ced7dc5112.png)

cc: @avinashanne @sumerjoshi