### PR TITLE
Create request entity if content-length is set (#1872)

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -102,7 +102,8 @@ public class ProxyResponseRenderer implements ResponseRenderer {
     addRequestHeaders(httpRequest, responseDefinition);
 
     Request originalRequest = responseDefinition.getOriginalRequest();
-    if (originalRequest.getBody() != null && originalRequest.getBody().length > 0) {
+    if ((originalRequest.getBody() != null && originalRequest.getBody().length > 0)
+        || originalRequest.containsHeader(CONTENT_LENGTH)) {
       httpRequest.setEntity(buildEntityFrom(originalRequest));
     }
     CloseableHttpClient client = buildClient(serveEvent.getRequest().isBrowserProxyRequest());
@@ -229,7 +230,9 @@ public class ProxyResponseRenderer implements ResponseRenderer {
 
     return applyGzipWrapperIfRequired(
         originalRequest,
-        new ByteArrayEntity(originalRequest.getBody(), ContentType.DEFAULT_BINARY));
+        new ByteArrayEntity(
+            originalRequest.getBody(),
+            originalRequest.contentTypeHeader().isPresent() ? contentType : null));
   }
 
   private static HttpEntity applyGzipWrapperIfRequired(


### PR DESCRIPTION
fixes #1872

To enable valid POST requests without a body, an empty entity is required.
Otherwise, the proxy request will not include the header content-length.
Additionally, the content-type will only be set if it is already present
in the originalRequest.
This prevents a new, additional header from being set.