### PR TITLE
Fixed #1897 - Wrong port used on Junit Jupiter nested classes

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2022 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,17 @@ import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.http.JvmProxyConfigurer;
 import com.github.tomakehurst.wiremock.junit.DslWrapper;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.junit.jupiter.api.extension.*;
-import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.platform.commons.util.AnnotationUtils;
 
 /**
  * JUnit Jupiter extension that manages a WireMock server instance's lifecycle and configuration.
  *
- * See http://wiremock.org/docs/junit-jupiter/ for full documentation.
+ * <p>See http://wiremock.org/docs/junit-jupiter/ for full documentation.
  */
 public class WireMockExtension extends DslWrapper
     implements ParameterResolver,
@@ -49,6 +52,10 @@ public class WireMockExtension extends DslWrapper
 
   private Boolean proxyMode;
 
+  private static final String WIRE_MOCK_SERVER_KEY = "wireMockServer";
+  private static final String WIRE_MOCK_RUNTIME_INFO_KEY = "wireMockRuntimeInfo";
+  private static final String PROXY_MODE_KEY = "proxyMode";
+
   public WireMockExtension() {
     configureStaticDsl = true;
     failOnUnmatchedRequests = false;
@@ -57,10 +64,11 @@ public class WireMockExtension extends DslWrapper
   /**
    * Constructor intended for subclasses.
    *
-   * The parameter is a builder so that we can avoid a constructor explosion or
+   * <p>The parameter is a builder so that we can avoid a constructor explosion or
    * backwards-incompatible changes when new options are added.
    *
-   * @param builder a {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder} instance holding the initialisation parameters for the extension.
+   * @param builder a {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *     instance holding the initialisation parameters for the extension.
    */
   protected WireMockExtension(Builder builder) {
     this.options = builder.options;
@@ -81,8 +89,11 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * Alias for {@link #newInstance()} for use with custom subclasses, with a more relevant name for that use.
-   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder} instance.
+   * Alias for {@link #newInstance()} for use with custom subclasses, with a more relevant name for
+   * that use.
+   *
+   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *     instance.
    */
   public static Builder extensionOptions() {
     return newInstance();
@@ -90,7 +101,9 @@ public class WireMockExtension extends DslWrapper
 
   /**
    * Create a new builder for the extension.
-   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder} instance.
+   *
+   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *     instance.
    */
   public static Builder newInstance() {
     return new Builder();
@@ -98,25 +111,35 @@ public class WireMockExtension extends DslWrapper
 
   /**
    * To be overridden in subclasses in order to run code immediately after per-class WireMock setup.
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock instance/
+   *
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onBeforeAll(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
    * To be overridden in subclasses in order to run code immediately after per-test WireMock setup.
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock instance/
+   *
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onBeforeEach(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-test cleanup of WireMock and its associated resources.
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock instance/
+   * To be overridden in subclasses in order to run code immediately after per-test cleanup of
+   * WireMock and its associated resources.
+   *
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onAfterEach(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-class cleanup of WireMock.
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock instance/
+   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
+   * WireMock.
+   *
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onAfterAll(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
@@ -133,49 +156,50 @@ public class WireMockExtension extends DslWrapper
       throws ParameterResolutionException {
 
     if (parameterIsWireMockRuntimeInfo(parameterContext)) {
-      return runtimeInfo;
+      Store store = getStore(extensionContext);
+      return store.get(WIRE_MOCK_RUNTIME_INFO_KEY, WireMockRuntimeInfo.class);
     }
 
     return null;
   }
 
-  private void startServerIfRequired(ExtensionContext extensionContext) {
-    if (wireMockServer == null || !wireMockServer.isRunning()) {
-      wireMockServer = new WireMockServer(resolveOptions(extensionContext));
-      wireMockServer.start();
+  private Store getStore(ExtensionContext extensionContext) {
+    Class<?> clazz =
+        getAnnotatedClass(extensionContext)
+            .orElseThrow(() -> new NoSuchElementException("No value present"));
+    return extensionContext.getStore(Namespace.create(getClass(), clazz));
+  }
 
-      runtimeInfo = new WireMockRuntimeInfo(wireMockServer);
-
-      this.admin = wireMockServer;
-      this.stubbing = wireMockServer;
-
-      if (configureStaticDsl) {
-        WireMock.configureFor(new WireMock(this));
+  private Optional<Class<?>> getAnnotatedClass(ExtensionContext extensionContext) {
+    Optional<ExtensionContext> current = Optional.of(extensionContext);
+    while (current.isPresent()) {
+      Optional<Class<?>> clazz = current.get().getTestClass();
+      if (AnnotationUtils.isAnnotated(clazz, WireMockTest.class)) {
+        return Optional.of(clazz.get());
       }
+      current = current.get().getParent();
     }
+    return Optional.empty();
   }
 
-  private void setAdditionalOptions(ExtensionContext extensionContext) {
-    if (proxyMode == null) {
-      proxyMode =
-          extensionContext
-              .getElement()
-              .flatMap(
-                  annotatedElement ->
-                      AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class))
-              .<Boolean>map(WireMockTest::proxyMode)
-              .orElse(false);
+  private Optional<WireMockTest> getWireMockTestAnnotation(ExtensionContext extensionContext) {
+    Optional<Class<?>> clazz = getAnnotatedClass(extensionContext);
+    if (!clazz.isPresent()) {
+      return Optional.empty();
     }
+
+    return AnnotationUtils.findAnnotation(clazz.get(), WireMockTest.class);
   }
 
-  private Options resolveOptions(ExtensionContext extensionContext) {
-    return extensionContext
-        .getElement()
-        .flatMap(
-            annotatedElement ->
-                AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class))
-        .<Options>map(this::buildOptionsFromWireMockTestAnnotation)
-        .orElse(Optional.ofNullable(this.options).orElse(DEFAULT_OPTIONS));
+  private WireMockServer startServer(Options options) {
+    WireMockServer wireMockServer = new WireMockServer(options);
+    wireMockServer.start();
+
+    this.wireMockServer = wireMockServer;
+    this.admin = wireMockServer;
+    this.stubbing = wireMockServer;
+
+    return wireMockServer;
   }
 
   private Options buildOptionsFromWireMockTestAnnotation(WireMockTest annotation) {
@@ -191,9 +215,15 @@ public class WireMockExtension extends DslWrapper
     return options;
   }
 
-  private void stopServerIfRunning() {
+  private void stopServerIfRunning(WireMockServer wireMockServer) {
     if (wireMockServer.isRunning()) {
       wireMockServer.stop();
+    }
+  }
+
+  private void startServerIfNotRunning(WireMockServer wireMockServer) {
+    if (!wireMockServer.isRunning()) {
+      wireMockServer.start();
     }
   }
 
@@ -203,22 +233,86 @@ public class WireMockExtension extends DslWrapper
 
   @Override
   public final void beforeAll(ExtensionContext context) throws Exception {
-    startServerIfRequired(context);
-    setAdditionalOptions(context);
+    Optional<WireMockTest> wireMockTestAnnotation = getWireMockTestAnnotation(context);
+
+    WireMockRuntimeInfo runtimeInfo = null;
+    if (wireMockTestAnnotation.isPresent()) {
+      Options options =
+          wireMockTestAnnotation
+              .<Options>map(this::buildOptionsFromWireMockTestAnnotation)
+              .orElse(DEFAULT_OPTIONS);
+
+      Store store = getStore(context);
+      WireMockServer wireMockServer =
+          store.getOrComputeIfAbsent(
+              WIRE_MOCK_SERVER_KEY, (key) -> startServer(options), WireMockServer.class);
+
+      runtimeInfo =
+          store.getOrComputeIfAbsent(
+              WIRE_MOCK_RUNTIME_INFO_KEY,
+              (key) -> new WireMockRuntimeInfo(wireMockServer),
+              WireMockRuntimeInfo.class);
+
+      boolean proxyMode =
+          store.getOrComputeIfAbsent(
+              PROXY_MODE_KEY,
+              (key) -> wireMockTestAnnotation.<Boolean>map(WireMockTest::proxyMode).orElse(false),
+              boolean.class);
+
+      this.options = options;
+      this.runtimeInfo = runtimeInfo;
+      this.proxyMode = proxyMode;
+    } else {
+      if (this.wireMockServer == null) {
+        Options options = Optional.ofNullable(this.options).orElse(DEFAULT_OPTIONS);
+        startServer(options);
+        runtimeInfo = new WireMockRuntimeInfo(wireMockServer);
+        this.options = options;
+        this.runtimeInfo = runtimeInfo;
+      } else {
+        startServerIfNotRunning(this.wireMockServer);
+        runtimeInfo = this.runtimeInfo;
+      }
+    }
 
     onBeforeAll(runtimeInfo);
   }
 
   @Override
   public final void beforeEach(ExtensionContext context) throws Exception {
-    if (wireMockServer == null) {
-      isNonStatic = true;
-      startServerIfRequired(context);
-    } else {
-      resetToDefaultMappings();
-    }
+    Optional<WireMockTest> wireMockTestAnnotation = getWireMockTestAnnotation(context);
 
-    setAdditionalOptions(context);
+    WireMockServer wireMockServer = null;
+    WireMockRuntimeInfo runtimeInfo = null;
+    boolean proxyMode = false;
+    if (wireMockTestAnnotation.isPresent()) {
+      Store store = getStore(context);
+      wireMockServer = store.get(WIRE_MOCK_SERVER_KEY, WireMockServer.class);
+      runtimeInfo = store.get(WIRE_MOCK_RUNTIME_INFO_KEY, WireMockRuntimeInfo.class);
+      proxyMode = store.get(PROXY_MODE_KEY, boolean.class);
+
+      startServerIfNotRunning(wireMockServer);
+      wireMockServer.resetToDefaultMappings();
+
+      WireMock.configureFor(new WireMock(wireMockServer));
+    } else {
+      if (this.wireMockServer == null) {
+        isNonStatic = true;
+        Options options = Optional.ofNullable(this.options).orElse(DEFAULT_OPTIONS);
+        wireMockServer = startServer(options);
+        runtimeInfo = new WireMockRuntimeInfo(wireMockServer);
+        this.options = options;
+        this.runtimeInfo = runtimeInfo;
+      } else {
+        startServerIfNotRunning(this.wireMockServer);
+        wireMockServer = this.wireMockServer;
+        resetToDefaultMappings();
+      }
+      proxyMode = this.proxyMode;
+      if (configureStaticDsl) {
+        WireMock.configureFor(new WireMock(wireMockServer));
+      }
+    }
 
     if (proxyMode) {
       JvmProxyConfigurer.configureFor(wireMockServer);
@@ -229,19 +323,50 @@ public class WireMockExtension extends DslWrapper
 
   @Override
   public final void afterAll(ExtensionContext context) throws Exception {
-    stopServerIfRunning();
+    Optional<WireMockTest> wireMockTestAnnotation = getWireMockTestAnnotation(context);
+
+    WireMockServer wireMockServer = null;
+    WireMockRuntimeInfo runtimeInfo = null;
+
+    if (wireMockTestAnnotation.isPresent()) {
+      Store store = getStore(context);
+      wireMockServer = store.get(WIRE_MOCK_SERVER_KEY, WireMockServer.class);
+      runtimeInfo = store.get(WIRE_MOCK_RUNTIME_INFO_KEY, WireMockRuntimeInfo.class);
+    } else {
+      wireMockServer = this.wireMockServer;
+      runtimeInfo = this.runtimeInfo;
+    }
+
+    stopServerIfRunning(wireMockServer);
 
     onAfterAll(runtimeInfo);
   }
 
   @Override
   public final void afterEach(ExtensionContext context) throws Exception {
+    Optional<WireMockTest> wireMockTestAnnotation = getWireMockTestAnnotation(context);
+
+    WireMockServer wireMockServer = null;
+    WireMockRuntimeInfo runtimeInfo = null;
+    boolean proxyMode = false;
+
+    if (wireMockTestAnnotation.isPresent()) {
+      Store store = getStore(context);
+      wireMockServer = store.get(WIRE_MOCK_SERVER_KEY, WireMockServer.class);
+      runtimeInfo = store.get(WIRE_MOCK_RUNTIME_INFO_KEY, WireMockRuntimeInfo.class);
+      proxyMode = store.get(PROXY_MODE_KEY, boolean.class);
+    } else {
+      wireMockServer = this.wireMockServer;
+      runtimeInfo = this.runtimeInfo;
+      proxyMode = this.proxyMode;
+    }
+
     if (failOnUnmatchedRequests) {
       wireMockServer.checkForUnmatchedRequests();
     }
 
     if (isNonStatic) {
-      stopServerIfRunning();
+      stopServerIfRunning(wireMockServer);
     }
 
     if (proxyMode) {

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionProgrammaticWithNestedTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionProgrammaticWithNestedTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2021-2022 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.junit5;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class JUnitJupiterExtensionProgrammaticWithNestedTest {
+
+  @RegisterExtension
+  static WireMockExtension wm1 =
+      WireMockExtension.newInstance()
+          .options(wireMockConfig().port(8765))
+          .configureStaticDsl(true)
+          .build();
+
+  CloseableHttpClient client;
+
+  @BeforeEach
+  void init() {
+    client = HttpClientFactory.createClient();
+  }
+
+  @Test
+  void runs_on_the_supplied_port() throws Exception {
+    WireMockRuntimeInfo wm1RuntimeInfo = wm1.getRuntimeInfo();
+    assertThat(wm1RuntimeInfo.getHttpPort(), is(8765));
+
+    stubFor(get("/wm1").willReturn(ok()));
+    HttpGet request = new HttpGet(wm1RuntimeInfo.getHttpBaseUrl() + "/wm1");
+    try (CloseableHttpResponse response = client.execute(request)) {
+      assertThat(response.getCode(), is(200));
+    }
+  }
+
+  @Nested
+  class RunsOn8766 {
+    @RegisterExtension
+    WireMockExtension wm2 =
+        WireMockExtension.newInstance().options(wireMockConfig().port(8766)).build();
+
+    @Test
+    void runs_on_the_supplied_port() throws Exception {
+      WireMockRuntimeInfo wm1RuntimeInfo = wm1.getRuntimeInfo();
+      assertThat(wm1RuntimeInfo.getHttpPort(), is(8765));
+
+      stubFor(get("/wm1").willReturn(ok()));
+      HttpGet request1 = new HttpGet(wm1RuntimeInfo.getHttpBaseUrl() + "/wm1");
+      try (CloseableHttpResponse response = client.execute(request1)) {
+        assertThat(response.getCode(), is(200));
+      }
+
+      WireMockRuntimeInfo wm2RuntimeInfo = wm2.getRuntimeInfo();
+      assertThat(wm2RuntimeInfo.getHttpPort(), is(8766));
+
+      wm2.stubFor(get("/wm2").willReturn(ok()));
+      HttpGet request2 = new HttpGet(wm2RuntimeInfo.getHttpBaseUrl() + "/wm2");
+      try (CloseableHttpResponse response = client.execute(request2)) {
+        assertThat(response.getCode(), is(200));
+      }
+    }
+  }
+
+  private String getContent(String url) throws Exception {
+    try (CloseableHttpResponse response = client.execute(new HttpGet(url))) {
+      return EntityUtils.toString(response.getEntity());
+    }
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JunitJupiterExtensionDeclarativeWithConfiguredNestedTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JunitJupiterExtensionDeclarativeWithConfiguredNestedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2022 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,15 @@ class JunitJupiterExtensionDeclarativeWithConfiguredNestedTest {
     @Test
     void runs_on_the_supplied_port(WireMockRuntimeInfo wmRuntimeInfo) {
       assertThat(wmRuntimeInfo.getHttpPort(), is(8767));
+    }
+
+    @Nested
+    @WireMockTest(httpPort = 8768)
+    class RunsOn8768 {
+      @Test
+      void runs_on_the_supplied_port(WireMockRuntimeInfo wmRuntimeInfo) {
+        assertThat(wmRuntimeInfo.getHttpPort(), is(8768));
+      }
     }
   }
 


### PR DESCRIPTION
Fixed a bug where incorrect ports are used in test cases where nested classes exist and each class has a different `@WireMockTest` annotation.

Even if there are multiple `@WireMockTest` annotations, the above problem occurs because only one instance of `WireMockExtension` is created.
This problem is solved by managing WireMock Server for each class using `ExtensionContext.Store`.

Issue: https://github.com/wiremock/wiremock/issues/1897

