### PR TITLE
Bump commons-fileupload version from 1.4 to 1.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     exclude group: 'org.mozilla', module: 'rhino'
   }
 
-  api 'commons-fileupload:commons-fileupload:1.4',  {
+  api 'commons-fileupload:commons-fileupload:1.5',  {
     exclude group: 'commons-io', module: 'commons-io'
   }
   api "commons-io:commons-io:2.11.0"

--- a/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Thomas Akehurst
+ * Copyright (C) 2019-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,16 @@ package com.github.tomakehurst.wiremock.http.multipart;
 import com.github.tomakehurst.wiremock.http.Body;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
-import com.github.tomakehurst.wiremock.http.Request;
-import com.google.common.base.Function;
+import com.github.tomakehurst.wiremock.http.Request.Part;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.Iterators;
 import java.util.Iterator;
+import java.util.function.Function;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemHeaders;
 
-public class FileItemPartAdapter implements Request.Part {
+public class FileItemPartAdapter implements Part {
 
   private final FileItem fileItem;
 
@@ -49,7 +50,7 @@ public class FileItemPartAdapter implements Request.Part {
   public HttpHeaders getHeaders() {
     FileItemHeaders headers = fileItem.getHeaders();
     Iterator<String> i = headers.getHeaderNames();
-    ImmutableList.Builder<HttpHeader> builder = ImmutableList.builder();
+    Builder<HttpHeader> builder = ImmutableList.builder();
     while (i.hasNext()) {
       String name = i.next();
       builder.add(getHeader(name));
@@ -63,11 +64,5 @@ public class FileItemPartAdapter implements Request.Part {
     return new Body(fileItem.get());
   }
 
-  public static final Function<FileItem, Request.Part> TO_PARTS =
-      new Function<FileItem, Request.Part>() {
-        @Override
-        public Request.Part apply(FileItem fileItem) {
-          return new FileItemPartAdapter(fileItem);
-        }
-      };
+  public static final Function<FileItem, Part> TO_PARTS = FileItemPartAdapter::new;
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/multipart/PartParser.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/multipart/PartParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Thomas Akehurst
+ * Copyright (C) 2019-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@ import static com.github.tomakehurst.wiremock.http.multipart.FileItemPartAdapter
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.Request;
-import com.google.common.collect.Lists;
+import com.github.tomakehurst.wiremock.http.Request.Part;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.FileUploadException;
@@ -37,7 +37,7 @@ import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 public class PartParser {
 
   @SuppressWarnings("unchecked")
-  public static Collection<Request.Part> parseFrom(Request request) {
+  public static Collection<Part> parseFrom(Request request) {
     FileItemFactory fileItemFactory =
         new DiskFileItemFactory(Integer.MAX_VALUE, new File(System.getProperty("java.io.tmpdir")));
 
@@ -52,7 +52,7 @@ public class PartParser {
 
     try {
       List<FileItem> items = upload.parseRequest(uploadContext);
-      return Lists.transform(items, TO_PARTS);
+      return items.stream().map(TO_PARTS).collect(Collectors.toList());
     } catch (FileUploadException e) {
       return throwUnchecked(e, Collection.class);
     }
@@ -96,7 +96,7 @@ public class PartParser {
     }
 
     @Override
-    public InputStream getInputStream() throws IOException {
+    public InputStream getInputStream() {
       return new ByteArrayInputStream(content);
     }
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/jetty11/MultipartParser.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/jetty11/MultipartParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Thomas Akehurst
+ * Copyright (C) 2018-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.github.tomakehurst.wiremock.jetty11;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
-import static com.google.common.collect.FluentIterable.from;
 
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.servlet.WireMockHttpServletMultipartAdapter;
@@ -24,6 +23,7 @@ import com.google.common.base.Function;
 import jakarta.servlet.http.Part;
 import java.io.ByteArrayInputStream;
 import java.util.Collection;
+import java.util.stream.Collectors;
 import org.eclipse.jetty.server.MultiPartInputStreamParser;
 
 public class MultipartParser {
@@ -33,15 +33,9 @@ public class MultipartParser {
     MultiPartInputStreamParser parser =
         new MultiPartInputStreamParser(new ByteArrayInputStream(body), contentType, null, null);
     try {
-      return from(parser.getParts())
-          .transform(
-              new Function<Part, Request.Part>() {
-                @Override
-                public Request.Part apply(Part input) {
-                  return WireMockHttpServletMultipartAdapter.from(input);
-                }
-              })
-          .toList();
+      return parser.getParts().stream()
+          .map((Function<Part, Request.Part>) WireMockHttpServletMultipartAdapter::from)
+          .collect(Collectors.toList());
     } catch (Exception e) {
       return throwUnchecked(e, Collection.class);
     }


### PR DESCRIPTION
Hey,

Fix a DoS vulnerability described in https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-3326457 and small refactoring.

It seems the `setFileCountMax()` is not necessary. Wiremock has its own FIleUpload class and is used for testing scenarios only (no untrusted user input).

Thank you for your time!