### PR TITLE
Lint: remove `static` locking of `GuavaBase64Encoder`

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/Encoding.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Encoding.java
@@ -19,25 +19,12 @@ import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.Base64;
 
 public class Encoding {
 
-  private static Base64Encoder encoder = null;
-
-  private static Base64Encoder getInstance() {
-    if (encoder == null) {
-      synchronized (Encoding.class) {
-        if (encoder == null) {
-          encoder = new GuavaBase64Encoder();
-        }
-      }
-    }
-
-    return encoder;
-  }
-
   public static byte[] decodeBase64(String base64) {
-    return base64 != null ? getInstance().decode(base64) : null;
+    return base64 != null ? Base64.getDecoder().decode(base64) : null;
   }
 
   public static String encodeBase64(byte[] content) {
@@ -45,7 +32,9 @@ public class Encoding {
   }
 
   public static String encodeBase64(byte[] content, boolean padding) {
-    return content != null ? getInstance().encode(content, padding) : null;
+    Base64.Encoder encoder = getEncoder(padding);
+
+    return content != null ? encoder.encodeToString(content) : null;
   }
 
   public static String urlEncode(String unencodedUrl) {
@@ -53,6 +42,14 @@ public class Encoding {
       return URLEncoder.encode(unencodedUrl, "utf-8");
     } catch (UnsupportedEncodingException e) {
       return throwUnchecked(e, String.class);
+    }
+  }
+
+  private static Base64.Encoder getEncoder(boolean padding) {
+    if (!padding) {
+      return Base64.getEncoder().withoutPadding();
+    } else {
+      return Base64.getEncoder();
     }
   }
 }


### PR DESCRIPTION
As highlighted by SonarQube, this isn't the most ideal way of setting
this up.

Instead of restoring it, we can instead replace this with
`java.util.Base64`, as the Guava encoder isn't part of our public
interface, and we've got access to the core Java package.
