### PR TITLE
Allow fixing class loader in ClasspathFileSource

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/ClasspathFileSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/ClasspathFileSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Thomas Akehurst
+ * Copyright (C) 2014-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,17 +40,25 @@ import java.util.zip.ZipFile;
 public class ClasspathFileSource implements FileSource {
 
   private final String path;
+  private final ClassLoader classLoader;
   private URI pathUri;
   private ZipFile zipFile;
   private File rootDirectory;
 
   public ClasspathFileSource(String path) {
+    this((ClassLoader) null, path);
+  }
+
+  public ClasspathFileSource(Class<?> classpath, String path) {
+    this(classpath.getClassLoader(), path);
+  }
+
+  public ClasspathFileSource(ClassLoader classLoader, String path) {
     this.path = path;
+    this.classLoader = classLoader;
 
     try {
-      URL resource =
-          firstNonNull(currentThread().getContextClassLoader(), Resources.class.getClassLoader())
-              .getResource(path);
+      URL resource = getClassLoader().getResource(path);
 
       if (resource == null) {
         rootDirectory = new File(path);
@@ -75,6 +83,11 @@ public class ClasspathFileSource implements FileSource {
     } catch (Exception e) {
       throwUnchecked(e);
     }
+  }
+
+  private ClassLoader getClassLoader() {
+    if (classLoader != null) return classLoader;
+    return firstNonNull(currentThread().getContextClassLoader(), Resources.class.getClassLoader());
   }
 
   private boolean isFileSystem() {
@@ -119,7 +132,7 @@ public class ClasspathFileSource implements FileSource {
 
   @Override
   public FileSource child(String subDirectoryName) {
-    return new ClasspathFileSource(path + "/" + subDirectoryName);
+    return new ClasspathFileSource(classLoader, path + "/" + subDirectoryName);
   }
 
   @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/common/ClasspathFileSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/ClasspathFileSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Thomas Akehurst
+ * Copyright (C) 2014-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.File;
+import java.net.*;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -66,6 +68,15 @@ public class ClasspathFileSourceTest {
     initForJar();
 
     BinaryFile binaryFile = classpathFileSource.getBinaryFileNamed("guava/pom.xml");
+
+    assertThat("Expected a non zero length file", binaryFile.readContents().length, greaterThan(0));
+  }
+
+  @Test
+  public void readsBinaryFileFromCustomClassLoader() throws MalformedURLException {
+    initForCustomClassLoader();
+
+    BinaryFile binaryFile = classpathFileSource.child("__files").getBinaryFileNamed("stuff.txt");
 
     assertThat("Expected a non zero length file", binaryFile.readContents().length, greaterThan(0));
   }
@@ -129,11 +140,17 @@ public class ClasspathFileSourceTest {
     classpathFileSource.createIfNecessary();
   }
 
-  void initForJar() {
+  private void initForJar() {
     classpathFileSource = new ClasspathFileSource("META-INF/maven/com.google.guava");
   }
 
   private void initForFileSystem() {
     classpathFileSource = new ClasspathFileSource("filesource");
+  }
+
+  private void initForCustomClassLoader() throws MalformedURLException {
+    URL[] urls = {new File("src/main/resources/classpath-filesource.jar").toURI().toURL()};
+    ClassLoader cl = new URLClassLoader(urls);
+    classpathFileSource = new ClasspathFileSource(cl, "jar-filesource");
   }
 }


### PR DESCRIPTION
I sometimes experience problems with ClassPathFileSource when I am using a dependency with Wiremock files and the web framework changes the context class loader to do its own magic.

This small change allows to pin the class loader of a ClassPathFileSource. Existing behavior is not modified.