### PR TITLE
Allow request body content from file

### DIFF
--- a/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
+++ b/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
@@ -33,6 +33,7 @@ public class WebhookDefinition {
   private String url;
   private List<HttpHeader> headers;
   private Body body = Body.none();
+  private String bodyFileName;
   private DelayDistribution delay;
   private Parameters parameters;
 
@@ -43,6 +44,7 @@ public class WebhookDefinition {
         toHttpHeaders(parameters.getMetadata("headers", null)),
         parameters.getString("body", null),
         parameters.getString("base64Body", null),
+        parameters.getString("bodyFileName", null),
         getDelayDistribution(parameters.getMetadata("delay", null)),
         parameters);
   }
@@ -85,6 +87,7 @@ public class WebhookDefinition {
       String url,
       HttpHeaders headers,
       String body,
+      String bodyFileName,
       String base64Body,
       DelayDistribution delay,
       Parameters parameters) {
@@ -127,6 +130,15 @@ public class WebhookDefinition {
 
   public String getBody() {
     return body.isBinary() ? null : body.asString();
+  }
+
+  public String getBodyFileName() {
+    return bodyFileName;
+  }
+
+  @JsonIgnore
+  public boolean specifiesBodyFile() {
+    return bodyFileName != null && body.isAbsent();
   }
 
   public DelayDistribution getDelay() {

--- a/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -165,7 +165,10 @@ public class Webhooks extends PostServeAction {
                                     .collect(toList())))
                     .collect(toList()));
 
-    if (webhookDefinition.getBody() != null) {
+    if (webhookDefinition.specifiesBodyFile()) { 
+      renderedWebhookDefinition =
+          webhookDefinition.withBody(renderTemplate(model, webhookDefinition.getBodyFileName()));
+    } else if (webhookDefinition.getBody() != null) {
       renderedWebhookDefinition =
           webhookDefinition.withBody(renderTemplate(model, webhookDefinition.getBody()));
     }


### PR DESCRIPTION
I want to be able to have the webhook request body in a file in __files
e.g.
```
  "postServeActions": [
        {
            "name": "webhook",
            "parameters": {
                "method": "POST",
                "url": "http://localhost:8099/",
                "headers": {
                    "Content-Type": "application/json"
                },
                "bodyFileName": "req_scp_voice.json"
            }
        }
    ]

```

