### PR TITLE
Add convenient method for matching absence of query param in a request

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -193,6 +193,11 @@ public class RequestPatternBuilder {
     return this;
   }
 
+  public RequestPatternBuilder withoutQueryParam(String key) {
+    queryParams.put(key, MultiValuePattern.absent());
+    return this;
+  }
+
   public RequestPatternBuilder withCookie(String key, StringValuePattern valuePattern) {
     cookies.put(key, valuePattern);
     return this;

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -374,6 +374,27 @@ public class VerificationAcceptanceTest {
     }
 
     @Test
+    public void verifiesQueryParamAbsent() {
+      testClient.get("/without/queryParam?test-param=test-value");
+      verify(
+          getRequestedFor(urlPathEqualTo("/without/queryParam"))
+              .withQueryParam("test-param", equalTo("test-value"))
+              .withoutQueryParam("absent-param"));
+    }
+
+    @Test
+    public void failsVerificationWhenAbsentQueryParamPresent() {
+      assertThrows(
+          VerificationException.class,
+          () -> {
+            testClient.get("/without/queryParam?test-param=test-value");
+            verify(
+                getRequestedFor(urlPathEqualTo("/without/queryParam"))
+                    .withoutQueryParam("test-param"));
+          });
+    }
+
+    @Test
     public void resetErasesCounters() {
       assertThrows(
           VerificationException.class,

--- a/src/test/java/ignored/Examples.java
+++ b/src/test/java/ignored/Examples.java
@@ -167,6 +167,17 @@ public class Examples extends AcceptanceTestBase {
   }
 
   @Test
+  public void verifyWithoutQueryParam() {
+    assertThrows(
+        VerificationException.class,
+        () -> {
+          verify(
+              getRequestedFor(urlPathEqualTo("without/queryParam"))
+                  .withoutQueryParam("test-param"));
+        });
+  }
+
+  @Test
   public void findingRequests() {
     List<LoggedRequest> requests = findAll(putRequestedFor(urlMatching("/api/.*")));
   }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This pull request adds a convenient method for matching absence of query param in a request.
Usage example :
```java
//after this pull request
verify(
    getRequestedFor(urlPathEqualTo("without/queryParam"))
        .withoutQueryParam("test-param"));
```

It was possible to verify the same even without this method as shown below, but felt counter-intuitive (given there is already a `withoutHeader` method).
```java
//before this pull request
verify(
    getRequestedFor(urlPathEqualTo("without/queryParam"))
        .withQueryParam("test-param", absent()));
```

## References

- This change was inspired by `withoutHeader` and follows similar pattern.
https://github.com/wiremock/wiremock/blob/2f8b5263d984b3cf212f898e52d4d1b4a52d338a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java#L166
- There is another pull request for adding similar method for form param.
https://github.com/wiremock/wiremock/pull/2193

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
