### PR TITLE
perf: Avoid double parsing response JSON body

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -103,7 +103,7 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer
             .build();
 
     if (responseDefinition.specifiesTextBodyContent()) {
-      boolean isJsonBody = responseDefinition.getJsonBody() != null;
+      boolean isJsonBody = responseDefinition.isJsonBody();
       HandlebarsOptimizedTemplate bodyTemplate =
           templateEngine.getTemplate(
               HttpTemplateCacheKey.forInlineBody(responseDefinition),

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -103,7 +103,7 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer
             .build();
 
     if (responseDefinition.specifiesTextBodyContent()) {
-      boolean isJsonBody = responseDefinition.isJsonBody();
+      boolean isJsonBody = responseDefinition.getReponseBody().isJson();
       HandlebarsOptimizedTemplate bodyTemplate =
           templateEngine.getTemplate(
               HttpTemplateCacheKey.forInlineBody(responseDefinition),

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Thomas Akehurst
+ * Copyright (C) 2011-2022 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -353,6 +353,10 @@ public class ResponseDefinition {
 
   public String getBase64Body() {
     return body.isBinary() ? body.asBase64() : null;
+  }
+
+  public boolean isJsonBody() {
+    return body.isJson();
   }
 
   public JsonNode getJsonBody() {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -355,8 +355,9 @@ public class ResponseDefinition {
     return body.isBinary() ? body.asBase64() : null;
   }
 
-  public boolean isJsonBody() {
-    return body.isJson();
+  @JsonIgnore
+  public Body getReponseBody() {
+    return body;
   }
 
   public JsonNode getJsonBody() {


### PR DESCRIPTION
For a single request, we're double parsing the JSON body. The flame graph below shows an 18 KB JSON response--not particularly large. Eliminating the double parsing would cut out ~25% of the work.

![ResponseDefinition getJsonBody](https://user-images.githubusercontent.com/663139/150100524-102637a8-b08f-47af-8b9e-b2d1ced654e4.png)

