### PR TITLE
Configure default ObjectMapper with JavaTimeModule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,8 @@ dependencies {
   api platform("com.fasterxml.jackson:jackson-bom:$versions.jackson")
   api "com.fasterxml.jackson.core:jackson-core",
       "com.fasterxml.jackson.core:jackson-annotations",
-      "com.fasterxml.jackson.core:jackson-databind"
+      "com.fasterxml.jackson.core:jackson-databind",
+      "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
   api "org.apache.httpcomponents.client5:httpclient5:5.2.1"
   api "org.xmlunit:xmlunit-core:$versions.xmlUnit"
   api "org.xmlunit:xmlunit-legacy:$versions.xmlUnit", {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Thomas Akehurst
+ * Copyright (C) 2011-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
 import java.util.Map;
 
@@ -46,6 +48,8 @@ public final class Json {
           objectMapper.configure(JsonParser.Feature.IGNORE_UNDEFINED, true);
           objectMapper.configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true);
           objectMapper.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true);
+          objectMapper.registerModule(new JavaTimeModule());
+          objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
           return objectMapper;
         }
       };

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/ParametersTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/ParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,10 @@ package com.github.tomakehurst.wiremock.extension;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.time.LocalDate;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 public class ParametersTest {
@@ -30,7 +29,8 @@ public class ParametersTest {
   @Test
   public void convertsParametersToAnObject() {
     MyData myData =
-        Parameters.from(ImmutableMap.of("name", "Tom", "num", 27, "date", "2023-01-01")).as(MyData.class);
+        Parameters.from(ImmutableMap.of("name", "Tom", "num", 27, "date", "2023-01-01"))
+            .as(MyData.class);
 
     assertThat(myData.getName(), is("Tom"));
     assertThat(myData.getNum(), is(27));
@@ -55,7 +55,9 @@ public class ParametersTest {
     private final LocalDate date;
 
     @JsonCreator
-    public MyData(@JsonProperty("name") String name, @JsonProperty("num") Integer num,
+    public MyData(
+        @JsonProperty("name") String name,
+        @JsonProperty("num") Integer num,
         @JsonProperty("date") LocalDate date) {
       this.name = name;
       this.num = num;

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/ParametersTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/ParametersTest.java
@@ -18,6 +18,8 @@ package com.github.tomakehurst.wiremock.extension;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import java.time.LocalDate;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
@@ -28,31 +30,36 @@ public class ParametersTest {
   @Test
   public void convertsParametersToAnObject() {
     MyData myData =
-        Parameters.from(ImmutableMap.<String, Object>of("name", "Tom", "num", 27)).as(MyData.class);
+        Parameters.from(ImmutableMap.of("name", "Tom", "num", 27, "date", "2023-01-01")).as(MyData.class);
 
     assertThat(myData.getName(), is("Tom"));
     assertThat(myData.getNum(), is(27));
+    assertThat(myData.getDate(), is(LocalDate.of(2023, 1, 1)));
   }
 
   @Test
   public void convertsToParametersFromAnObject() {
-    MyData myData = new MyData("Mark", 12);
+    MyData myData = new MyData("Mark", 12, LocalDate.of(2023, 1, 1));
 
     Parameters parameters = Parameters.of(myData);
 
     assertThat(parameters.getString("name"), is("Mark"));
     assertThat(parameters.getInt("num"), is(12));
+    assertThat(parameters.getString("date"), is("2023-01-01"));
   }
 
   public static class MyData {
 
     private final String name;
     private final Integer num;
+    private final LocalDate date;
 
     @JsonCreator
-    public MyData(@JsonProperty("name") String name, @JsonProperty("num") Integer num) {
+    public MyData(@JsonProperty("name") String name, @JsonProperty("num") Integer num,
+        @JsonProperty("date") LocalDate date) {
       this.name = name;
       this.num = num;
+      this.date = date;
     }
 
     public String getName() {
@@ -61,6 +68,10 @@ public class ParametersTest {
 
     public Integer getNum() {
       return num;
+    }
+
+    public LocalDate getDate() {
+      return date;
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/wiremock/wiremock/issues/1127

* registers JavaTimeModule, "Class that registers capability of serializing java.time objects with the Jackson core." https://fasterxml.github.io/jackson-modules-java8/javadoc/datetime/2.9/com/fasterxml/jackson/datatype/jsr310/JavaTimeModule.html
* I recommend disabling SerializationFeature.WRITE_DATES_AS_TIMESTAMPS as explained [here](https://www.baeldung.com/jackson-serialize-dates#iso-8601)