### PR TITLE
Fixed clock skew problems with dynamically created certificates

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ssl/CertificateAuthority.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ssl/CertificateAuthority.java
@@ -52,6 +52,7 @@ public class CertificateAuthority {
           makeX509CertInfo(
               sigAlg,
               "WireMock Local Self Signed Root Certificate",
+              ZonedDateTime.now().minus(Period.ofDays(1)),
               Period.ofYears(10),
               pair.getPublic(),
               certificateAuthorityExtensions(pair.getPublic()));
@@ -125,6 +126,7 @@ public class CertificateAuthority {
           makeX509CertInfo(
               sigAlg,
               hostName.getAsciiName(),
+              ZonedDateTime.now().minus(Period.ofDays(1)),
               Period.ofYears(1),
               pair.getPublic(),
               subjectAlternativeName(hostName));
@@ -168,11 +170,11 @@ public class CertificateAuthority {
   private static X509CertInfo makeX509CertInfo(
       String sigAlg,
       String subjectName,
+      ZonedDateTime start,
       Period validity,
       PublicKey publicKey,
       CertificateExtensions certificateExtensions)
       throws IOException, CertificateException, NoSuchAlgorithmException {
-    ZonedDateTime start = ZonedDateTime.now();
     ZonedDateTime end = start.plus(validity);
 
     X500Name myname = new X500Name("CN=" + subjectName);


### PR DESCRIPTION
There is an issue when using dynamically generated certificates for TLS connections to Wiremock regarding the certificate validity start time. The certificates are generated with validity start time being the same instant as the request arrives. If Wiremock runs at the same machine as the client, the problem doesn't manifest itself as they are both using the same clock. However, if the client is somewhere else and its time lags behind the Wiremock machine's time, even if it's an infinitesimal difference, the certificates won't be marked as valid.

To fix the clock skew problem, the certificates are now generated using a day before the present moment as the start time. This avoids the problem.