### PR TITLE
Issue 1989: Support Content-Encoding: deflate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/src/main/java/com/github/tomakehurst/wiremock/common/BodyDecompressor.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/BodyDecompressor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.common;
+
+import static com.google.common.net.HttpHeaders.*;
+
+import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
+import com.github.tomakehurst.wiremock.http.Response;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+
+public class BodyDecompressor {
+
+  private static final List<CaseInsensitiveKey> EXCLUDED_HEADERS =
+      ImmutableList.of(
+          CaseInsensitiveKey.from(CONTENT_ENCODING),
+          CaseInsensitiveKey.from(CONTENT_LENGTH),
+          CaseInsensitiveKey.from(TRANSFER_ENCODING));
+  private final byte[] bytes;
+  private final Predicate<HttpHeader> predicate;
+
+  public BodyDecompressor(Response response) {
+    this(response.getBody(), response.getHeaders());
+  }
+
+  public BodyDecompressor(byte[] body, HttpHeaders headers) {
+    if (body != null && body.length > 0 && headers != null) {
+      HttpHeader contentEncoding = headers.getHeader(CONTENT_ENCODING);
+      for (Compression algorithm : Compression.values()) {
+        if (contentEncoding.containsValue(algorithm.contentEncodingValue)) {
+          // Once we decompress the body, we need to remove these headers as they are no longer
+          // correct.
+          bytes = algorithm.decompress(body);
+          predicate = (header) -> !EXCLUDED_HEADERS.contains(header.caseInsensitiveKey());
+          return;
+        }
+      }
+    }
+    predicate = (header) -> true;
+    bytes = body;
+  }
+
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  public boolean shouldRetain(HttpHeader header) {
+    return predicate.test(header);
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Compression.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Compression.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.common;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public enum Compression implements CompressionAlgorithm {
+  GZIP("gzip", new Gzip()),
+  DEFLATE("deflate", new Zlib());
+
+  public final String contentEncodingValue;
+  public final CompressionAlgorithm algorithm;
+
+  Compression(String contentEncodingValue, CompressionAlgorithm algorithm) {
+    this.contentEncodingValue = contentEncodingValue;
+    this.algorithm = algorithm;
+  }
+
+  @Override
+  public InputStream decompressionStream(InputStream source) {
+    return algorithm.decompressionStream(source);
+  }
+
+  @Override
+  public OutputStream compressionStream(OutputStream source) {
+    return algorithm.compressionStream(source);
+  }
+
+  @Override
+  public boolean matches(byte[] bytes) {
+    return algorithm.matches(bytes);
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/common/CompressionAlgorithm.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/CompressionAlgorithm.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.common;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+import static com.github.tomakehurst.wiremock.common.Strings.DEFAULT_CHARSET;
+import static com.github.tomakehurst.wiremock.common.Strings.bytesFromString;
+
+import com.google.common.io.ByteStreams;
+import java.io.*;
+import java.nio.charset.Charset;
+
+public interface CompressionAlgorithm {
+
+  /**
+   * Convert a stream of compressed bytes to decompressed, readable bytes.
+   *
+   * @param source A stream of bytes previously compressed with this compression algorithm.
+   * @return A stream that can be used to convert compressed bytes to decompressed, readable bytes.
+   */
+  InputStream decompressionStream(InputStream source);
+
+  /**
+   * Compress bytes before passing them along to an OutputStream.
+   *
+   * @param outputStream A stream of bytes connected to some output destination.
+   * @return A stream that will compress bytes prior to passing them to outputStream.
+   */
+  OutputStream compressionStream(OutputStream outputStream);
+
+  /**
+   * Detect if bytes, based on their header, match this algorithm. May return false if insufficient
+   * bytes are available.
+   *
+   * @param bytes The bytes to test.
+   * @return true if these bytes have been compressed with this compression algorithm.
+   */
+  boolean matches(byte[] bytes);
+
+  default byte[] decompress(byte[] compressedContent) {
+    if (compressedContent.length == 0) {
+      return new byte[0];
+    }
+    try {
+      InputStream stream = decompressionStream(new ByteArrayInputStream(compressedContent));
+      return ByteStreams.toByteArray(stream);
+    } catch (IOException e) {
+      return throwUnchecked(e, byte[].class);
+    }
+  }
+
+  default String decompressToString(byte[] gzippedContent) {
+    return new String(decompress(gzippedContent));
+  }
+
+  default byte[] compress(byte[] plainContent) {
+    try {
+      ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+      OutputStream stream = compressionStream(bytes);
+      stream.write(plainContent);
+      stream.close();
+      return bytes.toByteArray();
+    } catch (IOException e) {
+      return throwUnchecked(e, byte[].class);
+    }
+  }
+
+  default byte[] compress(String plainContent, Charset charset) {
+    return compress(bytesFromString(plainContent, charset));
+  }
+
+  default byte[] compress(String plainContent) {
+    return compress(plainContent, DEFAULT_CHARSET);
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2022 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,17 +17,15 @@ package com.github.tomakehurst.wiremock.recording;
 
 import static com.github.tomakehurst.wiremock.common.ContentTypes.determineIsTextFromMimeType;
 import static com.google.common.collect.Iterables.filter;
-import static com.google.common.net.HttpHeaders.*;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
-import com.github.tomakehurst.wiremock.common.Gzip;
+import com.github.tomakehurst.wiremock.common.BodyDecompressor;
 import com.github.tomakehurst.wiremock.common.Strings;
-import com.github.tomakehurst.wiremock.http.*;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
+import com.github.tomakehurst.wiremock.http.LoggedResponse;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
 import java.nio.charset.Charset;
-import java.util.List;
 
 /**
  * Transforms a LoggedResponse into a ResponseDefinition, which will be used to construct a
@@ -36,52 +34,28 @@ import java.util.List;
 public class LoggedResponseDefinitionTransformer
     implements Function<LoggedResponse, ResponseDefinition> {
 
-  private static final List<CaseInsensitiveKey> EXCLUDED_HEADERS =
-      ImmutableList.of(
-          CaseInsensitiveKey.from(CONTENT_ENCODING),
-          CaseInsensitiveKey.from(CONTENT_LENGTH),
-          CaseInsensitiveKey.from(TRANSFER_ENCODING));
-
   @Override
   public ResponseDefinition apply(LoggedResponse response) {
     final ResponseDefinitionBuilder responseDefinitionBuilder =
         new ResponseDefinitionBuilder().withStatus(response.getStatus());
 
+    BodyDecompressor decompressor = new BodyDecompressor(response.getBody(), response.getHeaders());
     if (response.getBody() != null && response.getBody().length > 0) {
-
-      byte[] body = bodyDecompressedIfRequired(response);
       String mimeType = response.getMimeType();
       Charset charset = response.getCharset();
       if (determineIsTextFromMimeType(mimeType)) {
-        responseDefinitionBuilder.withBody(Strings.stringFromBytes(body, charset));
+        responseDefinitionBuilder.withBody(
+            Strings.stringFromBytes(decompressor.getBytes(), charset));
       } else {
-        responseDefinitionBuilder.withBody(body);
+        responseDefinitionBuilder.withBody(decompressor.getBytes());
       }
     }
-
     if (response.getHeaders() != null) {
-      responseDefinitionBuilder.withHeaders(withoutContentEncodingAndContentLength(response));
+      HttpHeaders headers =
+          new HttpHeaders(filter(response.getHeaders().all(), decompressor::shouldRetain));
+      responseDefinitionBuilder.withHeaders(headers);
     }
 
     return responseDefinitionBuilder.build();
-  }
-
-  private byte[] bodyDecompressedIfRequired(LoggedResponse response) {
-    if (response.getHeaders() != null
-        && response.getHeaders().getHeader(CONTENT_ENCODING).containsValue("gzip")) {
-      return Gzip.unGzip(response.getBody());
-    }
-    return response.getBody();
-  }
-
-  private HttpHeaders withoutContentEncodingAndContentLength(LoggedResponse response) {
-    return new HttpHeaders(
-        filter(
-            response.getHeaders().all(),
-            new Predicate<HttpHeader>() {
-              public boolean apply(HttpHeader header) {
-                return !EXCLUDED_HEADERS.contains(header.caseInsensitiveKey());
-              }
-            }));
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -26,7 +26,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.io.ByteStreams.toByteArray;
 import static java.util.Collections.list;
 
-import com.github.tomakehurst.wiremock.common.Gzip;
+import com.github.tomakehurst.wiremock.common.Compression;
 import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
 import com.github.tomakehurst.wiremock.http.Cookie;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
@@ -136,15 +136,30 @@ public class WireMockHttpServletRequestAdapter implements Request {
   public byte[] getBody() {
     if (cachedBody == null) {
       try {
-        byte[] body = toByteArray(request.getInputStream());
-        boolean isGzipped = hasGzipEncoding() || Gzip.isGzipped(body);
-        cachedBody = isGzipped ? Gzip.unGzip(body) : body;
+        cachedBody = decodeBody();
       } catch (IOException ioe) {
         throw new RuntimeException(ioe);
       }
     }
-
     return cachedBody;
+  }
+
+  private byte[] decodeBody() throws IOException {
+    byte[] body = toByteArray(request.getInputStream());
+    String encodingHeader = request.getHeader("Content-Encoding");
+    if (encodingHeader != null) {
+      for (Compression compression : Compression.values()) {
+        if (encodingHeader.contains(compression.contentEncodingValue)) {
+          return compression.decompress(body);
+        }
+      }
+    }
+    for (Compression compression : Compression.values()) {
+      if (compression.matches(body)) {
+        return compression.decompress(body);
+      }
+    }
+    return body;
   }
 
   private Charset encodingFromContentTypeHeaderOrUtf8() {
@@ -153,11 +168,6 @@ public class WireMockHttpServletRequestAdapter implements Request {
       return contentTypeHeader.charset();
     }
     return UTF_8;
-  }
-
-  private boolean hasGzipEncoding() {
-    String encodingHeader = request.getHeader("Content-Encoding");
-    return encodingHeader != null && encodingHeader.contains("gzip");
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Thomas Akehurst
+ * Copyright (C) 2011-2022 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.matching.*;
 import com.github.tomakehurst.wiremock.verification.VerificationResult;
-import com.google.common.base.Predicate;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
@@ -142,7 +141,8 @@ public class StubMappingJsonRecorder implements RequestListener {
   private void writeToMappingAndBodyFile(
       Request request, Response response, RequestPattern requestPattern) {
     String fileId = idGenerator.generate();
-    byte[] body = bodyDecompressedIfRequired(response);
+    BodyDecompressor decompressor = new BodyDecompressor(response);
+    byte[] body = decompressor.getBytes();
 
     String mappingFileName = UniqueFilenameGenerator.generate(request.getUrl(), "mapping", fileId);
     String bodyFileName =
@@ -155,9 +155,11 @@ public class StubMappingJsonRecorder implements RequestListener {
 
     ResponseDefinitionBuilder responseDefinitionBuilder =
         responseDefinition().withStatus(response.getStatus()).withBodyFile(bodyFileName);
-    if (response.getHeaders().size() > 0) {
-      responseDefinitionBuilder.withHeaders(
-          withoutContentEncodingAndContentLength(response.getHeaders()));
+
+    if (response.getHeaders() != null) {
+      HttpHeaders headers =
+          new HttpHeaders(filter(response.getHeaders().all(), decompressor::shouldRetain));
+      responseDefinitionBuilder.withHeaders(headers);
     }
 
     ResponseDefinition responseToWrite = responseDefinitionBuilder.build();
@@ -167,25 +169,6 @@ public class StubMappingJsonRecorder implements RequestListener {
 
     filesFileSource.writeBinaryFile(bodyFileName, body);
     mappingsFileSource.writeTextFile(mappingFileName, write(mapping));
-  }
-
-  private HttpHeaders withoutContentEncodingAndContentLength(HttpHeaders httpHeaders) {
-    return new HttpHeaders(
-        filter(
-            httpHeaders.all(),
-            new Predicate<HttpHeader>() {
-              public boolean apply(HttpHeader header) {
-                return !header.keyEquals("Content-Encoding") && !header.keyEquals("Content-Length");
-              }
-            }));
-  }
-
-  private byte[] bodyDecompressedIfRequired(Response response) {
-    if (response.getHeaders().getHeader("Content-Encoding").containsValue("gzip")) {
-      return Gzip.unGzip(response.getBody());
-    }
-
-    return response.getBody();
   }
 
   private boolean requestNotAlreadyReceived(RequestPattern requestPattern) {

--- a/src/test/java/com/github/tomakehurst/wiremock/GzipAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/GzipAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Thomas Akehurst
+ * Copyright (C) 2015-2022 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,7 @@
 package com.github.tomakehurst.wiremock;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.common.Gzip.gzip;
-import static com.github.tomakehurst.wiremock.common.Gzip.unGzipToString;
+import static com.github.tomakehurst.wiremock.common.Compression.GZIP;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -57,7 +56,7 @@ public class GzipAcceptanceTest {
 
       byte[] gzippedContent = response.binaryContent();
 
-      String plainText = unGzipToString(gzippedContent);
+      String plainText = GZIP.decompressToString(gzippedContent);
       assertThat(plainText, is("body text"));
     }
 
@@ -74,7 +73,7 @@ public class GzipAcceptanceTest {
 
       byte[] gzippedContent = response.binaryContent();
 
-      String plainText = unGzipToString(gzippedContent);
+      String plainText = GZIP.decompressToString(gzippedContent);
       assertThat(plainText, is("body text"));
     }
 
@@ -125,11 +124,13 @@ public class GzipAcceptanceTest {
           testClient.get("/gzip-response", withHeader("Accept-Encoding", "gzip,deflate"));
       assertThat(response.firstHeader("Content-Encoding"), is("gzip"));
       assertThat(response.headers().containsKey("Transfer-Encoding"), is(false));
-      assertThat(response.firstHeader("Content-Length"), is(String.valueOf(gzip(bodyText).length)));
+      assertThat(
+          response.firstHeader("Content-Length"),
+          is(String.valueOf(GZIP.compress(bodyText).length)));
 
       byte[] gzippedContent = response.binaryContent();
 
-      String plainText = unGzipToString(gzippedContent);
+      String plainText = GZIP.decompressToString(gzippedContent);
       assertThat(plainText, is(bodyText));
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/NotMatchedPageAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/NotMatchedPageAcceptanceTest.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.common.Compression.GZIP;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.file;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
@@ -271,7 +272,7 @@ public class NotMatchedPageAcceptanceTest {
             .willReturn(ok()));
 
     ByteArrayEntity entity =
-        new ByteArrayEntity(Gzip.gzip("{\"id\":\"wrong\"}"), ContentType.DEFAULT_BINARY);
+        new ByteArrayEntity(GZIP.compress("{\"id\":\"wrong\"}"), ContentType.DEFAULT_BINARY);
     WireMockResponse response =
         testClient.post("/gzip", entity, withHeader("Content-Encoding", "gzip"));
 

--- a/src/test/java/com/github/tomakehurst/wiremock/RecordingDslAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecordingDslAcceptanceTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.common.Gzip.gzip;
+import static com.github.tomakehurst.wiremock.common.Compression.GZIP;
 import static com.github.tomakehurst.wiremock.common.Strings.DEFAULT_CHARSET;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
@@ -271,7 +271,7 @@ public class RecordingDslAcceptanceTest extends AcceptanceTestBase {
   public void recordsIntoPlainTextWhenResponseIsGZipped() {
     proxyingService.startRecording(targetBaseUrl);
 
-    byte[] gzippedBody = gzip("Zippy");
+    byte[] gzippedBody = GZIP.compress("Zippy");
     targetService.stubFor(
         get("/gzipped-response")
             .willReturn(
@@ -291,7 +291,7 @@ public class RecordingDslAcceptanceTest extends AcceptanceTestBase {
     proxyingService.startRecording(targetBaseUrl);
 
     byte[] originalBody = "sdkfnslkdjfsjdf".getBytes(DEFAULT_CHARSET);
-    byte[] gzippedBody = gzip(originalBody);
+    byte[] gzippedBody = GZIP.compress(originalBody);
     targetService.stubFor(
         get("/gzipped-response")
             .willReturn(

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -15,7 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.stubbing;
 
-import static com.github.tomakehurst.wiremock.common.Gzip.gzip;
+
+import static com.github.tomakehurst.wiremock.common.Compression.GZIP;
 import static com.github.tomakehurst.wiremock.http.CaseInsensitiveKey.TO_CASE_INSENSITIVE_KEYS;
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
@@ -392,7 +393,7 @@ public class StubMappingJsonRecorderTest {
             .headers(
                 new HttpHeaders(
                     httpHeader("Content-Encoding", "gzip"), httpHeader("Content-Length", "123")))
-            .body(gzip("Recorded body content"))
+            .body(GZIP.compress("Recorded body content"))
             .build();
 
     listener.requestReceived(request, response);


### PR DESCRIPTION
This change adds support for Content-Encoding: deflate, and fixes a bug so that if an unrecognized Content-Encoding type is encountered we pass it through instead of removing it and making recorded stubs unusable.

Prior to these changes, if a Content-Encoding header is present, we remove it.  However, we only decompress the body if the Content-Encoding is gzip. If we're going to remove the header, we should also decode the content, and vice-versa.

Also, added .gitattributes so that when spotlessApply is used on Windows line endings are not changed to CRLF.