### PR TITLE
removes maven dir in output shadow jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -294,8 +294,7 @@ shadowJar {
 
   mergeServiceFiles()
 
-  exclude 'META-INF/maven/javax.servlet/**'
-  exclude 'META-INF/maven/org.apache.commons/commons-text/**'
+  exclude 'META-INF/maven/**'
   exclude 'module-info.class'
   exclude 'handlebars-*.js'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -295,6 +295,7 @@ shadowJar {
   mergeServiceFiles()
 
   exclude 'META-INF/maven/javax.servlet/**'
+  exclude 'META-INF/maven/org.apache.commons/commons-text/**'
   exclude 'module-info.class'
   exclude 'handlebars-*.js'
 }


### PR DESCRIPTION
I think this is okay as I cannot find a reference to it either in the code or in the dependencies of any of the build stages (transitive or otherwise).