### PR TITLE
New Feature: not() in verify #1892

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -268,6 +268,10 @@ public class WireMock {
     return new NegativeContainsPattern(value);
   }
 
+  public static StringValuePattern not(StringValuePattern unexpectedPattern){
+    return new NotPattern(unexpectedPattern);
+  }
+
   public static StringValuePattern matching(String regex) {
     return new RegexPattern(regex);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/NotPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/NotPattern.java
@@ -1,18 +1,20 @@
 package com.github.tomakehurst.wiremock.matching;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class NotPattern extends StringValuePattern{
 
     private StringValuePattern unexpectedPattern;
 
-    public NotPattern(@JsonProperty("not") StringValuePattern unexpectedPattern){
+    public NotPattern(@JsonProperty("not") StringValuePattern unexpectedPattern) {
         super(unexpectedPattern.expectedValue);
         this.unexpectedPattern = unexpectedPattern;
     }
 
-    public String getNotExpectedValue(){
-        return unexpectedPattern.expectedValue;
+    public StringValuePattern getNot(){
+        return unexpectedPattern;
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/NotPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/NotPattern.java
@@ -31,7 +31,10 @@ public class NotPattern extends StringValuePattern{
 
             @Override
             public double getDistance() {
-                return 1.0 - matchResult.getDistance();
+                if(matchResult.isExactMatch()){
+                    return 0;
+                }
+                return 1.0;
             }
         };
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/NotPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/NotPattern.java
@@ -1,0 +1,36 @@
+package com.github.tomakehurst.wiremock.matching;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class NotPattern extends StringValuePattern{
+
+    private StringValuePattern unexpectedPattern;
+
+    public NotPattern(@JsonProperty("not") StringValuePattern unexpectedPattern){
+        super(unexpectedPattern.expectedValue);
+        this.unexpectedPattern = unexpectedPattern;
+    }
+
+    public String getNotExpectedValue(){
+        return unexpectedPattern.expectedValue;
+    }
+
+    @Override
+    public MatchResult match(String value) {
+        return invert(unexpectedPattern.match(value));
+    }
+
+    private MatchResult invert(final MatchResult matchResult){
+        return new MatchResult() {
+            @Override
+            public boolean isExactMatch() {
+                return !matchResult.isExactMatch();
+            }
+
+            @Override
+            public double getDistance() {
+                return 1.0 - matchResult.getDistance();
+            }
+        };
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
@@ -95,6 +95,8 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
             return deserializeAnd(rootNode);
         } else if (patternClass.equals(LogicalOr.class)) {
             return deserializeOr(rootNode);
+        } else if (patternClass.equals(NotPattern.class)) {
+            return deserializeNot(rootNode);
         }
 
         final Map.Entry<String, JsonNode> mainFieldEntry = findMainFieldEntry(rootNode);
@@ -306,6 +308,22 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
             return new LogicalOr(operands);
         } catch (IOException e) {
             return throwUnchecked(e, LogicalOr.class);
+        }
+    }
+
+    private StringValuePattern deserializeNot(JsonNode rootNode) throws JsonMappingException {
+        if(!rootNode.has("not")){
+            throw new JsonMappingException(rootNode.toString() + " is not a valid not operation");
+        }
+
+        JsonNode notNode = rootNode.findValue("not");
+        JsonParser parser = Json.getObjectMapper().treeAsTokens(notNode);
+
+        try{
+            StringValuePattern unexpectedPattern = parser.readValueAs(new TypeReference<StringValuePattern>(){});
+            return new NotPattern(unexpectedPattern);
+        } catch (IOException e) {
+            return throwUnchecked(e, NotPattern.class);
         }
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -310,6 +310,15 @@ public class VerificationAcceptanceTest {
               .withRequestBody(containing("Important value")));
     }
 
+      @Test
+      public void throwsVerificitationExceptionWhenBodyMatches() {
+          testClient.postWithBody("/body/json", SAMPLE_JSON, "application/json", "utf-8");
+          assertThrows(VerificationException.class, ()->verify(
+                  postRequestedFor(urlEqualTo("/body/json"))
+                          .withRequestBody(not(containing("Important value"))))
+          );
+      }
+
     @Test
     public void verifiesWithQueryParam() {
       testClient.get("/query?param=my-value");

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -324,6 +324,16 @@ public class VerificationAcceptanceTest {
           verify(postRequestedFor(urlEqualTo("/body/json")).withRequestBody(not(containing("stuff"))));
       }
 
+      @Test
+      public void verifiesWithHeaderDoesNotContainValue(){
+          testClient.get(
+                  "/header/not",
+                  withHeader("X-Thing", "One"),
+                  withHeader("X-Thing", "Two"),
+                  withHeader("X-Thing", "Three"));
+          verify(getRequestedFor(urlEqualTo("/header/not")).withHeader("X-Thing", not(containing("Four"))));
+      }
+
     @Test
     public void verifiesWithQueryParam() {
       testClient.get("/query?param=my-value");

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -328,9 +328,7 @@ public class VerificationAcceptanceTest {
       public void verifiesWithHeaderDoesNotContainValue(){
           testClient.get(
                   "/header/not",
-                  withHeader("X-Thing", "One"),
-                  withHeader("X-Thing", "Two"),
-                  withHeader("X-Thing", "Three"));
+                  withHeader("X-Thing", "One"));
           verify(getRequestedFor(urlEqualTo("/header/not")).withHeader("X-Thing", not(containing("Four"))));
       }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -318,6 +318,11 @@ public class VerificationAcceptanceTest {
                           .withRequestBody(not(containing("Important value"))))
           );
       }
+      @Test
+      public void verifiesWithBodyDoesNotContainValue(){
+          testClient.postWithBody("/body/json", SAMPLE_JSON, "application/json", "utf-8");
+          verify(postRequestedFor(urlEqualTo("/body/json")).withRequestBody(not(containing("stuff"))));
+      }
 
     @Test
     public void verifiesWithQueryParam() {

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/NotPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/NotPatternTest.java
@@ -1,0 +1,37 @@
+package com.github.tomakehurst.wiremock.matching;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+
+class NotPatternTest {
+
+    @Test
+    void shouldReturnExactMatchWhenValueIsNull() {
+        MatchResult matchResult = WireMock.not(WireMock.containing("thing")).match(null);
+        boolean result = matchResult.isExactMatch();
+
+        assertTrue(result);
+    }
+
+    @Test
+    void shouldReturnNoMatchWhenValueIsContainedInTestValue() {
+        MatchResult matchResult = WireMock.not(WireMock.containing("thing")).match("otherthings");
+        boolean result = matchResult.isExactMatch();
+        double distance = matchResult.getDistance();
+
+        assertFalse(result);
+        assertThat(distance, is(1.0));
+    }
+
+    @Test
+    void shouldReturnExactMatchWhenValueIsNotContainedInTestValue() {
+        MatchResult matchResult = WireMock.not(WireMock.containing("thing")).match("otherstuff");
+        boolean result = matchResult.isExactMatch();
+
+        assertTrue(result);
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
@@ -35,436 +35,437 @@ import org.skyscreamer.jsonassert.JSONAssert;
 
 public class RequestPatternTest {
 
-  @Test
-  public void matchesExactlyWith0DistanceWhenUrlAndMethodAreExactMatch() {
-    RequestPattern requestPattern = newRequestPattern(PUT, urlPathEqualTo("/my/url")).build();
-
-    MatchResult matchResult = requestPattern.match(mockRequest().method(PUT).url("/my/url"));
-    assertThat(matchResult.getDistance(), is(0.0));
-    assertTrue(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void returnsNon0DistanceWhenUrlDoesNotMatch() {
-    RequestPattern requestPattern =
-        newRequestPattern(PUT, urlPathEqualTo("/my/url")).withUrl("/my/url").build();
-
-    MatchResult matchResult = requestPattern.match(mockRequest().url("/totally/other/url"));
-    assertThat(matchResult.getDistance(), greaterThan(0.0));
-    assertFalse(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void matchesExactlyWith0DistanceWhenAllRequiredHeadersMatch() {
-    RequestPattern requestPattern =
-        newRequestPattern(PUT, urlPathEqualTo("/my/url"))
-            .withHeader("My-Header", equalTo("my-expected-header-val"))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(
-            mockRequest().method(PUT).header("My-Header", "my-expected-header-val").url("/my/url"));
-    assertThat(matchResult.getDistance(), is(0.0));
-    assertTrue(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void doesNotMatchWhenHeaderDoesNotMatch() {
-    RequestPattern requestPattern =
-        newRequestPattern(GET, urlPathEqualTo("/my/url"))
-            .withHeader("My-Header", equalTo("my-expected-header-val"))
-            .withHeader("My-Other-Header", equalTo("my-other-expected-header-val"))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(
-            mockRequest()
-                .method(GET)
-                .header("My-Header", "my-expected-header-val")
-                .header("My-Other-Header", "wrong")
-                .url("/my/url"));
-
-    assertFalse(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void matchesExactlyWhenRequiredAbsentHeaderIsAbsent() {
-    RequestPattern requestPattern =
-        newRequestPattern(GET, urlPathEqualTo("/my/url"))
-            .withHeader("My-Header", absent())
-            .withHeader("My-Other-Header", equalTo("my-other-expected-header-val"))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(
-            mockRequest()
-                .method(GET)
-                .header("My-Other-Header", "my-other-expected-header-val")
-                .url("/my/url"));
-
-    assertTrue(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void doesNotMatchWhenRequiredAbsentHeaderIsPresent() {
-    RequestPattern requestPattern =
-        newRequestPattern(GET, urlPathEqualTo("/my/url"))
-            .withHeader("My-Header", absent())
-            .withHeader("My-Other-Header", equalTo("my-other-expected-header-val"))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(
-            mockRequest()
-                .method(GET)
-                .header("My-Header", "my-expected-header-val")
-                .header("My-Other-Header", "wrong")
-                .url("/my/url"));
-
-    assertFalse(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void bindsToJsonCompatibleWithOriginalRequestPatternForUrl() throws Exception {
-    RequestPattern requestPattern = newRequestPattern(GET, urlEqualTo("/my/url")).build();
-
-    String actualJson = Json.write(requestPattern);
-
-    JSONAssert.assertEquals(
-        "{									                \n"
-            + "		\"method\": \"GET\",						\n"
-            + "		\"url\": \"/my/url\"                		\n"
-            + "}												    ",
-        actualJson,
-        true);
-  }
-
-  @Test
-  public void bindsToJsonCompatibleWithOriginalRequestPatternForUrlPattern() throws Exception {
-    RequestPattern requestPattern = newRequestPattern(GET, urlMatching("/my/url")).build();
-
-    String actualJson = Json.write(requestPattern);
-
-    JSONAssert.assertEquals(
-        "{									                \n"
-            + "		\"method\": \"GET\",						\n"
-            + "		\"urlPattern\": \"/my/url\"           		\n"
-            + "}												    ",
-        actualJson,
-        true);
-  }
-
-  @Test
-  public void bindsToJsonCompatibleWithOriginalRequestPatternForUrlPathPattern() throws Exception {
-    RequestPattern requestPattern = newRequestPattern(GET, urlPathMatching("/my/url")).build();
-
-    String actualJson = Json.write(requestPattern);
-
-    JSONAssert.assertEquals(
-        "{									                \n"
-            + "		\"method\": \"GET\",						\n"
-            + "		\"urlPathPattern\": \"/my/url\"             \n"
-            + "}												    ",
-        actualJson,
-        true);
-  }
-
-  @Test
-  public void bindsToJsonCompatibleWithOriginalRequestPatternForUrlPathAndHeaders()
-      throws Exception {
-    RequestPattern requestPattern =
-        newRequestPattern(GET, urlPathEqualTo("/my/url"))
-            .withHeader("Accept", matching("(.*)xml(.*)"))
-            .withHeader("If-None-Match", matching("([a-z0-9]*)"))
-            .build();
-
-    String actualJson = Json.write(requestPattern);
-
-    JSONAssert.assertEquals(URL_PATH_AND_HEADERS_EXAMPLE, actualJson, true);
-  }
-
-  static final String URL_PATH_AND_HEADERS_EXAMPLE =
-      "{									                \n"
-          + "		\"method\": \"GET\",						\n"
-          + "		\"urlPath\": \"/my/url\",             		\n"
-          + "		\"headers\": {								\n"
-          + "			\"Accept\": {							\n"
-          + "				\"matches\": \"(.*)xml(.*)\"		\n"
-          + "			},										\n"
-          + "			\"If-None-Match\": {					\n"
-          + "				\"matches\": \"([a-z0-9]*)\"		\n"
-          + "			}										\n"
-          + "		}											\n"
-          + "}												    ";
-
-  @Test
-  public void matchesExactlyWith0DistanceWhenAllRequiredQueryParametersMatch() {
-    RequestPattern requestPattern =
-        newRequestPattern(PUT, urlPathEqualTo("/my/url"))
-            .withQueryParam("param1", equalTo("1"))
-            .withQueryParam("param2", equalTo("2"))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(mockRequest().method(PUT).url("/my/url?param1=1&param1=555&param2=2"));
-    assertThat(matchResult.getDistance(), is(0.0));
-    assertTrue(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void returnsNon0DistanceWhenRequiredQueryParameterMatchDoesNotMatch() {
-    RequestPattern requestPattern =
-        newRequestPattern(PUT, urlPathEqualTo("/my/url"))
-            .withQueryParam("param1", equalTo("1"))
-            .withQueryParam("param2", equalTo("2"))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(mockRequest().method(PUT).url("/my/url?param1=555&param2=2"));
-    assertThat(matchResult.getDistance(), greaterThan(0.0));
-    assertFalse(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void bindsToJsonCompatibleWithOriginalRequestPatternWithQueryParams() throws Exception {
-    RequestPattern requestPattern =
-        newRequestPattern(GET, urlPathEqualTo("/my/url"))
-            .withQueryParam("param1", equalTo("1"))
-            .withQueryParam("param2", matching("2"))
-            .build();
-
-    String actualJson = Json.write(requestPattern);
-
-    JSONAssert.assertEquals(
-        "{                              \n"
-            + "    \"method\": \"GET\",       \n"
-            + "    \"urlPath\": \"/my/url\",  \n"
-            + "    \"queryParameters\": {     \n"
-            + "        \"param1\": {          \n"
-            + "            \"equalTo\": \"1\" \n"
-            + "        },                     \n"
-            + "        \"param2\": {          \n"
-            + "            \"matches\": \"2\" \n"
-            + "        }                      \n"
-            + "    }                          \n"
-            + "}",
-        actualJson,
-        true);
-  }
-
-  @Test
-  public void matchesExactlyWith0DistanceWhenBodyPatternsAllMatch() {
-    RequestPattern requestPattern =
-        newRequestPattern(PUT, urlPathEqualTo("/my/url"))
-            .withRequestBody(equalTo("exactwordone approxwordtwo blah blah"))
-            .withRequestBody(containing("two"))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(
-            mockRequest().method(PUT).url("/my/url").body("exactwordone approxwordtwo blah blah"));
-    assertThat(matchResult.getDistance(), is(0.0));
-    assertTrue(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void doesNotMatchExactlyWhenOneBodyPatternDoesNotMatch() {
-    RequestPattern requestPattern =
-        newRequestPattern(PUT, urlPathEqualTo("/my/url"))
-            .withRequestBody(equalTo("exactwordone approxwordtwo blah blah"))
-            .withRequestBody(containing("three"))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(
-            mockRequest().method(PUT).url("/my/url").body("exactwordone approxwordtwo blah blah"));
-
-    assertFalse(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void matchesExactlyWith0DistanceWhenMultipartPatternsAllMatch() {
-    RequestPattern requestPattern =
-        newRequestPattern(POST, urlPathEqualTo("/my/url"))
-            .withAnyRequestBodyPart(
-                aMultipart()
-                    .withName("part-1")
-                    .withHeader("Content-Type", containing("text/plain"))
-                    .withBody(equalTo("body part value")))
-            .withAnyRequestBodyPart(
-                aMultipart()
-                    .withName("part-2")
-                    .withHeader("Content-Type", containing("application/octet-stream"))
-                    .withBody(containing("other body")))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(
-            mockRequest()
-                .method(POST)
-                .url("/my/url")
-                .header("Content-Type", "multipart/form-data; boundary=BOUNDARY")
-                .multipartBody(
-                    "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-1\"; filename=\"\"\r\nContent-Type: text/plain\r\n\r\n"
-                        + "body part value\r\n"
-                        + "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-2\"; filename=\"\"\r\nContent-Type: application/octet-stream\r\nContent-Transfer-Encoding: base64\r\n\r\n"
-                        + "c29tZSBvdGhlciBib2R5IHZhbHVl\r\n"
-                        + // some other body value
-                        "--BOUNDARY--"));
-
-    assertThat(matchResult.getDistance(), is(0.0));
-    assertTrue(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void doesNotMatchExactlyWhenOneMultipartBodyPatternDoesNotMatch() {
-    RequestPattern requestPattern =
-        newRequestPattern(PUT, urlPathEqualTo("/my/url"))
-            .withAnyRequestBodyPart(
-                aMultipart().withName("part-2").withBody(containing("non existing part")))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(
-            mockRequest()
-                .method(PUT)
-                .url("/my/url")
-                .header("Content-Type", "multipart/form-data; boundary=BOUNDARY")
-                .multipartBody(
-                    "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-2\"; filename=\"\"\r\nContent-Type: application/octet-stream\r\nContent-Transfer-Encoding: base64\r\n\r\n"
-                        + "c29tZSBvdGhlciBib2R5IHZhbHVl\r\n"
-                        + // some other body value
-                        "--BOUNDARY--"));
-
-    assertFalse(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void doesNotMatchExactlyWhenOneMultipartHeaderPatternDoesNotMatch() {
-    RequestPattern requestPattern =
-        newRequestPattern(PUT, urlPathEqualTo("/my/url"))
-            .withAnyRequestBodyPart(
-                aMultipart()
-                    .withName("part-1")
-                    .withHeader("Content-Type", containing("application/json")))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(
-            mockRequest()
-                .method(PUT)
-                .url("/my/url")
-                .header("Content-Type", "multipart/form-data; boundary=BOUNDARY")
-                .multipartBody(
-                    "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-1\"; filename=\"\"\r\nContent-Type: application/octet-stream\r\nContent-Transfer-Encoding: base64\r\n\r\n"
-                        + "c29tZSBvdGhlciBib2R5IHZhbHVl\r\n"
-                        + // some other body value
-                        "--BOUNDARY--"));
-
-    assertFalse(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void matchesExactlyWith0DistanceWhenAllMultipartPatternsMatchAllParts() {
-    RequestPattern requestPattern =
-        newRequestPattern(POST, urlPathEqualTo("/my/url"))
-            .withAllRequestBodyParts(
-                aMultipart()
-                    .withHeader("Content-Type", containing("text/plain"))
-                    .withBody(containing("body value")))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(
-            mockRequest()
-                .method(POST)
-                .url("/my/url")
-                .header("Content-Type", "multipart/form-data; boundary=BOUNDARY")
-                .multipartBody(
-                    "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-1\"; filename=\"\"\r\nContent-Type: text/plain\r\n\r\n"
-                        + "body value-1\r\n"
-                        + "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-2\"; filename=\"\"\r\nContent-Type: text/plain\r\nContent-Transfer-Encoding: base64\r\n\r\n"
-                        + "c29tZSBvdGhlciBib2R5IHZhbHVl\r\n"
-                        + // some other body value
-                        "--BOUNDARY--"));
-
-    assertThat(matchResult.getDistance(), is(0.0));
-    assertTrue(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void matchesExactlyWhenAllCookiesMatch() {
-    RequestPattern requestPattern =
-        newRequestPattern(POST, urlPathEqualTo("/my/url"))
-            .withCookie("my_cookie", equalTo("my-cookie-value"))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(
-            mockRequest().method(POST).cookie("my_cookie", "my-cookie-value").url("/my/url"));
-
-    assertThat(matchResult.getDistance(), is(0.0));
-    assertTrue(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void doesNotMatchWhenARequiredCookieIsMissing() {
-    RequestPattern requestPattern =
-        newRequestPattern(POST, urlPathEqualTo("/my/url"))
-            .withCookie("my_cookie", equalTo("my-cookie-value"))
-            .build();
-
-    MatchResult matchResult = requestPattern.match(mockRequest().method(POST).url("/my/url"));
-
-    assertFalse(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void doesNotMatchWhenRequiredCookieValueIsWrong() {
-    RequestPattern requestPattern =
-        newRequestPattern(POST, urlPathEqualTo("/my/url"))
-            .withCookie("my_cookie", equalTo("my-cookie-value"))
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(
-            mockRequest().method(POST).cookie("my_cookie", "wrong-value").url("/my/url"));
-
-    assertFalse(matchResult.isExactMatch());
-  }
-
-  @Test
-  public void doesNotMatchWhenRequiredAbsentCookieIsPresent() {
-    RequestPattern requestPattern =
-        newRequestPattern(POST, urlPathEqualTo("/my/url"))
-            .withCookie("my_cookie", absent())
-            .build();
-
-    MatchResult matchResult =
-        requestPattern.match(
-            mockRequest().method(POST).cookie("my_cookie", "any-value").url("/my/url"));
-
-    assertFalse(matchResult.isExactMatch());
-  }
-
-  static final String ALL_BODY_PATTERNS_EXAMPLE =
-      "{                                                      \n"
-          + "    \"url\" : \"/all/body/patterns\",                  \n"
-          + "    \"method\" : \"PUT\",                              \n"
-          + "    \"bodyPatterns\" : [                               \n"
-          + "        { \"equalTo\": \"thing\" },                    \n"
-          + "        { \"equalToJson\": \"{ \\\"thing\\\": 1 }\" }, \n"
-          + "        { \"matchesJsonPath\": \"@.*\" },              \n"
-          + "        { \"equalToXml\": \"<thing />\" },             \n"
-          + "        { \"matchesXPath\": \"//thing\" },             \n"
-          + "        { \"contains\": \"thin\" },                    \n"
-          + "        { \"doesNotContain\": \"stuff\" },            \n"
-          + "        { \"matches\": \".*thing.*\" },                \n"
-          + "        { \"doesNotMatch\": \"^stuff.+\" }             \n"
-          + "    ]                                                  \n"
-          + "}";
-
-  @SuppressWarnings("unchecked")
+    @Test
+    public void matchesExactlyWith0DistanceWhenUrlAndMethodAreExactMatch() {
+        RequestPattern requestPattern = newRequestPattern(PUT, urlPathEqualTo("/my/url")).build();
+
+        MatchResult matchResult = requestPattern.match(mockRequest().method(PUT).url("/my/url"));
+        assertThat(matchResult.getDistance(), is(0.0));
+        assertTrue(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void returnsNon0DistanceWhenUrlDoesNotMatch() {
+        RequestPattern requestPattern =
+                newRequestPattern(PUT, urlPathEqualTo("/my/url")).withUrl("/my/url").build();
+
+        MatchResult matchResult = requestPattern.match(mockRequest().url("/totally/other/url"));
+        assertThat(matchResult.getDistance(), greaterThan(0.0));
+        assertFalse(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void matchesExactlyWith0DistanceWhenAllRequiredHeadersMatch() {
+        RequestPattern requestPattern =
+                newRequestPattern(PUT, urlPathEqualTo("/my/url"))
+                        .withHeader("My-Header", equalTo("my-expected-header-val"))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(
+                        mockRequest().method(PUT).header("My-Header", "my-expected-header-val").url("/my/url"));
+        assertThat(matchResult.getDistance(), is(0.0));
+        assertTrue(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void doesNotMatchWhenHeaderDoesNotMatch() {
+        RequestPattern requestPattern =
+                newRequestPattern(GET, urlPathEqualTo("/my/url"))
+                        .withHeader("My-Header", equalTo("my-expected-header-val"))
+                        .withHeader("My-Other-Header", equalTo("my-other-expected-header-val"))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(
+                        mockRequest()
+                                .method(GET)
+                                .header("My-Header", "my-expected-header-val")
+                                .header("My-Other-Header", "wrong")
+                                .url("/my/url"));
+
+        assertFalse(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void matchesExactlyWhenRequiredAbsentHeaderIsAbsent() {
+        RequestPattern requestPattern =
+                newRequestPattern(GET, urlPathEqualTo("/my/url"))
+                        .withHeader("My-Header", absent())
+                        .withHeader("My-Other-Header", equalTo("my-other-expected-header-val"))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(
+                        mockRequest()
+                                .method(GET)
+                                .header("My-Other-Header", "my-other-expected-header-val")
+                                .url("/my/url"));
+
+        assertTrue(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void doesNotMatchWhenRequiredAbsentHeaderIsPresent() {
+        RequestPattern requestPattern =
+                newRequestPattern(GET, urlPathEqualTo("/my/url"))
+                        .withHeader("My-Header", absent())
+                        .withHeader("My-Other-Header", equalTo("my-other-expected-header-val"))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(
+                        mockRequest()
+                                .method(GET)
+                                .header("My-Header", "my-expected-header-val")
+                                .header("My-Other-Header", "wrong")
+                                .url("/my/url"));
+
+        assertFalse(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void bindsToJsonCompatibleWithOriginalRequestPatternForUrl() throws Exception {
+        RequestPattern requestPattern = newRequestPattern(GET, urlEqualTo("/my/url")).build();
+
+        String actualJson = Json.write(requestPattern);
+
+        JSONAssert.assertEquals(
+                "{									                \n"
+                        + "		\"method\": \"GET\",						\n"
+                        + "		\"url\": \"/my/url\"                		\n"
+                        + "}												    ",
+                actualJson,
+                true);
+    }
+
+    @Test
+    public void bindsToJsonCompatibleWithOriginalRequestPatternForUrlPattern() throws Exception {
+        RequestPattern requestPattern = newRequestPattern(GET, urlMatching("/my/url")).build();
+
+        String actualJson = Json.write(requestPattern);
+
+        JSONAssert.assertEquals(
+                "{									                \n"
+                        + "		\"method\": \"GET\",						\n"
+                        + "		\"urlPattern\": \"/my/url\"           		\n"
+                        + "}												    ",
+                actualJson,
+                true);
+    }
+
+    @Test
+    public void bindsToJsonCompatibleWithOriginalRequestPatternForUrlPathPattern() throws Exception {
+        RequestPattern requestPattern = newRequestPattern(GET, urlPathMatching("/my/url")).build();
+
+        String actualJson = Json.write(requestPattern);
+
+        JSONAssert.assertEquals(
+                "{									                \n"
+                        + "		\"method\": \"GET\",						\n"
+                        + "		\"urlPathPattern\": \"/my/url\"             \n"
+                        + "}												    ",
+                actualJson,
+                true);
+    }
+
+    @Test
+    public void bindsToJsonCompatibleWithOriginalRequestPatternForUrlPathAndHeaders()
+            throws Exception {
+        RequestPattern requestPattern =
+                newRequestPattern(GET, urlPathEqualTo("/my/url"))
+                        .withHeader("Accept", matching("(.*)xml(.*)"))
+                        .withHeader("If-None-Match", matching("([a-z0-9]*)"))
+                        .build();
+
+        String actualJson = Json.write(requestPattern);
+
+        JSONAssert.assertEquals(URL_PATH_AND_HEADERS_EXAMPLE, actualJson, true);
+    }
+
+    static final String URL_PATH_AND_HEADERS_EXAMPLE =
+            "{									                \n"
+                    + "		\"method\": \"GET\",						\n"
+                    + "		\"urlPath\": \"/my/url\",             		\n"
+                    + "		\"headers\": {								\n"
+                    + "			\"Accept\": {							\n"
+                    + "				\"matches\": \"(.*)xml(.*)\"		\n"
+                    + "			},										\n"
+                    + "			\"If-None-Match\": {					\n"
+                    + "				\"matches\": \"([a-z0-9]*)\"		\n"
+                    + "			}										\n"
+                    + "		}											\n"
+                    + "}												    ";
+
+    @Test
+    public void matchesExactlyWith0DistanceWhenAllRequiredQueryParametersMatch() {
+        RequestPattern requestPattern =
+                newRequestPattern(PUT, urlPathEqualTo("/my/url"))
+                        .withQueryParam("param1", equalTo("1"))
+                        .withQueryParam("param2", equalTo("2"))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(mockRequest().method(PUT).url("/my/url?param1=1&param1=555&param2=2"));
+        assertThat(matchResult.getDistance(), is(0.0));
+        assertTrue(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void returnsNon0DistanceWhenRequiredQueryParameterMatchDoesNotMatch() {
+        RequestPattern requestPattern =
+                newRequestPattern(PUT, urlPathEqualTo("/my/url"))
+                        .withQueryParam("param1", equalTo("1"))
+                        .withQueryParam("param2", equalTo("2"))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(mockRequest().method(PUT).url("/my/url?param1=555&param2=2"));
+        assertThat(matchResult.getDistance(), greaterThan(0.0));
+        assertFalse(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void bindsToJsonCompatibleWithOriginalRequestPatternWithQueryParams() throws Exception {
+        RequestPattern requestPattern =
+                newRequestPattern(GET, urlPathEqualTo("/my/url"))
+                        .withQueryParam("param1", equalTo("1"))
+                        .withQueryParam("param2", matching("2"))
+                        .build();
+
+        String actualJson = Json.write(requestPattern);
+
+        JSONAssert.assertEquals(
+                "{                              \n"
+                        + "    \"method\": \"GET\",       \n"
+                        + "    \"urlPath\": \"/my/url\",  \n"
+                        + "    \"queryParameters\": {     \n"
+                        + "        \"param1\": {          \n"
+                        + "            \"equalTo\": \"1\" \n"
+                        + "        },                     \n"
+                        + "        \"param2\": {          \n"
+                        + "            \"matches\": \"2\" \n"
+                        + "        }                      \n"
+                        + "    }                          \n"
+                        + "}",
+                actualJson,
+                true);
+    }
+
+    @Test
+    public void matchesExactlyWith0DistanceWhenBodyPatternsAllMatch() {
+        RequestPattern requestPattern =
+                newRequestPattern(PUT, urlPathEqualTo("/my/url"))
+                        .withRequestBody(equalTo("exactwordone approxwordtwo blah blah"))
+                        .withRequestBody(containing("two"))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(
+                        mockRequest().method(PUT).url("/my/url").body("exactwordone approxwordtwo blah blah"));
+        assertThat(matchResult.getDistance(), is(0.0));
+        assertTrue(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void doesNotMatchExactlyWhenOneBodyPatternDoesNotMatch() {
+        RequestPattern requestPattern =
+                newRequestPattern(PUT, urlPathEqualTo("/my/url"))
+                        .withRequestBody(equalTo("exactwordone approxwordtwo blah blah"))
+                        .withRequestBody(containing("three"))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(
+                        mockRequest().method(PUT).url("/my/url").body("exactwordone approxwordtwo blah blah"));
+
+        assertFalse(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void matchesExactlyWith0DistanceWhenMultipartPatternsAllMatch() {
+        RequestPattern requestPattern =
+                newRequestPattern(POST, urlPathEqualTo("/my/url"))
+                        .withAnyRequestBodyPart(
+                                aMultipart()
+                                        .withName("part-1")
+                                        .withHeader("Content-Type", containing("text/plain"))
+                                        .withBody(equalTo("body part value")))
+                        .withAnyRequestBodyPart(
+                                aMultipart()
+                                        .withName("part-2")
+                                        .withHeader("Content-Type", containing("application/octet-stream"))
+                                        .withBody(containing("other body")))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(
+                        mockRequest()
+                                .method(POST)
+                                .url("/my/url")
+                                .header("Content-Type", "multipart/form-data; boundary=BOUNDARY")
+                                .multipartBody(
+                                        "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-1\"; filename=\"\"\r\nContent-Type: text/plain\r\n\r\n"
+                                                + "body part value\r\n"
+                                                + "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-2\"; filename=\"\"\r\nContent-Type: application/octet-stream\r\nContent-Transfer-Encoding: base64\r\n\r\n"
+                                                + "c29tZSBvdGhlciBib2R5IHZhbHVl\r\n"
+                                                + // some other body value
+                                                "--BOUNDARY--"));
+
+        assertThat(matchResult.getDistance(), is(0.0));
+        assertTrue(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void doesNotMatchExactlyWhenOneMultipartBodyPatternDoesNotMatch() {
+        RequestPattern requestPattern =
+                newRequestPattern(PUT, urlPathEqualTo("/my/url"))
+                        .withAnyRequestBodyPart(
+                                aMultipart().withName("part-2").withBody(containing("non existing part")))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(
+                        mockRequest()
+                                .method(PUT)
+                                .url("/my/url")
+                                .header("Content-Type", "multipart/form-data; boundary=BOUNDARY")
+                                .multipartBody(
+                                        "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-2\"; filename=\"\"\r\nContent-Type: application/octet-stream\r\nContent-Transfer-Encoding: base64\r\n\r\n"
+                                                + "c29tZSBvdGhlciBib2R5IHZhbHVl\r\n"
+                                                + // some other body value
+                                                "--BOUNDARY--"));
+
+        assertFalse(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void doesNotMatchExactlyWhenOneMultipartHeaderPatternDoesNotMatch() {
+        RequestPattern requestPattern =
+                newRequestPattern(PUT, urlPathEqualTo("/my/url"))
+                        .withAnyRequestBodyPart(
+                                aMultipart()
+                                        .withName("part-1")
+                                        .withHeader("Content-Type", containing("application/json")))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(
+                        mockRequest()
+                                .method(PUT)
+                                .url("/my/url")
+                                .header("Content-Type", "multipart/form-data; boundary=BOUNDARY")
+                                .multipartBody(
+                                        "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-1\"; filename=\"\"\r\nContent-Type: application/octet-stream\r\nContent-Transfer-Encoding: base64\r\n\r\n"
+                                                + "c29tZSBvdGhlciBib2R5IHZhbHVl\r\n"
+                                                + // some other body value
+                                                "--BOUNDARY--"));
+
+        assertFalse(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void matchesExactlyWith0DistanceWhenAllMultipartPatternsMatchAllParts() {
+        RequestPattern requestPattern =
+                newRequestPattern(POST, urlPathEqualTo("/my/url"))
+                        .withAllRequestBodyParts(
+                                aMultipart()
+                                        .withHeader("Content-Type", containing("text/plain"))
+                                        .withBody(containing("body value")))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(
+                        mockRequest()
+                                .method(POST)
+                                .url("/my/url")
+                                .header("Content-Type", "multipart/form-data; boundary=BOUNDARY")
+                                .multipartBody(
+                                        "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-1\"; filename=\"\"\r\nContent-Type: text/plain\r\n\r\n"
+                                                + "body value-1\r\n"
+                                                + "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-2\"; filename=\"\"\r\nContent-Type: text/plain\r\nContent-Transfer-Encoding: base64\r\n\r\n"
+                                                + "c29tZSBvdGhlciBib2R5IHZhbHVl\r\n"
+                                                + // some other body value
+                                                "--BOUNDARY--"));
+
+        assertThat(matchResult.getDistance(), is(0.0));
+        assertTrue(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void matchesExactlyWhenAllCookiesMatch() {
+        RequestPattern requestPattern =
+                newRequestPattern(POST, urlPathEqualTo("/my/url"))
+                        .withCookie("my_cookie", equalTo("my-cookie-value"))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(
+                        mockRequest().method(POST).cookie("my_cookie", "my-cookie-value").url("/my/url"));
+
+        assertThat(matchResult.getDistance(), is(0.0));
+        assertTrue(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void doesNotMatchWhenARequiredCookieIsMissing() {
+        RequestPattern requestPattern =
+                newRequestPattern(POST, urlPathEqualTo("/my/url"))
+                        .withCookie("my_cookie", equalTo("my-cookie-value"))
+                        .build();
+
+        MatchResult matchResult = requestPattern.match(mockRequest().method(POST).url("/my/url"));
+
+        assertFalse(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void doesNotMatchWhenRequiredCookieValueIsWrong() {
+        RequestPattern requestPattern =
+                newRequestPattern(POST, urlPathEqualTo("/my/url"))
+                        .withCookie("my_cookie", equalTo("my-cookie-value"))
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(
+                        mockRequest().method(POST).cookie("my_cookie", "wrong-value").url("/my/url"));
+
+        assertFalse(matchResult.isExactMatch());
+    }
+
+    @Test
+    public void doesNotMatchWhenRequiredAbsentCookieIsPresent() {
+        RequestPattern requestPattern =
+                newRequestPattern(POST, urlPathEqualTo("/my/url"))
+                        .withCookie("my_cookie", absent())
+                        .build();
+
+        MatchResult matchResult =
+                requestPattern.match(
+                        mockRequest().method(POST).cookie("my_cookie", "any-value").url("/my/url"));
+
+        assertFalse(matchResult.isExactMatch());
+    }
+
+    static final String ALL_BODY_PATTERNS_EXAMPLE =
+            "{                                                      \n"
+                    + "    \"url\" : \"/all/body/patterns\",                  \n"
+                    + "    \"method\" : \"PUT\",                              \n"
+                    + "    \"bodyPatterns\" : [                               \n"
+                    + "        { \"equalTo\": \"thing\" },                    \n"
+                    + "        { \"equalToJson\": \"{ \\\"thing\\\": 1 }\" }, \n"
+                    + "        { \"matchesJsonPath\": \"@.*\" },              \n"
+                    + "        { \"equalToXml\": \"<thing />\" },             \n"
+                    + "        { \"matchesXPath\": \"//thing\" },             \n"
+                    + "        { \"contains\": \"thin\" },                    \n"
+                    + "        { \"doesNotContain\": \"stuff\" },            \n"
+                    + "        { \"not\": { \"contains\": \"thing\" } },     \n"
+                    + "        { \"matches\": \".*thing.*\" },                \n"
+                    + "        { \"doesNotMatch\": \"^stuff.+\" }             \n"
+                    + "    ]                                                  \n"
+                    + "}";
+
+    @SuppressWarnings("unchecked")
   @Test
   public void correctlyDeserialisesBodyPatterns() {
     RequestPattern pattern = Json.read(ALL_BODY_PATTERNS_EXAMPLE, RequestPattern.class);
@@ -477,67 +478,67 @@ public class RequestPatternTest {
             valuePattern(EqualToXmlPattern.class, "<thing />"),
             valuePattern(MatchesXPathPattern.class, "//thing"),
             valuePattern(ContainsPattern.class, "thin"),
-            notValuePattern(NotPattern.class, new ContainsPattern("thing")),
             valuePattern(NegativeContainsPattern.class, "stuff"),
+            valuePattern(NotPattern.class, containing("thing").expectedValue),
             valuePattern(RegexPattern.class, ".*thing.*"),
             valuePattern(NegativeRegexPattern.class, "^stuff.+")));
   }
 
-  @Test
-  public void correctlySerialisesBodyPatterns() throws Exception {
-    RequestPattern requestPattern =
-        newRequestPattern(RequestMethod.PUT, urlEqualTo("/all/body/patterns"))
-            .withRequestBody(equalTo("thing"))
-            .withRequestBody(equalToJson("{ \"thing\": 1 }"))
-            .withRequestBody(matchingJsonPath("@.*"))
-            .withRequestBody(equalToXml("<thing />"))
-            .withRequestBody(matchingXPath("//thing"))
-            .withRequestBody(containing("thin"))
-            .withRequestBody(notContaining("stuff"))
-            .withRequestBody(matching(".*thing.*"))
-            .withRequestBody(notMatching("^stuff.+"))
-            .build();
+    @Test
+    public void correctlySerialisesBodyPatterns() throws Exception {
+        RequestPattern requestPattern =
+                newRequestPattern(RequestMethod.PUT, urlEqualTo("/all/body/patterns"))
+                        .withRequestBody(equalTo("thing"))
+                        .withRequestBody(equalToJson("{ \"thing\": 1 }"))
+                        .withRequestBody(matchingJsonPath("@.*"))
+                        .withRequestBody(equalToXml("<thing />"))
+                        .withRequestBody(matchingXPath("//thing"))
+                        .withRequestBody(containing("thin"))
+                        .withRequestBody(notContaining("stuff"))
+                        .withRequestBody(not(containing("thing")))
+                        .withRequestBody(matching(".*thing.*"))
+                        .withRequestBody(notMatching("^stuff.+"))
+                        .build();
 
-    String json = Json.write(requestPattern);
-    System.out.println(json);
-    JSONAssert.assertEquals(ALL_BODY_PATTERNS_EXAMPLE, json, true);
-  }
+        String json = Json.write(requestPattern);
+        JSONAssert.assertEquals(ALL_BODY_PATTERNS_EXAMPLE, json, true);
+    }
 
-  static Matcher<ContentPattern<?>> valuePattern(
-      final Class<? extends StringValuePattern> patternClass, final String expectedValue) {
-    return new TypeSafeDiagnosingMatcher<ContentPattern<?>>() {
-      @Override
-      protected boolean matchesSafely(ContentPattern<?> item, Description mismatchDescription) {
-        return item.getClass().equals(patternClass) && item.getValue().equals(expectedValue);
-      }
+    static Matcher<ContentPattern<?>> valuePattern(
+            final Class<? extends StringValuePattern> patternClass, final String expectedValue) {
+        return new TypeSafeDiagnosingMatcher<ContentPattern<?>>() {
+            @Override
+            protected boolean matchesSafely(ContentPattern<?> item, Description mismatchDescription) {
+                return item.getClass().equals(patternClass) && item.getValue().equals(expectedValue);
+            }
 
-      @Override
-      public void describeTo(Description description) {
-        description.appendText(
-            "a value pattern of type "
-                + patternClass.getSimpleName()
-                + " with expected value "
-                + expectedValue);
-      }
-    };
-  }
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(
+                        "a value pattern of type "
+                                + patternClass.getSimpleName()
+                                + " with expected value "
+                                + expectedValue);
+            }
+        };
+    }
 
-  static Matcher<ContentPattern<?>> notValuePattern(
-          final Class<? extends StringValuePattern> patternClass, final StringValuePattern unexpectedPattern) {
-    return new TypeSafeDiagnosingMatcher<ContentPattern<?>>() {
-      @Override
-      protected boolean matchesSafely(ContentPattern<?> item, Description mismatchDescription) {
-        return item.getClass().equals(patternClass) && item.getValue().equals(unexpectedPattern.expectedValue);
-      }
+    static Matcher<ContentPattern<?>> notValuePattern(
+            final Class<? extends StringValuePattern> patternClass, final StringValuePattern unexpectedPattern) {
+        return new TypeSafeDiagnosingMatcher<ContentPattern<?>>() {
+            @Override
+            protected boolean matchesSafely(ContentPattern<?> item, Description mismatchDescription) {
+                return item.getClass().equals(patternClass) && item.getValue().equals(unexpectedPattern.expectedValue);
+            }
 
-      @Override
-      public void describeTo(Description description) {
-        description.appendText(
-                "a value pattern of type "
-                        + patternClass.getSimpleName()
-                        + " with expected value "
-                        + unexpectedPattern.expectedValue);
-      }
-    };
-  }
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(
+                        "a value pattern of type "
+                                + patternClass.getSimpleName()
+                                + " with expected value "
+                                + unexpectedPattern.expectedValue);
+            }
+        };
+    }
 }


### PR DESCRIPTION
Implemented a not method in WireMock.java which takes StringPatternValue parameter and returns the opposite of the result. 
For example, verify(getRequestedFor(urlEqualTo("/header/not")).withHeader("X-Thing", not(containing("Four"))));

The functionality has been properly tested, unit and acceptance tests are passing.

New File Added: NotPattern
File modified: StringValuePatternJsonDeserializer