### PR TITLE
Fix null-valued headers

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -215,7 +215,11 @@ public class WireMockHttpServletRequestAdapter implements Request {
     org.eclipse.jetty.server.Request jettyRequest = (org.eclipse.jetty.server.Request) request;
     List<HttpHeader> headers =
         jettyRequest.getHttpFields().stream()
-            .map(field -> HttpHeader.httpHeader(field.getName(), field.getValue()))
+            .map(
+                field ->
+                    field.getValue() == null
+                        ? HttpHeader.empty(field.getName())
+                        : HttpHeader.httpHeader(field.getName(), field.getValue()))
             .collect(Collectors.toList());
     return new HttpHeaders(headers);
   }


### PR DESCRIPTION
Found a bug with null-valued headers introduced in https://github.com/wiremock/wiremock/pull/1791.