### PR TITLE
Skips NPE when a multipart could not be parsed

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
@@ -81,7 +81,7 @@ public class StubMappingJsonRecorder implements RequestListener {
       }
     }
 
-    if (request.isMultipart()) {
+    if (request.isMultipart() && request.getParts() != null) {
       for (Request.Part part : request.getParts()) {
         builder.withRequestBodyPart(valuePatternForPart(part));
       }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -484,6 +484,44 @@ public class StubMappingJsonRecorderTest {
             argThat(equalToJson(MULTIPART_REQUEST_MAPPING, STRICT_ORDER)));
   }
 
+  private static final String BAD_MULTIPART_REQUEST_MAPPING =
+      "{ 													             \n"
+          + "	\"id\": \"41544750-0c69-3fd7-93b1-f79499f987c3\",				\n"
+          + "	\"uuid\": \"41544750-0c69-3fd7-93b1-f79499f987c3\",				\n"
+          + "	\"request\": {									             \n"
+          + "		\"url\": \"/multipart/content\",                         \n"
+          + "		\"method\": \"POST\" 						             \n"
+          + "	},												             \n"
+          + "	\"response\": {									             \n"
+          + "		\"status\": 200, 							             \n"
+          + "		\"bodyFileName\": \"body-multipart-content-1$2!3.txt\"        \n"
+          + "	}												             \n"
+          + "}";
+
+  @Test
+  public void multipartRequestProcessingWithNonFileMultipart() {
+    when(admin.countRequestsMatching((any(RequestPattern.class))))
+            .thenReturn(VerificationResult.withCount(0));
+
+    Request request =
+            new MockRequestBuilder()
+                    .withMethod(RequestMethod.POST)
+                    .withHeader("Content-Type", "multipart/form-data; boundary=aBoundary")
+                    .withUrl("/multipart/content")
+                    .withBody("--aBoundary\r\nContent")
+                    .withMultiparts(null) // this is what request.getParts returns when parsing doesn't work
+                    .build();
+    doReturn(true).when(request).isMultipart();
+
+    listener.requestReceived(
+            request, response().status(200).body("anything").fromProxy(true).build());
+
+    verify(mappingsFileSource)
+            .writeTextFile(
+                    eq("mapping-multipart-content-1$2!3.json"),
+                    argThat(equalToJson(BAD_MULTIPART_REQUEST_MAPPING, STRICT_ORDER)));
+  }
+
   @Test
   public void detectsJsonExtensionFromFileExtension() throws Exception {
     assertResultingFileExtension("/my/file.json", "json");


### PR DESCRIPTION
Recording the body instead.

This can happen when content of the multipart is not a file, so there is no header with content disposition giving it a filename. E.g. an OData $batch request.

Wiremock is currently failing the request, giving a 500 back because of the NPE, even when proxying when we got proper data back.

**edit** went a bit further on the library and saw what was going on, I assumed the lib I was using bad generating the request wrong and hence couldn't be parsed, but really wiremock assumes is going to be files whose parsing will work, not a bad assumption but it doesn't fit certain cases and the NPE is bad.