### PR TITLE
No error when data is stored in an encoding other than UTF8

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/trafficlistener/ConsoleNotifyingWiremockNetworkTrafficListener.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/trafficlistener/ConsoleNotifyingWiremockNetworkTrafficListener.java
@@ -16,18 +16,24 @@
 package com.github.tomakehurst.wiremock.http.trafficlistener;
 
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 
 public class ConsoleNotifyingWiremockNetworkTrafficListener
     implements WiremockNetworkTrafficListener {
   private static final ConsoleNotifier CONSOLE_NOTIFIER = new ConsoleNotifier(true);
 
-  private final Charset charset = Charset.forName("UTF-8");
-  private final CharsetDecoder decoder = charset.newDecoder();
+  private static final Charset CHARSET = StandardCharsets.UTF_8;
+  private static final CharsetDecoder DECODER_DEFAULT = CHARSET.newDecoder();
+  private static final CharsetDecoder DECODER_REPLACE = CHARSET.newDecoder()
+      .onMalformedInput(CodingErrorAction.REPLACE)
+      .onUnmappableCharacter(CodingErrorAction.REPLACE);
 
   @Override
   public void opened(Socket socket) {
@@ -36,24 +42,32 @@ public class ConsoleNotifyingWiremockNetworkTrafficListener
 
   @Override
   public void incoming(Socket socket, ByteBuffer bytes) {
-    try {
-      CONSOLE_NOTIFIER.info("Incoming bytes: " + decoder.decode(bytes));
-    } catch (CharacterCodingException e) {
-      CONSOLE_NOTIFIER.error("Problem decoding network traffic", e);
-    }
+    notifyBytes("incoming", bytes);
   }
 
   @Override
   public void outgoing(Socket socket, ByteBuffer bytes) {
-    try {
-      CONSOLE_NOTIFIER.info("Outgoing bytes: " + decoder.decode(bytes));
-    } catch (CharacterCodingException e) {
-      CONSOLE_NOTIFIER.error("Problem decoding network traffic", e);
-    }
+    notifyBytes("outgoing", bytes);
   }
 
   @Override
   public void closed(Socket socket) {
     CONSOLE_NOTIFIER.info("Closed " + socket);
+  }
+
+  public static String decodeBytes(ByteBuffer bytes) throws CharacterCodingException {
+    try {
+      return DECODER_DEFAULT.decode(bytes).toString();
+    } catch (CharacterCodingException e) {
+      return "(erroneous bytes dropped) " + DECODER_REPLACE.decode(bytes).toString();
+    }
+  }
+
+  private void notifyBytes(String type, ByteBuffer bytes) {
+    try {
+      CONSOLE_NOTIFIER.info(type + " bytes: " + decodeBytes(bytes));
+    } catch (CharacterCodingException e) {
+      CONSOLE_NOTIFIER.error("Problem decoding " + type + " network traffic. ", e);
+    }
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/trafficlistener/ConsoleNotifyingWiremockNetworkTrafficListenerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/trafficlistener/ConsoleNotifyingWiremockNetworkTrafficListenerTest.java
@@ -1,0 +1,48 @@
+package com.github.tomakehurst.wiremock.http.trafficlistener;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class ConsoleNotifyingWiremockNetworkTrafficListenerTest {
+
+    @Test
+    void decodeBytes() throws CharacterCodingException {
+        String inputStr = "hello world";
+        byte[] helloWorldBytes = inputStr.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer input = ByteBuffer.wrap(helloWorldBytes);
+        String actual = ConsoleNotifyingWiremockNetworkTrafficListener.decodeBytes(input);
+        assertThat(actual, is(inputStr));
+    }
+
+    @Test
+    void decodeBytesForUtf8() throws CharacterCodingException {
+        String inputStr = "hello ക world";
+        ByteBuffer input = ByteBuffer.wrap(inputStr.getBytes(StandardCharsets.UTF_8));
+        String actual = ConsoleNotifyingWiremockNetworkTrafficListener.decodeBytes(input);
+        assertThat(actual, is(inputStr));
+    }
+
+    @Test
+    void decodeBytesForUtf16() throws CharacterCodingException {
+        String inputStr = "hello ക world";
+        byte[] inputBytes = inputStr.getBytes(StandardCharsets.UTF_16);
+        ByteBuffer input = ByteBuffer.wrap(inputBytes);
+        String inputAsUtf8 = new String(inputBytes, StandardCharsets.UTF_8);
+        String actual = ConsoleNotifyingWiremockNetworkTrafficListener.decodeBytes(input);
+        assertThat(actual, is("(erroneous bytes dropped) " + inputAsUtf8));
+    }
+
+    @Test
+    void decodeBytesIncorrect() throws CharacterCodingException {
+        byte[] incorrect = {(byte) 'H', -75, -75, -75, (byte) 'I'};
+        ByteBuffer input = ByteBuffer.wrap(incorrect);
+        String actual = ConsoleNotifyingWiremockNetworkTrafficListener.decodeBytes(input);
+        assertThat(actual, is("(erroneous bytes dropped) ���I"));
+    }
+}


### PR DESCRIPTION
'java.nio.charset.MalformedInputException: Input length = 1' exception

prevents this error:
```
2022-01-20 20:00:11.222 Problem decoding network traffic
java.nio.charset.MalformedInputException: Input length = 1
    at java.base/java.nio.charset.CoderResult.throwException(CoderResult.java:274)
    at java.base/java.nio.charset.CharsetDecoder.decode(CharsetDecoder.java:822)
    at com.github.tomakehurst.wiremock.http.trafficlistener.ConsoleNotifyingWiremockNetworkTrafficListener.incoming(ConsoleNotifyingWiremockNetworkTrafficListener.java:40)
    at com.github.tomakehurst.wiremock.jetty9.JettyHttpServer$NetworkTrafficListenerAdapter.incoming(JettyHttpServer.java:488)
    at wiremock.org.eclipse.jetty.io.NetworkTrafficSocketChannelEndPoint.notifyIncoming(NetworkTrafficSocketChannelEndPoint.java:126)
    at wiremock.org.eclipse.jetty.io.NetworkTrafficSocketChannelEndPoint.fill(NetworkTrafficSocketChannelEndPoint.java:52)
    at wiremock.org.eclipse.jetty.server.HttpConnection.fillRequestBuffer(HttpConnection.java:345)
    at wiremock.org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)
    at wiremock.org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
    at wiremock.org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
    at wiremock.org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
    at wiremock.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
    at wiremock.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
    at wiremock.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
    at wiremock.org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
    at wiremock.org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:383)
    at wiremock.org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:882)
    at wiremock.org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1036)
    at java.base/java.lang.Thread.run(Thread.java:832)
```