### PR TITLE
Reduce threshold for flakey test

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/direct/DirectCallHttpServerIntegrationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/direct/DirectCallHttpServerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2022 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ class DirectCallHttpServerIntegrationTest {
     stopwatch.stop();
 
     assertEquals(200, response.getStatus());
-    assertThat(stopwatch.elapsed(MILLISECONDS), greaterThanOrEqualTo(500L));
+    assertThat(stopwatch.elapsed(MILLISECONDS), greaterThanOrEqualTo(499L));
   }
 
   @Test


### PR DESCRIPTION
We're seeing this test failing quite a bit, in cases where the delay is
499ms instead of 500ms, and therefore failing.

To avoid this, we can instead reduce the threshold to >= 499ms, and give
us a bit of breathing room for us to remediate this longer-term.
