### PR TITLE
perf: Avoid unnecessary intermediate `JsonNode`

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -103,7 +103,7 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer
             .build();
 
     if (responseDefinition.specifiesTextBodyContent()) {
-      boolean isJsonBody = responseDefinition.getJsonBody() != null;
+      boolean isJsonBody = responseDefinition.isJsonBody();
       HandlebarsOptimizedTemplate bodyTemplate =
           templateEngine.getTemplate(
               HttpTemplateCacheKey.forInlineBody(responseDefinition),

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -17,25 +17,21 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.common.FileSource;
-import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.TextFile;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
 import com.github.tomakehurst.wiremock.extension.StubLifecycleListener;
-import com.github.tomakehurst.wiremock.http.HttpHeader;
-import com.github.tomakehurst.wiremock.http.HttpHeaders;
-import com.github.tomakehurst.wiremock.http.Request;
-import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -200,12 +196,12 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer
       ImmutableMap<String, Object> model,
       HandlebarsOptimizedTemplate bodyTemplate,
       boolean isJsonBody) {
-    String newBody = uncheckedApplyTemplate(bodyTemplate, model);
-    if (isJsonBody) {
-      newResponseDefBuilder.withJsonBody(Json.read(newBody, JsonNode.class));
-    } else {
-      newResponseDefBuilder.withBody(newBody);
-    }
+    String bodyString = uncheckedApplyTemplate(bodyTemplate, model);
+    Body body =
+        isJsonBody
+            ? Body.fromJsonBytes(bodyString.getBytes(StandardCharsets.UTF_8))
+            : Body.fromOneOf(null, bodyString, null, null);
+    newResponseDefBuilder.withResponseBody(body);
   }
 
   private String uncheckedApplyTemplate(HandlebarsOptimizedTemplate template, Object context) {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -103,7 +103,7 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer
             .build();
 
     if (responseDefinition.specifiesTextBodyContent()) {
-      boolean isJsonBody = responseDefinition.isJsonBody();
+      boolean isJsonBody = responseDefinition.getReponseBody().isJson();
       HandlebarsOptimizedTemplate bodyTemplate =
           templateEngine.getTemplate(
               HttpTemplateCacheKey.forInlineBody(responseDefinition),

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Thomas Akehurst
+ * Copyright (C) 2015-2022 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,12 @@ public class Body {
     json = false;
   }
 
+  private Body(byte[] content, boolean binary, boolean json) {
+    this.content = content;
+    this.binary = binary;
+    this.json = json;
+  }
+
   public Body(String content) {
     this.content = Strings.bytesFromString(content);
     binary = false;
@@ -57,6 +63,10 @@ public class Body {
 
   static Body fromBytes(byte[] bytes) {
     return bytes != null ? new Body(bytes) : none();
+  }
+
+  public static Body fromJsonBytes(byte[] bytes) {
+    return bytes != null ? new Body(bytes, false, true) : none();
   }
 
   static Body fromString(String str) {
@@ -77,8 +87,10 @@ public class Body {
     return none();
   }
 
+  private static final Body EMPTY_BODY = new Body((byte[]) null);
+
   public static Body none() {
-    return new Body((byte[]) null);
+    return EMPTY_BODY;
   }
 
   public String asString() {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Thomas Akehurst
+ * Copyright (C) 2011-2022 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -353,6 +353,10 @@ public class ResponseDefinition {
 
   public String getBase64Body() {
     return body.isBinary() ? body.asBase64() : null;
+  }
+
+  public boolean isJsonBody() {
+    return body.isJson();
   }
 
   public JsonNode getJsonBody() {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -355,8 +355,9 @@ public class ResponseDefinition {
     return body.isBinary() ? body.asBase64() : null;
   }
 
-  public boolean isJsonBody() {
-    return body.isJson();
+  @JsonIgnore
+  public Body getReponseBody() {
+    return body;
   }
 
   public JsonNode getJsonBody() {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -128,7 +128,7 @@ public class ResponseDefinition {
         wasConfigured);
   }
 
-  private ResponseDefinition(
+  public ResponseDefinition(
       int status,
       String statusMessage,
       Body body,


### PR DESCRIPTION
This is the more aggressive version of https://github.com/wiremock/wiremock/pull/1772 that eliminates _all four_ major stacks in the flame graph below--not just the highlighted ones.

Dealing in terms of `Body` as a first-class entity separates out concerns nicely. PR diff is LOC negative already, but we could also delete `ResponseDefinitionBuilder.with...Body(...)`, `ResponseDefinition.get...Body`, and `ResponseDefinition(..., bytes[] body, ...)` if you don't mind the breaking API changes. We could also deprecate them for a while, or just leave them as is. Let me know your preference.

I'm already enjoying the performance benefits of this change via `ResponseDefinition.class.getDeclaredField("body").setAccessible(true)` etc., but it'd be nice to switch back to public APIs.

![ResponseDefinition getJsonBody](https://user-images.githubusercontent.com/663139/150100524-102637a8-b08f-47af-8b9e-b2d1ced654e4.png)
