### PR TITLE
Describe defaults and precedence of stub priority

### DIFF
--- a/docs-v2/_docs/stubbing.md
+++ b/docs-v2/_docs/stubbing.md
@@ -151,6 +151,8 @@ One example of this might be where you want to define a catch-all stub
 for any URL that doesn't match any more specific cases. Adding a
 priority to a stub mapping facilitates this:
 
+The default priority is 5. A lower number priority overrides stubs with a higher number priority. For instance, a priority of 1 overrides any stubs of priority of 5.
+
 ```java
 //Catch-all case
 stubFor(get(urlMatching("/api/.*")).atPriority(5)


### PR DESCRIPTION
The docs did not describe the precedence and defaults of priority of stubs.

I found that the default for priority is 5:

https://github.com/wiremock/wiremock/blob/60e9e858068548786af4a1a434b52fd1376c4d43/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java#L37

The code example seemed to indicate that lower priority numbers take precedence over stubs with a higher priority number:

https://github.com/wiremock/wiremock/blob/89907f038162f059ec98f8f812831bc6b5c12f44/docs-v2/_docs/stubbing.md?plain=1#L160