### PR TITLE
Make the testlogging maven project build

### DIFF
--- a/testlogging/pom.xml
+++ b/testlogging/pom.xml
@@ -10,22 +10,19 @@
 
   <properties>
     <slf4jversion>1.7.1</slf4jversion>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <project.resources.sourceEncoding>UTF-8</project.resources.sourceEncoding>
   </properties>
-
-  <repositories>
-    <repository>
-      <id>version99</id>
-      <url>https://version99.qos.ch/</url>
-    </repository>
-  </repositories>
 
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>
@@ -49,8 +46,8 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock</artifactId>
-      <version>1.30</version>
+      <artifactId>wiremock-jre8</artifactId>
+      <version>2.33.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -81,18 +78,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
       <version>${slf4jversion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>99-empty</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>99-empty</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/testlogging/src/test/java/WiremockTest.java
+++ b/testlogging/src/test/java/WiremockTest.java
@@ -12,9 +12,10 @@ import java.io.PrintStream;
 import java.net.URL;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class WiremockTest {
 
@@ -43,9 +44,9 @@ public class WiremockTest {
         URL uri = new URL("http://localhost:8080/blah");
         InputStream content = uri.openConnection().getInputStream();
 
-        final String retrievedBody = IOUtils.toString(content);
+        final String retrievedBody = IOUtils.toString(content, UTF_8);
         assertEquals("body", retrievedBody);
-        assertThat(stdOutCapture.toString(), containsString("c.g.t.wiremock.common.Log4jNotifier - Received request to /mappings/new"));
+        assertThat(stdOutCapture.toString(), containsString("INFO  o.e.j.s.h.ContextHandler.__admin - RequestHandlerClass from context returned com.github.tomakehurst.wiremock.http.AdminRequestHandler"));
     }
 
     private static class StringPrintStream extends PrintStream {


### PR DESCRIPTION
version99.qos.ch has been deprecated and the TLS cert has died.

Brought everything up to date.
