### PR TITLE
Fix the Slack link in the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ to it evoltion.
 You can help make WireMock a better tool in a number of ways:
 
 * Write or improve [documentation](#writing-documentation).
-* Join the [community Slack channel](https://join.slack.com/t/wiremock-community/shared_invite/zt-1mkbo0zlx-gxeZdTJ15Kchdt888Fn_1A), help other WireMock users and share tips. 
+* Join the [community Slack channel](http://slack.wiremock.org/), help other WireMock users and share tips. 
 * Raise an issue if you discover a bug.
 * Contribute bug fixes, new features or enhancements.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ to it evoltion.
 You can help make WireMock a better tool in a number of ways:
 
 * Write or improve [documentation](#writing-documentation).
-* Join the [community Slack channel](https://up9.slack.com/archives/C02V3EGV3U3), help other WireMock users and share tips. 
+* Join the [community Slack channel](https://join.slack.com/t/wiremock-community/shared_invite/zt-1mkbo0zlx-gxeZdTJ15Kchdt888Fn_1A), help other WireMock users and share tips. 
 * Raise an issue if you discover a bug.
 * Contribute bug fixes, new features or enhancements.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ WireMock - a web service test double for all occasions
 
 [![Build Status](https://github.com/tomakehurst/wiremock/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/tomakehurst/wiremock/actions/workflows/build-and-test.yml)
 [![Docs](https://img.shields.io/static/v1?label=Documentation&message=public&color=green)](https://wiremock.org/docs/)
-[![a](https://img.shields.io/badge/slack-Join%20us-brightgreen?style=flat&logo=slack)](https://join.slack.com/t/wiremock-community/shared_invite/zt-1mkbo0zlx-gxeZdTJ15Kchdt888Fn_1A)
+[![a](https://img.shields.io/badge/slack-Join%20us-brightgreen?style=flat&logo=slack)](http://slack.wiremock.org/)
 [![Participate](https://img.shields.io/static/v1?label=Contributing&message=guide&color=orange)](https://github.com/wiremock/wiremock/blob/master/CONTRIBUTING.md)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.tomakehurst/wiremock-jre8.svg)](https://search.maven.org/artifact/com.github.tomakehurst/wiremock-jre8)
 


### PR DESCRIPTION
Just a quick fix. The real improvement for this situation will be https://github.com/wiremock/wiremock.org-sources/issues/28 . Addresses https://github.com/wiremock/wiremock.org-sources/issues/31 for now