### PR TITLE
Replace com.google.common.base.Function (partly)

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/admin/LimitAndSinceDatePaginator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/LimitAndSinceDatePaginator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class LimitAndSinceDatePaginator implements Paginator<ServeEvent> {
 
@@ -47,17 +46,10 @@ public class LimitAndSinceDatePaginator implements Paginator<ServeEvent> {
 
   @Override
   public List<ServeEvent> select() {
-    FluentIterable<ServeEvent> chain = FluentIterable.from(source);
-    return chain
-        .filter(
-            new Predicate<ServeEvent>() {
-              @Override
-              public boolean apply(ServeEvent input) {
-                return since == null || input.getRequest().getLoggedDate().after(since);
-              }
-            })
+    return source.stream()
+        .filter(input -> since == null || input.getRequest().getLoggedDate().after(since))
         .limit(firstNonNull(limit, source.size()))
-        .toList();
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
@@ -20,7 +20,6 @@ import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.github.tomakehurst.wiremock.verification.NearMiss;
 import com.github.tomakehurst.wiremock.verification.diff.Diff;
-import com.google.common.base.Joiner;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -54,7 +53,7 @@ public class VerificationException extends AssertionError {
   }
 
   private static String renderList(List<?> list) {
-    return Joiner.on("\n\n").join(list.stream().map(Object::toString).collect(Collectors.toList()));
+    return list.stream().map(Object::toString).collect(Collectors.joining("\n\n"));
   }
 
   private VerificationException(String messageStart, Diff diff) {

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -17,7 +17,6 @@ package com.github.tomakehurst.wiremock.client;
 
 import static com.github.tomakehurst.wiremock.matching.RequestPattern.thatMatch;
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.allRequests;
-import static com.google.common.collect.FluentIterable.from;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.HttpHeaders.LOCATION;
 
@@ -267,7 +266,7 @@ public class WireMock {
   }
 
   public static MatchesXPathPattern matchingXPath(String value) {
-    return new MatchesXPathPattern(value, Collections.<String, String>emptyMap());
+    return new MatchesXPathPattern(value, Collections.emptyMap());
   }
 
   public static StringValuePattern matchingXPath(String value, Map<String, String> namespaces) {
@@ -717,7 +716,7 @@ public class WireMock {
     if (requestPattern.hasInlineCustomMatcher()) {
       List<LoggedRequest> requests =
           admin.findRequestsMatching(RequestPattern.everything()).getRequests();
-      actualCount = from(requests).filter(thatMatch(requestPattern)).size();
+      actualCount = (int) requests.stream().filter(thatMatch(requestPattern)).count();
     } else {
       VerificationResult result = admin.countRequestsMatching(requestPattern);
       result.assertRequestJournalEnabled();
@@ -734,7 +733,7 @@ public class WireMock {
   private VerificationException verificationExceptionForNearMisses(
       RequestPatternBuilder requestPatternBuilder, RequestPattern requestPattern) {
     List<NearMiss> nearMisses = findAllNearMissesFor(requestPatternBuilder);
-    if (nearMisses.size() > 0) {
+    if (!nearMisses.isEmpty()) {
       Diff diff = new Diff(requestPattern, nearMisses.get(0).getRequest());
       return VerificationException.forUnmatchedRequestPattern(diff);
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -266,7 +266,7 @@ public class WireMock {
   }
 
   public static MatchesXPathPattern matchingXPath(String value) {
-    return new MatchesXPathPattern(value, Collections.<String, String>emptyMap());
+    return new MatchesXPathPattern(value, Collections.emptyMap());
   }
 
   public static StringValuePattern matchingXPath(String value, Map<String, String> namespaces) {

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -266,7 +266,7 @@ public class WireMock {
   }
 
   public static MatchesXPathPattern matchingXPath(String value) {
-    return new MatchesXPathPattern(value, Collections.emptyMap());
+    return new MatchesXPathPattern(value, Collections.<String, String>emptyMap());
   }
 
   public static StringValuePattern matchingXPath(String value, Map<String, String> namespaces) {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/ContentTypes.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/ContentTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,12 @@ package com.github.tomakehurst.wiremock.common;
 
 import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
 import static com.github.tomakehurst.wiremock.common.TextType.JSON;
-import static com.google.common.collect.Iterables.any;
 import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.substringAfterLast;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.common.xml.Xml;
 import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import java.net.URI;
 import java.util.List;
@@ -120,14 +118,8 @@ public class ContentTypes {
   }
 
   public static boolean determineIsTextFromMimeType(final String mimeType) {
-    return any(
-        TEXT_MIME_TYPE_PATTERNS,
-        new Predicate<String>() {
-          @Override
-          public boolean apply(String pattern) {
-            return mimeType != null && mimeType.matches(pattern);
-          }
-        });
+    return TEXT_MIME_TYPE_PATTERNS.stream()
+        .anyMatch(pattern -> mimeType != null && mimeType.matches(pattern));
   }
 
   public static boolean determineIsText(String extension, String mimeType) {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/JsonException.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/JsonException.java
@@ -17,7 +17,6 @@ package com.github.tomakehurst.wiremock.common;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.google.common.base.Joiner;
 import java.util.List;
 import java.util.function.Function;
 import java.util.regex.PatternSyntaxException;
@@ -47,7 +46,7 @@ public class JsonException extends InvalidInputException {
       List<String> nodes =
           ((JsonMappingException) processingException)
               .getPath().stream().map(TO_NODE_NAMES).collect(Collectors.toList());
-      pointer = '/' + Joiner.on('/').join(nodes);
+      pointer = "/" + String.join("/", nodes);
     }
 
     return new JsonException(Errors.single(10, pointer, "Error parsing JSON", message));

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Urls.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Urls.java
@@ -16,23 +16,23 @@
 package com.github.tomakehurst.wiremock.common;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
-import static com.google.common.collect.FluentIterable.from;
 
 import com.github.tomakehurst.wiremock.http.QueryParameter;
-import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.Iterables;
+import com.google.common.collect.ImmutableListMultimap.Builder;
 import com.google.common.collect.Maps;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class Urls {
 
@@ -57,7 +57,7 @@ public class Urls {
     }
 
     Iterable<String> pairs = Splitter.on('&').split(query);
-    ImmutableListMultimap.Builder<String, String> builder = ImmutableListMultimap.builder();
+    Builder<String, String> builder = ImmutableListMultimap.builder();
     for (String queryElement : pairs) {
       int firstEqualsIndex = queryElement.indexOf('=');
       if (firstEqualsIndex == -1) {
@@ -83,10 +83,13 @@ public class Urls {
   }
 
   public static String urlToPathParts(URI uri) {
-    Iterable<String> uriPathNodes = Splitter.on("/").omitEmptyStrings().split(uri.getPath());
-    int nodeCount = Iterables.size(uriPathNodes);
+    List<String> uriPathNodes =
+        Arrays.stream(uri.getPath().split("/"))
+            .filter(s -> !s.isEmpty())
+            .collect(Collectors.toUnmodifiableList());
+    int nodeCount = uriPathNodes.size();
 
-    return nodeCount > 0 ? Joiner.on("-").join(from(uriPathNodes)) : "";
+    return nodeCount > 0 ? String.join("-", uriPathNodes) : "";
   }
 
   public static String decode(String encoded) {

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -380,9 +380,8 @@ public class WireMockConfiguration implements Options {
   }
 
   public WireMockConfiguration recordRequestHeadersForMatching(List<String> headers) {
-    this.matchingHeaders = headers.stream()
-        .map(TO_CASE_INSENSITIVE_KEYS)
-        .collect(Collectors.toUnmodifiableList());
+    this.matchingHeaders =
+        headers.stream().map(TO_CASE_INSENSITIVE_KEYS).collect(Collectors.toUnmodifiableList());
     return this;
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -20,7 +20,7 @@ import static com.github.tomakehurst.wiremock.common.BrowserProxySettings.DEFAUL
 import static com.github.tomakehurst.wiremock.common.Limit.UNLIMITED;
 import static com.github.tomakehurst.wiremock.core.WireMockApp.MAPPINGS_ROOT;
 import static com.github.tomakehurst.wiremock.extension.ExtensionLoader.valueAssignableFrom;
-import static com.google.common.collect.Lists.transform;
+import static com.github.tomakehurst.wiremock.http.CaseInsensitiveKey.TO_CASE_INSENSITIVE_KEYS;
 import static com.google.common.collect.Maps.newLinkedHashMap;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -67,6 +67,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class WireMockConfiguration implements Options {
 
@@ -379,7 +380,9 @@ public class WireMockConfiguration implements Options {
   }
 
   public WireMockConfiguration recordRequestHeadersForMatching(List<String> headers) {
-    this.matchingHeaders = transform(headers, CaseInsensitiveKey.TO_CASE_INSENSITIVE_KEYS);
+    this.matchingHeaders = headers.stream()
+        .map(TO_CASE_INSENSITIVE_KEYS)
+        .collect(Collectors.toUnmodifiableList());
     return this;
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -640,7 +640,8 @@ public class WireMockConfiguration implements Options {
   @Override
   @SuppressWarnings("unchecked")
   public <T extends Extension> Map<String, T> extensionsOfType(final Class<T> extensionType) {
-    return (Map<String, T>) Maps.filterEntries(extensions, valueAssignableFrom(extensionType));
+    return (Map<String, T>)
+        Maps.filterEntries(extensions, valueAssignableFrom(extensionType)::test);
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/ExtensionLoader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/ExtensionLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Thomas Akehurst
+ * Copyright (C) 2014-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,24 @@
 package com.github.tomakehurst.wiremock.extension;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
-import static com.google.common.collect.FluentIterable.from;
-import static java.util.Arrays.asList;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Maps;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class ExtensionLoader {
 
   @SuppressWarnings("unchecked")
   public static <T> Map<String, T> loadExtension(String... classNames) {
     return (Map<String, T>)
-        asMap(from(asList(classNames)).transform(toClasses()).transform(toExtensions()));
+        asMap(
+            Arrays.stream(classNames)
+                .map(toClasses())
+                .map(toExtensions())
+                .collect(Collectors.toList()));
   }
 
   public static Map<String, Extension> load(String... classNames) {
@@ -37,51 +41,37 @@ public class ExtensionLoader {
   }
 
   public static Map<String, Extension> asMap(Iterable<Extension> extensions) {
-    return Maps.uniqueIndex(
-        extensions,
-        new Function<Extension, String>() {
-          public String apply(Extension extension) {
-            return extension.getName();
-          }
-        });
+    return Maps.uniqueIndex(extensions, Extension::getName);
   }
 
+  @SafeVarargs
   public static Map<String, Extension> load(Class<? extends Extension>... classes) {
-    return asMap(from(asList(classes)).transform(toExtensions()));
+    return asMap(Arrays.stream(classes).map(toExtensions()).collect(Collectors.toList()));
   }
 
   private static Function<Class<? extends Extension>, Extension> toExtensions() {
-    return new Function<Class<? extends Extension>, Extension>() {
-      @SuppressWarnings("unchecked")
-      public Extension apply(Class<? extends Extension> extensionClass) {
-        try {
-          return extensionClass.getDeclaredConstructor().newInstance();
-        } catch (Exception e) {
-          return throwUnchecked(e, Extension.class);
-        }
+    return extensionClass -> {
+      try {
+        return extensionClass.getDeclaredConstructor().newInstance();
+      } catch (Exception e) {
+        return throwUnchecked(e, Extension.class);
       }
     };
   }
 
+  @SuppressWarnings("unchecked")
   private static Function<String, Class<? extends Extension>> toClasses() {
-    return new Function<String, Class<? extends Extension>>() {
-      @SuppressWarnings("unchecked")
-      public Class<? extends Extension> apply(String className) {
-        try {
-          return (Class<? extends Extension>) Class.forName(className);
-        } catch (ClassNotFoundException e) {
-          return throwUnchecked(e, Class.class);
-        }
+    return className -> {
+      try {
+        return (Class<? extends Extension>) Class.forName(className);
+      } catch (ClassNotFoundException e) {
+        return throwUnchecked(e, Class.class);
       }
     };
   }
 
   public static <T extends Extension> Predicate<Map.Entry<String, Extension>> valueAssignableFrom(
       final Class<T> extensionType) {
-    return new Predicate<Map.Entry<String, Extension>>() {
-      public boolean apply(Map.Entry<String, Extension> input) {
-        return extensionType.isAssignableFrom(input.getValue().getClass());
-      }
-    };
+    return input -> extensionType.isAssignableFrom(input.getValue().getClass());
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/CaseInsensitiveKey.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/CaseInsensitiveKey.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 public class CaseInsensitiveKey {
 
@@ -67,9 +67,5 @@ public class CaseInsensitiveKey {
   }
 
   public static final Function<String, CaseInsensitiveKey> TO_CASE_INSENSITIVE_KEYS =
-      new Function<String, CaseInsensitiveKey>() {
-        public CaseInsensitiveKey apply(String input) {
-          return from(input);
-        }
-      };
+      CaseInsensitiveKey::from;
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/CaseInsensitiveKey.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/CaseInsensitiveKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Thomas Akehurst
+ * Copyright (C) 2014-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Cookie.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Cookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
-import com.google.common.base.Joiner;
 import java.util.Collections;
 import java.util.List;
 
@@ -38,7 +37,7 @@ public class Cookie extends MultiValue {
   }
 
   public static Cookie absent() {
-    return new Cookie(null, Collections.<String>emptyList());
+    return new Cookie(null, Collections.emptyList());
   }
 
   public Cookie(String value) {
@@ -64,7 +63,7 @@ public class Cookie extends MultiValue {
 
   @JsonValue
   public ListOrSingle<String> getValues() {
-    return new ListOrSingle<>(isPresent() ? values() : Collections.<String>emptyList());
+    return new ListOrSingle<>(isPresent() ? values() : Collections.emptyList());
   }
 
   @JsonIgnore
@@ -74,6 +73,6 @@ public class Cookie extends MultiValue {
 
   @Override
   public String toString() {
-    return isAbsent() ? "(absent)" : Joiner.on("; ").join(getValues());
+    return isAbsent() ? "(absent)" : String.join("; ", getValues());
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/MultiValue.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/MultiValue.java
@@ -18,7 +18,6 @@ package com.github.tomakehurst.wiremock.http;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
-import com.google.common.base.Joiner;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,7 +32,7 @@ public class MultiValue {
   }
 
   public boolean isPresent() {
-    return values.size() > 0;
+    return !values.isEmpty();
   }
 
   public String key() {
@@ -72,7 +71,6 @@ public class MultiValue {
 
   @Override
   public String toString() {
-    return Joiner.on("\n")
-        .join(values.stream().map(value -> key + ": " + value).collect(Collectors.toList()));
+    return values.stream().map(value -> key + ": " + value).collect(Collectors.joining("\n"));
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.client.WireMock.JsonSchemaVersion;
 import com.github.tomakehurst.wiremock.common.DateTimeUnit;
 import com.github.tomakehurst.wiremock.common.Json;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -114,14 +113,7 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
   }
 
   private static Map.Entry<String, JsonNode> findMainFieldEntry(JsonNode rootNode) {
-    return find(
-        rootNode.fields(),
-        new Predicate<Map.Entry<String, JsonNode>>() {
-          @Override
-          public boolean apply(Map.Entry<String, JsonNode> input) {
-            return PATTERNS.keySet().contains(input.getKey());
-          }
-        });
+    return find(rootNode.fields(), input -> PATTERNS.containsKey(input.getKey()));
   }
 
   private EqualToPattern deserializeEqualTo(JsonNode rootNode) throws JsonMappingException {

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/ProxiedServeEventFilters.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/ProxiedServeEventFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package com.github.tomakehurst.wiremock.recording;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import com.google.common.base.Predicate;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Predicate;
 
 /** A predicate to filter proxied ServeEvents against RequestPattern filters and IDs */
 public class ProxiedServeEventFilters implements Predicate<ServeEvent> {
@@ -69,7 +69,7 @@ public class ProxiedServeEventFilters implements Predicate<ServeEvent> {
   }
 
   @Override
-  public boolean apply(ServeEvent serveEvent) {
+  public boolean test(ServeEvent serveEvent) {
     if (!serveEvent.getResponseDefinition().isProxyResponse() && !allowNonProxied) {
       return false;
     }
@@ -78,10 +78,6 @@ public class ProxiedServeEventFilters implements Predicate<ServeEvent> {
       return false;
     }
 
-    if (ids != null && !ids.contains(serveEvent.getId())) {
-      return false;
-    }
-
-    return true;
+    return ids == null || ids.contains(serveEvent.getId());
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
@@ -29,10 +29,10 @@ import com.github.tomakehurst.wiremock.store.BlobStore;
 import com.github.tomakehurst.wiremock.store.RecorderStateStore;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class Recorder {
@@ -88,8 +88,8 @@ public class Recorder {
     int startIndex =
         state.getStartingServeEventId() == null
             ? serveEvents.size()
-            : indexOf(serveEvents, withId(state.getStartingServeEventId()));
-    int endIndex = indexOf(serveEvents, withId(state.getFinishingServeEventId()));
+            : indexOf(serveEvents, withId(state.getStartingServeEventId())::test);
+    int endIndex = indexOf(serveEvents, withId(state.getFinishingServeEventId())::test);
     List<ServeEvent> eventsToSnapshot = serveEvents.subList(endIndex, startIndex);
 
     SnapshotRecordResult result = takeSnapshot(eventsToSnapshot, state.getSpec());
@@ -99,12 +99,7 @@ public class Recorder {
   }
 
   private static Predicate<ServeEvent> withId(final UUID id) {
-    return new Predicate<ServeEvent>() {
-      @Override
-      public boolean apply(ServeEvent input) {
-        return input.getId().equals(id);
-      }
-    };
+    return input -> input.getId().equals(id);
   }
 
   public SnapshotRecordResult takeSnapshot(List<ServeEvent> serveEvents, RecordSpec recordSpec) {

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,14 +29,10 @@ public class ScenarioProcessor {
 
   public void putRepeatedRequestsInScenarios(List<StubMapping> stubMappings) {
     ImmutableListMultimap<RequestPattern, StubMapping> stubsGroupedByRequest =
-        Multimaps.index(
-            stubMappings,
-            StubMapping::getRequest);
+        Multimaps.index(stubMappings, StubMapping::getRequest);
 
     Map<RequestPattern, Collection<StubMapping>> groupsWithMoreThanOneStub =
-        Maps.filterEntries(
-            stubsGroupedByRequest.asMap(),
-            input -> input.getValue().size() > 1);
+        Maps.filterEntries(stubsGroupedByRequest.asMap(), input -> input.getValue().size() > 1);
 
     int scenarioIndex = 0;
     for (Map.Entry<RequestPattern, Collection<StubMapping>> entry :

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
@@ -19,8 +19,6 @@ import com.github.tomakehurst.wiremock.common.Urls;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.collect.*;
 import java.net.URI;
 import java.util.Collection;
@@ -33,22 +31,12 @@ public class ScenarioProcessor {
     ImmutableListMultimap<RequestPattern, StubMapping> stubsGroupedByRequest =
         Multimaps.index(
             stubMappings,
-            new Function<StubMapping, RequestPattern>() {
-              @Override
-              public RequestPattern apply(StubMapping mapping) {
-                return mapping.getRequest();
-              }
-            });
+            StubMapping::getRequest);
 
     Map<RequestPattern, Collection<StubMapping>> groupsWithMoreThanOneStub =
         Maps.filterEntries(
             stubsGroupedByRequest.asMap(),
-            new Predicate<Map.Entry<RequestPattern, Collection<StubMapping>>>() {
-              @Override
-              public boolean apply(Map.Entry<RequestPattern, Collection<StubMapping>> input) {
-                return input.getValue().size() > 1;
-              }
-            });
+            input -> input.getValue().size() > 1);
 
     int scenarioIndex = 0;
     for (Map.Entry<RequestPattern, Collection<StubMapping>> entry :
@@ -62,7 +50,7 @@ public class ScenarioProcessor {
     StubMapping firstScenario = stubMappings.get(0);
     String scenarioName =
         "scenario-"
-            + Integer.toString(scenarioIndex)
+            + scenarioIndex
             + "-"
             + Urls.urlToPathParts(URI.create(firstScenario.getRequest().getUrl()));
 

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -59,6 +59,8 @@ import java.io.StringWriter;
 import java.net.URI;
 import java.util.*;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 
@@ -492,8 +494,10 @@ public class CommandLineOptions implements Options {
   public List<CaseInsensitiveKey> matchingHeaders() {
     if (optionSet.hasArgument(MATCH_HEADERS)) {
       String headerSpec = (String) optionSet.valueOf(MATCH_HEADERS);
-      UnmodifiableIterator<String> headerKeys = Iterators.forArray(headerSpec.split(","));
-      return ImmutableList.copyOf(Iterators.transform(headerKeys, TO_CASE_INSENSITIVE_KEYS));
+
+      return Arrays.stream(headerSpec.split(","))
+          .map(TO_CASE_INSENSITIVE_KEYS)
+          .collect(Collectors.toUnmodifiableList());
     }
 
     return Collections.emptyList();

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -50,7 +50,6 @@ import com.github.tomakehurst.wiremock.store.Stores;
 import com.github.tomakehurst.wiremock.verification.notmatched.NotMatchedRenderer;
 import com.github.tomakehurst.wiremock.verification.notmatched.PlainTextStubNotMatchedRenderer;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.*;
 import com.google.common.io.Resources;
@@ -802,7 +801,7 @@ public class CommandLineOptions implements Options {
       builder.put(TRUST_ALL_PROXY_TARGETS, browserProxySettings.trustAllProxyTargets());
       List<String> trustedProxyTargets = browserProxySettings.trustedProxyTargets();
       if (!trustedProxyTargets.isEmpty()) {
-        builder.put(TRUST_PROXY_TARGET, Joiner.on(", ").join(trustedProxyTargets));
+        builder.put(TRUST_PROXY_TARGET, String.join(", ", trustedProxyTargets));
       }
       builder.put(HTTPS_CA_KEYSTORE, keyStoreSettings.path());
       builder.put(HTTPS_CA_KEYSTORE_TYPE, keyStoreSettings.type());

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -660,7 +660,8 @@ public class CommandLineOptions implements Options {
   @Override
   @SuppressWarnings("unchecked")
   public <T extends Extension> Map<String, T> extensionsOfType(final Class<T> extensionType) {
-    return (Map<String, T>) Maps.filterEntries(extensions, valueAssignableFrom(extensionType));
+    return (Map<String, T>)
+        Maps.filterEntries(extensions, valueAssignableFrom(extensionType)::test);
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/AbstractRequestJournal.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/AbstractRequestJournal.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.verification;
 
 import static com.github.tomakehurst.wiremock.matching.RequestPattern.thatMatch;
-import static com.github.tomakehurst.wiremock.matching.RequestPattern.withRequstMatching;
+import static com.github.tomakehurst.wiremock.matching.RequestPattern.withRequestMatching;
 import static java.util.stream.Collectors.toList;
 
 import com.github.tomakehurst.wiremock.common.Json;
@@ -75,7 +75,7 @@ public abstract class AbstractRequestJournal implements RequestJournal {
 
   @Override
   public List<ServeEvent> removeEventsMatching(RequestPattern requestPattern) {
-    return removeServeEvents(withRequstMatching(requestPattern)::apply);
+    return removeServeEvents(withRequestMatching(requestPattern));
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -22,13 +22,11 @@ import static com.github.tomakehurst.wiremock.common.Urls.safelyCreateURL;
 import static com.github.tomakehurst.wiremock.common.Urls.splitQueryFromUrl;
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.collect.FluentIterable.from;
 
 import com.fasterxml.jackson.annotation.*;
 import com.github.tomakehurst.wiremock.common.Dates;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.http.*;
-import com.google.common.base.Predicate;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.Collection;
@@ -331,7 +329,7 @@ public class LoggedRequest implements Request {
   @JsonIgnore
   @Override
   public boolean isMultipart() {
-    return (multiparts != null && multiparts.size() > 0);
+    return (multiparts != null && !multiparts.isEmpty());
   }
 
   @JsonIgnore
@@ -344,15 +342,10 @@ public class LoggedRequest implements Request {
   @Override
   public Part getPart(final String name) {
     return (multiparts != null && name != null)
-        ? from(multiparts)
-            .firstMatch(
-                new Predicate<Part>() {
-                  @Override
-                  public boolean apply(Part input) {
-                    return (name.equals(input.getName()));
-                  }
-                })
-            .get()
+        ? multiparts.stream()
+            .filter(input -> (name.equals(input.getName())))
+            .findFirst()
+            .orElse(null)
         : null;
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/diff/JUnitStyleDiffRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/diff/JUnitStyleDiffRenderer.java
@@ -16,7 +16,6 @@
 package com.github.tomakehurst.wiremock.verification.diff;
 
 import com.github.tomakehurst.wiremock.common.Strings;
-import com.google.common.base.Joiner;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -27,8 +26,9 @@ public class JUnitStyleDiffRenderer {
     List<DiffLine<?>> lines = diff.getLines();
 
     String expected =
-        Joiner.on("\n").join(lines.stream().map(EXPECTED).collect(Collectors.toList()));
-    String actual = Joiner.on("\n").join(lines.stream().map(ACTUAL).collect(Collectors.toList()));
+        lines.stream().map(EXPECTED).map(Object::toString).collect(Collectors.joining("\n"));
+    String actual =
+        lines.stream().map(ACTUAL).map(Object::toString).collect(Collectors.joining("\n"));
 
     return lines.isEmpty() ? "" : junitStyleDiffMessage(expected, actual);
   }
@@ -40,8 +40,8 @@ public class JUnitStyleDiffRenderer {
         Strings.normaliseLineBreaks(actual.toString()));
   }
 
-  private static Function<DiffLine<?>, Object> EXPECTED =
+  private static final Function<DiffLine<?>, Object> EXPECTED =
       line -> line.isForNonMatch() ? line.getPrintedPatternValue() : line.getActual();
 
-  private static Function<DiffLine<?>, Object> ACTUAL = DiffLine::getActual;
+  private static final Function<DiffLine<?>, Object> ACTUAL = DiffLine::getActual;
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/EditStubMappingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/EditStubMappingAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,12 @@
 package com.github.tomakehurst.wiremock;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.google.common.collect.FluentIterable.from;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import com.google.common.base.Predicate;
 import java.util.UUID;
+import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
 public class EditStubMappingAcceptanceTest extends AcceptanceTestBase {
@@ -42,18 +41,16 @@ public class EditStubMappingAcceptanceTest extends AcceptanceTestBase {
     assertThat(testClient.get("/edit-this").content(), is("Modified"));
 
     int editThisStubCount =
-        from(wireMockServer.listAllStubMappings().getMappings())
-            .filter(withUrl("/edit-this"))
-            .size();
+        (int)
+            wireMockServer.listAllStubMappings().getMappings().stream()
+                .filter(withUrl("/edit-this"))
+                .count();
 
     assertThat(editThisStubCount, is(1));
   }
 
   private Predicate<StubMapping> withUrl(final String url) {
-    return new Predicate<StubMapping>() {
-      public boolean apply(StubMapping mapping) {
-        return (mapping.getRequest().getUrl() != null && mapping.getRequest().getUrl().equals(url));
-      }
-    };
+    return mapping ->
+        (mapping.getRequest().getUrl() != null && mapping.getRequest().getUrl().equals(url));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/RecordApiAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecordApiAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHea
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalToJson;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.findMappingWithUrl;
 import static com.google.common.base.Charsets.UTF_8;
-import static com.google.common.collect.Iterables.find;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,7 +33,6 @@ import com.github.tomakehurst.wiremock.testsupport.GlobalStubMappingTransformer;
 import com.github.tomakehurst.wiremock.testsupport.NonGlobalStubMappingTransformer;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import com.google.common.base.Predicate;
 import java.util.UUID;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.jupiter.api.AfterEach;
@@ -253,14 +251,10 @@ public class RecordApiAcceptanceTest extends AcceptanceTestBase {
   }
 
   private ServeEvent findServeEventWithRequestUrl(final String url) {
-    return find(
-        proxyingService.getAllServeEvents(),
-        new Predicate<ServeEvent>() {
-          @Override
-          public boolean apply(ServeEvent input) {
-            return url.equals(input.getRequest().getUrl());
-          }
-        });
+    return proxyingService.getAllServeEvents().stream()
+        .filter(input -> url.equals(input.getRequest().getUrl()))
+        .findFirst()
+        .orElse(null);
   }
 
   private static final String CAPTURE_HEADERS_SNAPSHOT_REQUEST =

--- a/src/test/java/com/github/tomakehurst/wiremock/RemoveStubMappingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RemoveStubMappingAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,13 @@
 package com.github.tomakehurst.wiremock;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.google.common.collect.FluentIterable.from;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import com.google.common.base.Predicate;
 import java.util.UUID;
+import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
 public class RemoveStubMappingAcceptanceTest extends AcceptanceTestBase {
@@ -137,15 +136,12 @@ public class RemoveStubMappingAcceptanceTest extends AcceptanceTestBase {
   }
 
   private Predicate<StubMapping> withAnyOf(final String... urls) {
-    return new Predicate<StubMapping>() {
-      public boolean apply(StubMapping mapping) {
-        return mapping.getRequest().getUrl() != null
+    return mapping ->
+        mapping.getRequest().getUrl() != null
             && asList(urls).contains(mapping.getRequest().getUrl());
-      }
-    };
   }
 
   private synchronized int getMatchingStubCount(String url1, String url2) {
-    return from(listAllStubMappings().getMappings()).filter(withAnyOf(url1, url2)).size();
+    return (int) listAllStubMappings().getMappings().stream().filter(withAnyOf(url1, url2)).count();
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/SavingMappingsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/SavingMappingsAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Thomas Akehurst
+ * Copyright (C) 2013-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,9 @@ import static org.hamcrest.Matchers.*;
 import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
 import java.io.File;
+import java.util.Arrays;
+import java.util.Objects;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -102,20 +102,12 @@ public class SavingMappingsAcceptanceTest extends AcceptanceTestBase {
   }
 
   private static Matcher<File> containsFileWithNameContaining(final String namePart) {
-    return new TypeSafeDiagnosingMatcher<File>() {
+    return new TypeSafeDiagnosingMatcher<>() {
       @Override
       protected boolean matchesSafely(File directory, Description mismatchDescription) {
         boolean found =
-            FluentIterable.from(directory.list())
-                .filter(
-                    new Predicate<String>() {
-                      @Override
-                      public boolean apply(String filename) {
-                        return filename.contains(namePart);
-                      }
-                    })
-                .first()
-                .isPresent();
+            Arrays.stream(Objects.requireNonNull(directory.list()))
+                .anyMatch(filename -> filename.contains(namePart));
 
         if (!found) {
           mismatchDescription.appendText("file with name containing " + namePart + " not found");
@@ -167,7 +159,7 @@ public class SavingMappingsAcceptanceTest extends AcceptanceTestBase {
   }
 
   static final TypeSafeDiagnosingMatcher<StubMapping> IS_PERSISTENT =
-      new TypeSafeDiagnosingMatcher<StubMapping>() {
+      new TypeSafeDiagnosingMatcher<>() {
         @Override
         public void describeTo(Description description) {
           description.appendText("a stub mapping marked as persistent");

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -20,8 +20,6 @@ import static com.github.tomakehurst.wiremock.testsupport.Network.findFreePort;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.collect.Iterables.any;
-import static com.google.common.collect.Iterables.filter;
-import static com.google.common.collect.Iterables.size;
 import static com.google.common.io.Files.asCharSink;
 import static com.google.common.io.Files.createParentDirs;
 import static com.google.common.io.Files.write;
@@ -43,12 +41,14 @@ import com.github.tomakehurst.wiremock.standalone.WireMockServerRunner;
 import com.github.tomakehurst.wiremock.testsupport.MappingJsonSamples;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import com.google.common.base.Predicate;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.zip.GZIPInputStream;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Description;
@@ -626,7 +626,7 @@ public class StandaloneAcceptanceTest {
 
       @Override
       public boolean matchesSafely(File dir) {
-        return !any(asList(dir.list()), contains(namePart));
+        return !any(asList(dir.list()), contains(namePart)::test);
       }
     };
   }
@@ -641,19 +641,15 @@ public class StandaloneAcceptanceTest {
 
       @Override
       public boolean matchesSafely(File dir) {
-        Iterable<String> fileNames = filter(asList(dir.list()), contains(namePart));
-        return size(fileNames) == 1;
+        return (int)
+                Arrays.stream(Objects.requireNonNull(dir.list())).filter(contains(namePart)).count()
+            == 1;
       }
     };
   }
 
   private static Predicate<String> contains(final String part) {
-    return new Predicate<String>() {
-      @Override
-      public boolean apply(String s) {
-        return s.contains(part);
-      }
-    };
+    return s -> s.contains(part);
   }
 
   /**

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/ProxiedServeEventFiltersTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/ProxiedServeEventFiltersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,18 +41,18 @@ public class ProxiedServeEventFiltersTest {
     ServeEvent serveEvent = proxiedServeEvent(mockRequest());
     ProxiedServeEventFilters filters =
         new ProxiedServeEventFilters(RequestPattern.ANYTHING, null, false);
-    assertTrue(filters.apply(serveEvent));
+    assertTrue(filters.test(serveEvent));
 
     // Should default to RequestPattern.ANYTHING when passing null for filters
     filters = new ProxiedServeEventFilters(null, null, false);
-    assertTrue(filters.apply(serveEvent));
+    assertTrue(filters.test(serveEvent));
   }
 
   @Test
   public void applyWithUnproxiedServeEvent() {
     ServeEvent serveEvent = toServeEvent(null, null, ResponseDefinition.ok());
     ProxiedServeEventFilters filters = new ProxiedServeEventFilters(null, null, false);
-    assertFalse(filters.apply(serveEvent));
+    assertFalse(filters.test(serveEvent));
   }
 
   @Test
@@ -61,9 +61,9 @@ public class ProxiedServeEventFiltersTest {
         new ProxiedServeEventFilters(newRequestPattern(GET, anyUrl()).build(), null, false);
     MockRequest request = mockRequest().method(GET).url("/foo");
 
-    assertTrue(filters.apply(proxiedServeEvent(request)));
-    assertTrue(filters.apply(proxiedServeEvent(request.url("/bar"))));
-    assertFalse(filters.apply(proxiedServeEvent(request.method(POST))));
+    assertTrue(filters.test(proxiedServeEvent(request)));
+    assertTrue(filters.test(proxiedServeEvent(request.url("/bar"))));
+    assertFalse(filters.test(proxiedServeEvent(request.method(POST))));
   }
 
   @Test
@@ -74,10 +74,10 @@ public class ProxiedServeEventFiltersTest {
             UUID.fromString("00000000-0000-0000-0000-000000000001"));
     ProxiedServeEventFilters filters = new ProxiedServeEventFilters(null, ids, false);
 
-    assertTrue(filters.apply(proxiedServeEvent(ids.get(0))));
-    assertTrue(filters.apply(proxiedServeEvent(ids.get(1))));
+    assertTrue(filters.test(proxiedServeEvent(ids.get(0))));
+    assertTrue(filters.test(proxiedServeEvent(ids.get(1))));
     assertFalse(
-        filters.apply(proxiedServeEvent(UUID.fromString("00000000-0000-0000-0000-000000000002"))));
+        filters.test(proxiedServeEvent(UUID.fromString("00000000-0000-0000-0000-000000000002"))));
   }
 
   @Test
@@ -87,9 +87,9 @@ public class ProxiedServeEventFiltersTest {
             newRequestPattern(GET, urlEqualTo("/foo")).build(), null, false);
     MockRequest request = mockRequest().method(GET).url("/foo");
 
-    assertTrue(filters.apply(proxiedServeEvent(request)));
-    assertFalse(filters.apply(proxiedServeEvent(request.url("/bar"))));
-    assertFalse(filters.apply(proxiedServeEvent(request.method(POST))));
+    assertTrue(filters.test(proxiedServeEvent(request)));
+    assertFalse(filters.test(proxiedServeEvent(request.url("/bar"))));
+    assertFalse(filters.test(proxiedServeEvent(request.method(POST))));
   }
 
   @Test
@@ -102,11 +102,11 @@ public class ProxiedServeEventFiltersTest {
     ProxiedServeEventFilters filters =
         new ProxiedServeEventFilters(newRequestPattern(GET, anyUrl()).build(), ids, false);
 
-    assertTrue(filters.apply(proxiedServeEvent(ids.get(0), request)));
+    assertTrue(filters.test(proxiedServeEvent(ids.get(0), request)));
     assertFalse(
-        filters.apply(
+        filters.test(
             proxiedServeEvent(UUID.fromString("00000000-0000-0000-0000-000000000002"), request)));
-    assertFalse(filters.apply(proxiedServeEvent(ids.get(0), request.method(POST))));
+    assertFalse(filters.test(proxiedServeEvent(ids.get(0), request.method(POST))));
   }
 
   private ServeEvent toServeEvent(

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -23,7 +23,6 @@ import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
 import static com.github.tomakehurst.wiremock.http.Response.response;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.*;
 import static com.google.common.base.Charsets.UTF_8;
-import static com.google.common.collect.Lists.transform;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.mockito.ArgumentMatchers.any;
@@ -41,6 +40,7 @@ import com.github.tomakehurst.wiremock.store.BlobStore;
 import com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder;
 import com.github.tomakehurst.wiremock.verification.VerificationResult;
 import java.util.*;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,7 +71,9 @@ public class StubMappingJsonRecorderTest {
             mappingsBlobStore,
             filesBlobStore,
             admin,
-            transform(headersToRecord, TO_CASE_INSENSITIVE_KEYS));
+            headersToRecord.stream()
+                .map(TO_CASE_INSENSITIVE_KEYS)
+                .collect(Collectors.toUnmodifiableList()));
     listener.setIdGenerator(fixedIdGenerator("1$2!3"));
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMatchers.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMatchers.java
@@ -234,8 +234,10 @@ public class WireMatchers {
 
         for (final Matcher<T> matcher : items) {
           if (StreamSupport.stream(actual.spliterator(), false)
-              .filter(isMatchFor(matcher))
-              .findAny().orElse(null) == null) {
+                  .filter(isMatchFor(matcher))
+                  .findAny()
+                  .orElse(null)
+              == null) {
             return false;
           }
         }
@@ -319,12 +321,14 @@ public class WireMatchers {
       @Override
       protected boolean matchesSafely(Path path, Description mismatchDescription) {
         List<File> files = asList(Objects.requireNonNull(path.toFile().listFiles()));
-        boolean matched = files.stream().anyMatch(file -> {
-          final String fileContents = fileContents(file);
+        boolean matched =
+            files.stream()
+                .anyMatch(
+                    file -> {
+                      final String fileContents = fileContents(file);
 
-          return Arrays.stream(contents)
-              .allMatch(fileContents::contains);
-        });
+                      return Arrays.stream(contents).allMatch(fileContents::contains);
+                    });
 
         if (files.size() == 0) {
           mismatchDescription.appendText("there were no files in " + path);
@@ -332,9 +336,7 @@ public class WireMatchers {
 
         if (!matched) {
           String allFileContents =
-              files.stream()
-                  .map(WireMatchers::fileContents)
-                  .collect(Collectors.joining("\n\n"));
+              files.stream().map(WireMatchers::fileContents).collect(Collectors.joining("\n\n"));
 
           mismatchDescription.appendText(allFileContents);
         }
@@ -344,8 +346,7 @@ public class WireMatchers {
 
       @Override
       public void describeTo(Description description) {
-        description.appendText("a file containing all of: " +
-            String.join(", ", contents));
+        description.appendText("a file containing all of: " + String.join(", ", contents));
       }
     };
   }
@@ -407,9 +408,7 @@ public class WireMatchers {
 
   public static List<StubMapping> findMappingsWithUrl(
       List<StubMapping> stubMappings, final String url) {
-    return stubMappings.stream()
-        .filter(withUrl(url))
-        .collect(Collectors.toUnmodifiableList());
+    return stubMappings.stream().filter(withUrl(url)).collect(Collectors.toUnmodifiableList());
   }
 
   public static TypeSafeDiagnosingMatcher<StubMapping> isInAScenario() {

--- a/src/test/java/ignored/MassiveNearMissTest.java
+++ b/src/test/java/ignored/MassiveNearMissTest.java
@@ -15,11 +15,7 @@
  */
 package ignored;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalToXml;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 

--- a/src/test/java/ignored/MassiveNearMissTest.java
+++ b/src/test/java/ignored/MassiveNearMissTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Thomas Akehurst
+ * Copyright (C) 2020-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,20 @@
  */
 package ignored;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToXml;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -69,7 +73,8 @@ public class MassiveNearMissTest {
       if (i > drop) sum += time;
     }
 
-    System.out.printf("Times:\n%s\n", Joiner.on("\n").join(times));
+    System.out.printf(
+        "Times:\n%s\n", times.stream().map(Object::toString).collect(Collectors.joining("\n")));
     long mean = sum / (reps - drop);
     System.out.printf("Mean: %dms\n", mean);
   }
@@ -122,7 +127,8 @@ public class MassiveNearMissTest {
       if (i > drop) sum += time;
     }
 
-    System.out.printf("Times:\n%s\n", Joiner.on("\n").join(times));
+    System.out.printf(
+        "Times:\n%s\n", times.stream().map(Object::toString).collect(Collectors.joining("\n")));
     long mean = sum / (reps - drop);
     System.out.printf("Mean: %dms\n", mean);
   }


### PR DESCRIPTION
Replace com.google.common.base.Function

## References

- https://github.com/wiremock/wiremock/issues/2111

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
