### PR TITLE
Run the logging test against standalone

### DIFF
--- a/testlogging/pom.xml
+++ b/testlogging/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <artifactId>wiremock-jre8-standalone</artifactId>
       <version>2.33.2</version>
       <scope>test</scope>
     </dependency>

--- a/testlogging/src/test/java/WiremockTest.java
+++ b/testlogging/src/test/java/WiremockTest.java
@@ -46,7 +46,7 @@ public class WiremockTest {
 
         final String retrievedBody = IOUtils.toString(content, UTF_8);
         assertEquals("body", retrievedBody);
-        assertThat(stdOutCapture.toString(), containsString("INFO  o.e.j.s.h.ContextHandler.__admin - RequestHandlerClass from context returned com.github.tomakehurst.wiremock.http.AdminRequestHandler"));
+        assertThat(stdOutCapture.toString(), containsString("LOGBACK INFO  w.o.e.j.s.h.ContextHandler.__admin - RequestHandlerClass from context returned com.github.tomakehurst.wiremock.http.AdminRequestHandler"));
     }
 
     private static class StringPrintStream extends PrintStream {

--- a/testlogging/src/test/resources/logback-test.xml
+++ b/testlogging/src/test/resources/logback-test.xml
@@ -4,7 +4,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] LOGBACK %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
The whole point is to make sure the standalone jar does not shade the
logging classes.
