### PR TITLE
feat: add a requestedFor method allowing to pass Http method as parameter

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -840,6 +840,10 @@ public class WireMock {
     return new RequestPatternBuilder(RequestMethod.ANY, urlPattern);
   }
 
+  public static RequestPatternBuilder requestedFor(String method, UrlPattern urlPattern) {
+    return new RequestPatternBuilder(RequestMethod.fromString(method), urlPattern);
+  }
+
   public static RequestPatternBuilder requestMadeFor(
       String customMatcherName, Parameters parameters) {
     return RequestPatternBuilder.forCustomMatcher(customMatcherName, parameters);

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -52,6 +52,8 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class VerificationAcceptanceTest {
 
@@ -533,6 +535,16 @@ public class VerificationAcceptanceTest {
           getRequestedFor(urlEqualTo("/without/header"))
               .withHeader("Content-Type", equalTo("application/json"))
               .withoutHeader("Accept"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+          "GET", "POST", "PUT", "HEAD", "TRACE", "PATCH", "OPTIONS", "DELETE", "ANY", "RANDOM"
+        })
+    public void verifyRequestedForSameMethodAsRequest(String method) {
+      testClient.request(method, "/methods");
+      verify(requestedFor(method, urlEqualTo("/methods")));
     }
 
     @Test


### PR DESCRIPTION
It is useful for parameterized test, when you also use `request(String method, UrlPattern urlPattern)`

So you are able to write your test like this:

```java
@ParameterizedTest
@ValueSource(strings = {"GET", "POST", "PUT", "HEAD", "TRACE", "PATCH", "OPTIONS", "DELETE", "ANY", "RANDOM"})
public void verifyRequestedForSameMethodAsRequest(String method) {
    wiremock.stubFor(request(method, urlEqualTo("/methods")).willReturn(ok("response"));
    // ... Test stuff here
    verify(requestedFor(method, urlEqualTo("/methods")));
}
```

- I look at https://wiremock.org/docs/verifying/ and there is not an exhaustive list of the applicable method, so I did not modified the documentation

## References

- https://github.com/wiremock/wiremock/issues/2174

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
