### PR TITLE
Downgrade SLF4J to 1.7.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: gradle
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: org.slf4j:*
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     exclude group: 'org.ow2.asm', module: 'asm'
   }
   api "org.ow2.asm:asm:9.3"
-  api "org.slf4j:slf4j-api:2.0.1"
+  api "org.slf4j:slf4j-api:1.7.36"
   api "net.sf.jopt-simple:jopt-simple:5.0.4"
 
   compileOnly("junit:junit:4.13.2") {


### PR DESCRIPTION
Fixes https://github.com/wiremock/wiremock/issues/1964

Versions 1.8.x and 2.x are incompatible with older versions. The vast majority of Java libraries are still using 1.7.x.

This PR downgrades SLF4J to the latest 1.7.x and updates the dependabot configuration to prevent upgrades to the 1.8.x and 2.x versions.