### PR TITLE
2197 | added field "mappings" to StubMapping and its processing if it exists

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/RemoteMappingsLoader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/RemoteMappingsLoader.java
@@ -48,6 +48,13 @@ public class RemoteMappingsLoader {
         filter(mappingsFileSource.listFilesRecursively(), byFileExtension("json"));
     for (TextFile mappingFile : mappingFiles) {
       StubMapping mapping = StubMapping.buildFrom(mappingFile.readContentsAsString());
+      if (mapping.getMappings() != null) {
+        mapping.getMappings().forEach(stubMapping -> {
+          convertBodyFromFileIfNecessary(stubMapping);
+          wireMock.register(stubMapping);
+        });
+        continue;
+      }
       convertBodyFromFileIfNecessary(mapping);
       wireMock.register(mapping);
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/RemoteMappingsLoader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/RemoteMappingsLoader.java
@@ -48,13 +48,6 @@ public class RemoteMappingsLoader {
         filter(mappingsFileSource.listFilesRecursively(), byFileExtension("json"));
     for (TextFile mappingFile : mappingFiles) {
       StubMapping mapping = StubMapping.buildFrom(mappingFile.readContentsAsString());
-      if (mapping.getMappings() != null) {
-        mapping.getMappings().forEach(stubMapping -> {
-          convertBodyFromFileIfNecessary(stubMapping);
-          wireMock.register(stubMapping);
-        });
-        continue;
-      }
       convertBodyFromFileIfNecessary(mapping);
       wireMock.register(mapping);
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/RemoteMappingsLoader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/RemoteMappingsLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class RemoteMappingsLoader {
     for (TextFile mappingFile : mappingFiles) {
       try {
         StubMappingCollection stubCollection =
-                Json.read(mappingFile.readContentsAsString(), StubMappingCollection.class);
+            Json.read(mappingFile.readContentsAsString(), StubMappingCollection.class);
         for (StubMapping mapping : stubCollection.getMappingOrMappings()) {
           convertBodyFromFileIfNecessary(mapping);
           wireMock.register(mapping);

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
@@ -54,6 +54,7 @@ public class StubMapping {
 
   private long insertionIndex;
   private boolean isDirty = true;
+  private List<StubMapping> mappings;
 
   public StubMapping(RequestPattern requestPattern, ResponseDefinition response) {
     setRequest(requestPattern);
@@ -246,6 +247,14 @@ public class StubMapping {
     this.metadata = metadata;
   }
 
+  public List<StubMapping> getMappings() {
+    return mappings;
+  }
+
+  public void setMappings(List<StubMapping> mappings) {
+    this.mappings = mappings;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -260,7 +269,8 @@ public class StubMapping {
         && Objects.equals(requiredScenarioState, that.requiredScenarioState)
         && Objects.equals(newScenarioState, that.newScenarioState)
         && Objects.equals(postServeActions, that.postServeActions)
-        && Objects.equals(metadata, that.metadata);
+        && Objects.equals(metadata, that.metadata)
+        && Objects.equals(mappings, that.mappings);
   }
 
   @Override
@@ -275,6 +285,7 @@ public class StubMapping {
         newScenarioState,
         postServeActions,
         metadata,
-        isDirty);
+        isDirty,
+        mappings);
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
@@ -54,7 +54,6 @@ public class StubMapping {
 
   private long insertionIndex;
   private boolean isDirty = true;
-  private List<StubMapping> mappings;
 
   public StubMapping(RequestPattern requestPattern, ResponseDefinition response) {
     setRequest(requestPattern);
@@ -247,14 +246,6 @@ public class StubMapping {
     this.metadata = metadata;
   }
 
-  public List<StubMapping> getMappings() {
-    return mappings;
-  }
-
-  public void setMappings(List<StubMapping> mappings) {
-    this.mappings = mappings;
-  }
-
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -269,8 +260,7 @@ public class StubMapping {
         && Objects.equals(requiredScenarioState, that.requiredScenarioState)
         && Objects.equals(newScenarioState, that.newScenarioState)
         && Objects.equals(postServeActions, that.postServeActions)
-        && Objects.equals(metadata, that.metadata)
-        && Objects.equals(mappings, that.mappings);
+        && Objects.equals(metadata, that.metadata);
   }
 
   @Override
@@ -285,7 +275,6 @@ public class StubMapping {
         newScenarioState,
         postServeActions,
         metadata,
-        isDirty,
-        mappings);
+        isDirty);
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/RemoteMappingsLoaderAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RemoteMappingsLoaderAcceptanceTest.java
@@ -87,4 +87,20 @@ public class RemoteMappingsLoaderAcceptanceTest extends AcceptanceTestBase {
 
     assertThat(stubMapping.getItem().getResponse().specifiesBinaryBodyContent(), is(true));
   }
+
+  @Test
+  public void loadMultipleMappingsFromOneFile() {
+    wmClient.loadMappingsFrom(rootDir);
+
+    assertThat(testClient.get("/todo/items").content(), is("<items><item>Buy milk</item></items>"));
+    assertThat(
+            testClient.postWithBody(
+                    "/todo/items",
+                    "{\"subscription\": \"Cancel newspaper subscription\"}",
+                    "application/json",
+                    "UTF-8").statusCode(),
+            is(201));
+    assertThat(testClient.get("/todo/items").content(),
+            is("<items><item>Buy milk</item><item>Cancel newspaper subscription</item></items>"));
+  }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/RemoteMappingsLoaderAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RemoteMappingsLoaderAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,13 +94,16 @@ public class RemoteMappingsLoaderAcceptanceTest extends AcceptanceTestBase {
 
     assertThat(testClient.get("/todo/items").content(), is("<items><item>Buy milk</item></items>"));
     assertThat(
-            testClient.postWithBody(
-                    "/todo/items",
-                    "{\"subscription\": \"Cancel newspaper subscription\"}",
-                    "application/json",
-                    "UTF-8").statusCode(),
-            is(201));
-    assertThat(testClient.get("/todo/items").content(),
-            is("<items><item>Buy milk</item><item>Cancel newspaper subscription</item></items>"));
+        testClient
+            .postWithBody(
+                "/todo/items",
+                "{\"subscription\": \"Cancel newspaper subscription\"}",
+                "application/json",
+                "UTF-8")
+            .statusCode(),
+        is(201));
+    assertThat(
+        testClient.get("/todo/items").content(),
+        is("<items><item>Buy milk</item><item>Cancel newspaper subscription</item></items>"));
   }
 }

--- a/src/test/resources/remoteloader/__files/body.xml
+++ b/src/test/resources/remoteloader/__files/body.xml
@@ -1,0 +1,1 @@
+<items><item>Buy milk</item><item>Cancel newspaper subscription</item></items>

--- a/src/test/resources/remoteloader/mappings/with-several-mappings-in-one-file.json
+++ b/src/test/resources/remoteloader/mappings/with-several-mappings-in-one-file.json
@@ -1,43 +1,37 @@
-{
-	"mappings": [
-		{
-			"scenarioName": "To do list",
-			"requiredScenarioState": "Started",
-			"request": {
-				"method": "GET",
-				"url": "/todo/items"
-			},
-			"response": {
-				"status": 200,
-				"body": "<items><item>Buy milk</item></items>"
-			}
-		},
-		{
-			"scenarioName": "To do list",
-			"requiredScenarioState": "Started",
-			"newScenarioState": "Cancel newspaper item added",
-			"request": {
-				"method": "POST",
-				"url": "/todo/items",
-				"bodyPatterns": [
-					{ "contains": "Cancel newspaper subscription" }
-				]
-			},
-			"response": {
-				"status": 201
-			}
-		},
-		{
-			"scenarioName": "To do list",
-			"requiredScenarioState": "Cancel newspaper item added",
-			"request": {
-				"method": "GET",
-				"url": "/todo/items"
-			},
-			"response": {
-				"status": 200,
-				"bodyFileName": "body.xml"
-			}
-		}
-	]
-}
+{"mappings": [
+  {
+    "request": {
+      "method": "GET",
+      "url": "/todo/items"
+    },
+    "response": {
+      "body": "<items><item>Buy milk<\/item><\/items>",
+      "status": 200
+    },
+    "requiredScenarioState": "Started",
+    "scenarioName": "To do list"
+  },
+  {
+    "request": {
+      "method": "POST",
+      "bodyPatterns": [{"contains": "Cancel newspaper subscription"}],
+      "url": "/todo/items"
+    },
+    "newScenarioState": "Cancel newspaper item added",
+    "response": {"status": 201},
+    "requiredScenarioState": "Started",
+    "scenarioName": "To do list"
+  },
+  {
+    "request": {
+      "method": "GET",
+      "url": "/todo/items"
+    },
+    "response": {
+      "bodyFileName": "body.xml",
+      "status": 200
+    },
+    "requiredScenarioState": "Cancel newspaper item added",
+    "scenarioName": "To do list"
+  }
+]}

--- a/src/test/resources/remoteloader/mappings/with-several-mappings-in-one-file.json
+++ b/src/test/resources/remoteloader/mappings/with-several-mappings-in-one-file.json
@@ -1,0 +1,43 @@
+{
+	"mappings": [
+		{
+			"scenarioName": "To do list",
+			"requiredScenarioState": "Started",
+			"request": {
+				"method": "GET",
+				"url": "/todo/items"
+			},
+			"response": {
+				"status": 200,
+				"body": "<items><item>Buy milk</item></items>"
+			}
+		},
+		{
+			"scenarioName": "To do list",
+			"requiredScenarioState": "Started",
+			"newScenarioState": "Cancel newspaper item added",
+			"request": {
+				"method": "POST",
+				"url": "/todo/items",
+				"bodyPatterns": [
+					{ "contains": "Cancel newspaper subscription" }
+				]
+			},
+			"response": {
+				"status": 201
+			}
+		},
+		{
+			"scenarioName": "To do list",
+			"requiredScenarioState": "Cancel newspaper item added",
+			"request": {
+				"method": "GET",
+				"url": "/todo/items"
+			},
+			"response": {
+				"status": 200,
+				"bodyFileName": "body.xml"
+			}
+		}
+	]
+}


### PR DESCRIPTION
This pull request adds field "mappings" to StubMapping class and processing to load() method of RemoteMappingsLoader class if present

## References

- Resolves #2197 issue in a simple way for now, because I don't know plans for 3.0 imports

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
