### PR TITLE
Fix JUnit5 extension bug when using both declarative + programmatic simultaneously 

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.junit.platform.commons.support.AnnotationSupport;
 /**
  * JUnit Jupiter extension that manages a WireMock server instance's lifecycle and configuration.
  *
- * See http://wiremock.org/docs/junit-jupiter/ for full documentation.
+ * <p>See http://wiremock.org/docs/junit-jupiter/ for full documentation.
  */
 public class WireMockExtension extends DslWrapper
     implements ParameterResolver,
@@ -59,10 +59,11 @@ public class WireMockExtension extends DslWrapper
   /**
    * Constructor intended for subclasses.
    *
-   * The parameter is a builder so that we can avoid a constructor explosion or
+   * <p>The parameter is a builder so that we can avoid a constructor explosion or
    * backwards-incompatible changes when new options are added.
    *
-   * @param builder a {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder} instance holding the initialisation parameters for the extension.
+   * @param builder a {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *     instance holding the initialisation parameters for the extension.
    */
   protected WireMockExtension(Builder builder) {
     this.options = builder.options;
@@ -85,8 +86,11 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * Alias for {@link #newInstance()} for use with custom subclasses, with a more relevant name for that use.
-   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder} instance.
+   * Alias for {@link #newInstance()} for use with custom subclasses, with a more relevant name for
+   * that use.
+   *
+   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *     instance.
    */
   public static Builder extensionOptions() {
     return newInstance();
@@ -94,7 +98,9 @@ public class WireMockExtension extends DslWrapper
 
   /**
    * Create a new builder for the extension.
-   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder} instance.
+   *
+   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *     instance.
    */
   public static Builder newInstance() {
     return new Builder();
@@ -102,25 +108,35 @@ public class WireMockExtension extends DslWrapper
 
   /**
    * To be overridden in subclasses in order to run code immediately after per-class WireMock setup.
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock instance/
+   *
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onBeforeAll(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
    * To be overridden in subclasses in order to run code immediately after per-test WireMock setup.
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock instance/
+   *
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onBeforeEach(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-test cleanup of WireMock and its associated resources.
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock instance/
+   * To be overridden in subclasses in order to run code immediately after per-test cleanup of
+   * WireMock and its associated resources.
+   *
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onAfterEach(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-class cleanup of WireMock.
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock instance/
+   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
+   * WireMock.
+   *
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onAfterAll(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
@@ -179,8 +195,7 @@ public class WireMockExtension extends DslWrapper
             annotatedElement ->
                 this.isDeclarative
                     ? AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class)
-                    : Optional.empty()
-        )
+                    : Optional.empty())
         .<Options>map(this::buildOptionsFromWireMockTestAnnotation)
         .orElse(Optional.ofNullable(this.options).orElse(DEFAULT_OPTIONS));
   }
@@ -205,7 +220,8 @@ public class WireMockExtension extends DslWrapper
   }
 
   private boolean parameterIsWireMockRuntimeInfo(ParameterContext parameterContext) {
-    return parameterContext.getParameter().getType().equals(WireMockRuntimeInfo.class) && this.isDeclarative;
+    return parameterContext.getParameter().getType().equals(WireMockRuntimeInfo.class)
+        && this.isDeclarative;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -42,16 +42,17 @@ public class WireMockExtension extends DslWrapper
   private final boolean configureStaticDsl;
   private final boolean failOnUnmatchedRequests;
 
+  private final boolean isDeclarative;
   private Options options;
   private WireMockServer wireMockServer;
   private WireMockRuntimeInfo runtimeInfo;
   private boolean isNonStatic = false;
-
   private Boolean proxyMode;
 
-  public WireMockExtension() {
+  WireMockExtension() {
     configureStaticDsl = true;
     failOnUnmatchedRequests = false;
+    isDeclarative = true;
   }
 
   /**
@@ -67,6 +68,7 @@ public class WireMockExtension extends DslWrapper
     this.configureStaticDsl = builder.configureStaticDsl;
     this.failOnUnmatchedRequests = builder.failOnUnmatchedRequests;
     this.proxyMode = builder.proxyMode;
+    this.isDeclarative = false;
   }
 
   private WireMockExtension(
@@ -78,6 +80,7 @@ public class WireMockExtension extends DslWrapper
     this.configureStaticDsl = configureStaticDsl;
     this.failOnUnmatchedRequests = failOnUnmatchedRequests;
     this.proxyMode = proxyMode;
+    this.isDeclarative = false;
   }
 
   /**
@@ -173,7 +176,10 @@ public class WireMockExtension extends DslWrapper
         .getElement()
         .flatMap(
             annotatedElement ->
-                AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class))
+                this.isDeclarative
+                    ? AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class)
+                    : Optional.empty()
+        )
         .<Options>map(this::buildOptionsFromWireMockTestAnnotation)
         .orElse(Optional.ofNullable(this.options).orElse(DEFAULT_OPTIONS));
   }
@@ -198,7 +204,7 @@ public class WireMockExtension extends DslWrapper
   }
 
   private boolean parameterIsWireMockRuntimeInfo(ParameterContext parameterContext) {
-    return parameterContext.getParameter().getType().equals(WireMockRuntimeInfo.class);
+    return parameterContext.getParameter().getType().equals(WireMockRuntimeInfo.class) && this.isDeclarative;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -43,6 +43,7 @@ public class WireMockExtension extends DslWrapper
   private final boolean failOnUnmatchedRequests;
 
   private final boolean isDeclarative;
+
   private Options options;
   private WireMockServer wireMockServer;
   private WireMockRuntimeInfo runtimeInfo;

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionDeclarativeProgrammaticMixTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionDeclarativeProgrammaticMixTest.java
@@ -1,0 +1,113 @@
+package com.github.tomakehurst.wiremock.junit5;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class JUnitJupiterExtensionDeclarativeProgrammaticMixTest {
+    @WireMockTest
+    public static class TestSaneStaticDefaults {
+        @RegisterExtension
+        public static WireMockExtension wms = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(44345))
+            .build();
+
+        @Test
+        void programmatic_port_option_used_when_no_port_specified_in_attributes_static() {
+            final int port = wms.getPort();
+            assertThat(port, is(44345));
+        }
+
+        @Test
+        void programmatic_port_is_different_from_declarative_port(WireMockRuntimeInfo wmRuntimeInfo) {
+            final int declarativePort = wmRuntimeInfo.getHttpPort();
+            final int staticMemberPort = wms.getPort();
+            assertThat(staticMemberPort, is(not(declarativePort)));
+        }
+
+        @Test
+        void wiremockruntimeinfo_always_injects_declarative_instance(WireMockRuntimeInfo wmRuntimeInfo) {
+            WireMockRuntimeInfo staticMemberRuntimeInfo = wms.getRuntimeInfo();
+            assertThat(wmRuntimeInfo, is(notNullValue()));
+            assertThat(wmRuntimeInfo, is(not(staticMemberRuntimeInfo)));
+        }
+    }
+
+    @WireMockTest(httpPort = 44777)
+    public static class TestNoStaticOverride {
+        @RegisterExtension
+        public static WireMockExtension wms = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(44346))
+            .build();
+
+        @Test
+        void programmatic_and_declarative_ports_are_as_defined(WireMockRuntimeInfo wmRuntimeInfo) {
+            final int declarativePort = wmRuntimeInfo.getHttpPort();
+            final int staticMemberPort = wms.getPort();
+
+            assertThat(staticMemberPort, is(44346));
+            assertThat(declarativePort, is(44777));
+        }
+    }
+
+    @WireMockTest
+    public static class TestSaneInstanceDefaults {
+        @RegisterExtension
+        public WireMockExtension wmi = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(44349))
+            .build();
+
+        @Test
+        void programmatic_port_option_used_when_no_port_specified_in_attributes_instance() {
+            final int port = wmi.getPort();
+            assertThat(port, is(44349));
+        }
+
+        @Test
+        void programmatic_port_is_different_from_declarative_port(WireMockRuntimeInfo wmRuntimeInfo) {
+            final int declarativePort = wmRuntimeInfo.getHttpPort();
+            final int staticMemberPort = wmi.getPort();
+            assertThat(staticMemberPort, is(not(declarativePort)));
+        }
+
+        @Test
+        void wiremockruntimeinfo_always_injects_declarative_instance(WireMockRuntimeInfo wmRuntimeInfo) {
+            WireMockRuntimeInfo staticMemberRuntimeInfo = wmi.getRuntimeInfo();
+            assertThat(wmRuntimeInfo, is(notNullValue()));
+            assertThat(wmRuntimeInfo, is(not(staticMemberRuntimeInfo)));
+        }
+    }
+
+    @WireMockTest(httpPort = 44778)
+    public static class TestNoInstanceOverride {
+        @RegisterExtension
+        public WireMockExtension wmi = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(44351))
+            .build();
+
+        @Test
+        void programmatic_port_option_used_when_no_port_specified_in_attributes_instance() {
+            final int port = wmi.getPort();
+            assertThat(port, is(44351));
+        }
+
+        @Test
+        void programmatic_port_is_different_from_declarative_port(WireMockRuntimeInfo wmRuntimeInfo) {
+            final int declarativePort = wmRuntimeInfo.getHttpPort();
+            final int staticMemberPort = wmi.getPort();
+            assertThat(staticMemberPort, is(not(declarativePort)));
+        }
+
+        @Test
+        void wiremockruntimeinfo_always_injects_declarative_instance(WireMockRuntimeInfo wmRuntimeInfo) {
+            WireMockRuntimeInfo staticMemberRuntimeInfo = wmi.getRuntimeInfo();
+            assertThat(wmRuntimeInfo, is(notNullValue()));
+            assertThat(wmRuntimeInfo, is(not(staticMemberRuntimeInfo)));
+        }
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionDeclarativeProgrammaticMixTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionDeclarativeProgrammaticMixTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.tomakehurst.wiremock.junit5;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
@@ -10,104 +25,103 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class JUnitJupiterExtensionDeclarativeProgrammaticMixTest {
-    @WireMockTest
-    public static class TestSaneStaticDefaults {
-        @RegisterExtension
-        public static WireMockExtension wms = WireMockExtension.newInstance()
-            .options(wireMockConfig().port(44345))
-            .build();
+  @WireMockTest
+  public static class TestSaneStaticDefaults {
+    @RegisterExtension
+    public static WireMockExtension wms =
+        WireMockExtension.newInstance().options(wireMockConfig().port(44345)).build();
 
-        @Test
-        void programmatic_port_option_used_when_no_port_specified_in_attributes_static() {
-            final int port = wms.getPort();
-            assertThat(port, is(44345));
-        }
-
-        @Test
-        void programmatic_port_is_different_from_declarative_port(WireMockRuntimeInfo wmRuntimeInfo) {
-            final int declarativePort = wmRuntimeInfo.getHttpPort();
-            final int staticMemberPort = wms.getPort();
-            assertThat(staticMemberPort, is(not(declarativePort)));
-        }
-
-        @Test
-        void wiremockruntimeinfo_always_injects_declarative_instance(WireMockRuntimeInfo wmRuntimeInfo) {
-            WireMockRuntimeInfo staticMemberRuntimeInfo = wms.getRuntimeInfo();
-            assertThat(wmRuntimeInfo, is(notNullValue()));
-            assertThat(wmRuntimeInfo, is(not(staticMemberRuntimeInfo)));
-        }
+    @Test
+    void programmatic_port_option_used_when_no_port_specified_in_attributes_static() {
+      final int port = wms.getPort();
+      assertThat(port, is(44345));
     }
 
-    @WireMockTest(httpPort = 44777)
-    public static class TestNoStaticOverride {
-        @RegisterExtension
-        public static WireMockExtension wms = WireMockExtension.newInstance()
-            .options(wireMockConfig().port(44346))
-            .build();
-
-        @Test
-        void programmatic_and_declarative_ports_are_as_defined(WireMockRuntimeInfo wmRuntimeInfo) {
-            final int declarativePort = wmRuntimeInfo.getHttpPort();
-            final int staticMemberPort = wms.getPort();
-
-            assertThat(staticMemberPort, is(44346));
-            assertThat(declarativePort, is(44777));
-        }
+    @Test
+    void programmatic_port_is_different_from_declarative_port(WireMockRuntimeInfo wmRuntimeInfo) {
+      final int declarativePort = wmRuntimeInfo.getHttpPort();
+      final int staticMemberPort = wms.getPort();
+      assertThat(staticMemberPort, is(not(declarativePort)));
     }
 
-    @WireMockTest
-    public static class TestSaneInstanceDefaults {
-        @RegisterExtension
-        public WireMockExtension wmi = WireMockExtension.newInstance()
-            .options(wireMockConfig().port(44349))
-            .build();
+    @Test
+    void wiremockruntimeinfo_always_injects_declarative_instance(
+        WireMockRuntimeInfo wmRuntimeInfo) {
+      WireMockRuntimeInfo staticMemberRuntimeInfo = wms.getRuntimeInfo();
+      assertThat(wmRuntimeInfo, is(notNullValue()));
+      assertThat(wmRuntimeInfo, is(not(staticMemberRuntimeInfo)));
+    }
+  }
 
-        @Test
-        void programmatic_port_option_used_when_no_port_specified_in_attributes_instance() {
-            final int port = wmi.getPort();
-            assertThat(port, is(44349));
-        }
+  @WireMockTest(httpPort = 44777)
+  public static class TestNoStaticOverride {
+    @RegisterExtension
+    public static WireMockExtension wms =
+        WireMockExtension.newInstance().options(wireMockConfig().port(44346)).build();
 
-        @Test
-        void programmatic_port_is_different_from_declarative_port(WireMockRuntimeInfo wmRuntimeInfo) {
-            final int declarativePort = wmRuntimeInfo.getHttpPort();
-            final int staticMemberPort = wmi.getPort();
-            assertThat(staticMemberPort, is(not(declarativePort)));
-        }
+    @Test
+    void programmatic_and_declarative_ports_are_as_defined(WireMockRuntimeInfo wmRuntimeInfo) {
+      final int declarativePort = wmRuntimeInfo.getHttpPort();
+      final int staticMemberPort = wms.getPort();
 
-        @Test
-        void wiremockruntimeinfo_always_injects_declarative_instance(WireMockRuntimeInfo wmRuntimeInfo) {
-            WireMockRuntimeInfo staticMemberRuntimeInfo = wmi.getRuntimeInfo();
-            assertThat(wmRuntimeInfo, is(notNullValue()));
-            assertThat(wmRuntimeInfo, is(not(staticMemberRuntimeInfo)));
-        }
+      assertThat(staticMemberPort, is(44346));
+      assertThat(declarativePort, is(44777));
+    }
+  }
+
+  @WireMockTest
+  public static class TestSaneInstanceDefaults {
+    @RegisterExtension
+    public WireMockExtension wmi =
+        WireMockExtension.newInstance().options(wireMockConfig().port(44349)).build();
+
+    @Test
+    void programmatic_port_option_used_when_no_port_specified_in_attributes_instance() {
+      final int port = wmi.getPort();
+      assertThat(port, is(44349));
     }
 
-    @WireMockTest(httpPort = 44778)
-    public static class TestNoInstanceOverride {
-        @RegisterExtension
-        public WireMockExtension wmi = WireMockExtension.newInstance()
-            .options(wireMockConfig().port(44351))
-            .build();
-
-        @Test
-        void programmatic_port_option_used_when_no_port_specified_in_attributes_instance() {
-            final int port = wmi.getPort();
-            assertThat(port, is(44351));
-        }
-
-        @Test
-        void programmatic_port_is_different_from_declarative_port(WireMockRuntimeInfo wmRuntimeInfo) {
-            final int declarativePort = wmRuntimeInfo.getHttpPort();
-            final int staticMemberPort = wmi.getPort();
-            assertThat(staticMemberPort, is(not(declarativePort)));
-        }
-
-        @Test
-        void wiremockruntimeinfo_always_injects_declarative_instance(WireMockRuntimeInfo wmRuntimeInfo) {
-            WireMockRuntimeInfo staticMemberRuntimeInfo = wmi.getRuntimeInfo();
-            assertThat(wmRuntimeInfo, is(notNullValue()));
-            assertThat(wmRuntimeInfo, is(not(staticMemberRuntimeInfo)));
-        }
+    @Test
+    void programmatic_port_is_different_from_declarative_port(WireMockRuntimeInfo wmRuntimeInfo) {
+      final int declarativePort = wmRuntimeInfo.getHttpPort();
+      final int staticMemberPort = wmi.getPort();
+      assertThat(staticMemberPort, is(not(declarativePort)));
     }
+
+    @Test
+    void wiremockruntimeinfo_always_injects_declarative_instance(
+        WireMockRuntimeInfo wmRuntimeInfo) {
+      WireMockRuntimeInfo staticMemberRuntimeInfo = wmi.getRuntimeInfo();
+      assertThat(wmRuntimeInfo, is(notNullValue()));
+      assertThat(wmRuntimeInfo, is(not(staticMemberRuntimeInfo)));
+    }
+  }
+
+  @WireMockTest(httpPort = 44778)
+  public static class TestNoInstanceOverride {
+    @RegisterExtension
+    public WireMockExtension wmi =
+        WireMockExtension.newInstance().options(wireMockConfig().port(44351)).build();
+
+    @Test
+    void programmatic_port_option_used_when_no_port_specified_in_attributes_instance() {
+      final int port = wmi.getPort();
+      assertThat(port, is(44351));
+    }
+
+    @Test
+    void programmatic_port_is_different_from_declarative_port(WireMockRuntimeInfo wmRuntimeInfo) {
+      final int declarativePort = wmRuntimeInfo.getHttpPort();
+      final int staticMemberPort = wmi.getPort();
+      assertThat(staticMemberPort, is(not(declarativePort)));
+    }
+
+    @Test
+    void wiremockruntimeinfo_always_injects_declarative_instance(
+        WireMockRuntimeInfo wmRuntimeInfo) {
+      WireMockRuntimeInfo staticMemberRuntimeInfo = wmi.getRuntimeInfo();
+      assertThat(wmRuntimeInfo, is(notNullValue()));
+      assertThat(wmRuntimeInfo, is(not(staticMemberRuntimeInfo)));
+    }
+  }
 }


### PR DESCRIPTION
This fixes #2122, please see the issue described there for details.

This PR makes it so that the options of httpPort/httpsPort/httpsEnabled/proxyMode and anything else that might be configured through the `@WireMockTest` attribute for a declarative setup in JUnit5 does not override programmatically configured options.