### PR TITLE
Refactor/prefer the java standard library instead of guava

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.client;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
+
 import com.github.tomakehurst.wiremock.common.Metadata;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.PostServeActionDefinition;

--- a/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
@@ -18,8 +18,6 @@ package com.github.tomakehurst.wiremock.client;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Lists.newArrayList;
-
 import com.github.tomakehurst.wiremock.common.Metadata;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.PostServeActionDefinition;
@@ -35,6 +33,7 @@ import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.matching.UrlPattern;
 import com.github.tomakehurst.wiremock.matching.ValueMatcher;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -50,7 +49,7 @@ class BasicMappingBuilder implements ScenarioMappingBuilder {
   private UUID id = UUID.randomUUID();
   private String name;
   private Boolean isPersistent = null;
-  private List<PostServeActionDefinition> postServeActions = newArrayList();
+  private List<PostServeActionDefinition> postServeActions = new ArrayList<>();
   private Metadata metadata;
 
   BasicMappingBuilder(RequestMethod method, UrlPattern urlPattern) {

--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -15,7 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.client;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.util.Arrays.asList;
@@ -25,7 +24,7 @@ import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.*;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +34,7 @@ public class ResponseDefinitionBuilder {
   protected String statusMessage;
   protected Body body = Body.none();
   protected String bodyFileName;
-  protected List<HttpHeader> headers = newArrayList();
+  protected List<HttpHeader> headers = new ArrayList<>();
   protected Integer fixedDelayMilliseconds;
   protected DelayDistribution delayDistribution;
   protected ChunkedDribbleDelay chunkedDribbleDelay;
@@ -52,8 +51,8 @@ public class ResponseDefinitionBuilder {
     builder.statusMessage = responseDefinition.getStatusMessage();
     builder.headers =
         responseDefinition.getHeaders() != null
-            ? newArrayList(responseDefinition.getHeaders().all())
-            : Lists.<HttpHeader>newArrayList();
+            ? new ArrayList<>(responseDefinition.getHeaders().all())
+            : new ArrayList<>();
     builder.body = responseDefinition.getReponseBody();
     builder.bodyFileName = responseDefinition.getBodyFileName();
     builder.fixedDelayMilliseconds = responseDefinition.getFixedDelayMilliseconds();
@@ -75,7 +74,7 @@ public class ResponseDefinitionBuilder {
       proxyResponseDefinitionBuilder.additionalRequestHeaders =
               responseDefinition.getAdditionalProxyRequestHeaders() != null
                       ? (List<HttpHeader>) responseDefinition.getAdditionalProxyRequestHeaders().all()
-                      : Lists.<HttpHeader>newArrayList();
+                      : new ArrayList<>();
 
       return proxyResponseDefinitionBuilder;
     }
@@ -221,7 +220,7 @@ public class ResponseDefinitionBuilder {
 
   public static class ProxyResponseDefinitionBuilder extends ResponseDefinitionBuilder {
 
-    private List<HttpHeader> additionalRequestHeaders = newArrayList();
+    private List<HttpHeader> additionalRequestHeaders = new ArrayList<>();
 
     public ProxyResponseDefinitionBuilder(ResponseDefinitionBuilder from) {
       this.status = from.status;

--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2022 Thomas Akehurst
+ * Copyright (C) 2011-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,12 +69,14 @@ public class ResponseDefinitionBuilder {
     builder.wasConfigured = responseDefinition.isFromConfiguredStub();
 
     if (builder.proxyBaseUrl != null) {
-      ProxyResponseDefinitionBuilder proxyResponseDefinitionBuilder = new ProxyResponseDefinitionBuilder(builder);
-      proxyResponseDefinitionBuilder.proxyUrlPrefixToRemove = responseDefinition.getProxyUrlPrefixToRemove();
+      ProxyResponseDefinitionBuilder proxyResponseDefinitionBuilder =
+          new ProxyResponseDefinitionBuilder(builder);
+      proxyResponseDefinitionBuilder.proxyUrlPrefixToRemove =
+          responseDefinition.getProxyUrlPrefixToRemove();
       proxyResponseDefinitionBuilder.additionalRequestHeaders =
-              responseDefinition.getAdditionalProxyRequestHeaders() != null
-                      ? (List<HttpHeader>) responseDefinition.getAdditionalProxyRequestHeaders().all()
-                      : new ArrayList<>();
+          responseDefinition.getAdditionalProxyRequestHeaders() != null
+              ? (List<HttpHeader>) responseDefinition.getAdditionalProxyRequestHeaders().all()
+              : new ArrayList<>();
 
       return proxyResponseDefinitionBuilder;
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/ListOrStringDeserialiser.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/ListOrStringDeserialiser.java
@@ -15,8 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import static com.google.common.collect.Lists.newArrayList;
-
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -24,6 +22,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -36,7 +35,7 @@ public class ListOrStringDeserialiser<T> extends JsonDeserializer<ListOrSingle<T
     JsonNode rootNode = parser.readValueAsTree();
     if (rootNode.isArray()) {
       ArrayNode arrayNode = (ArrayNode) rootNode;
-      List<T> items = newArrayList();
+      List<T> items = new ArrayList<>();
       for (Iterator<JsonNode> i = arrayNode.elements(); i.hasNext(); ) {
         JsonNode node = i.next();
         Object value = getValue(node);

--- a/src/main/java/com/github/tomakehurst/wiremock/common/ListOrStringDeserialiser.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/ListOrStringDeserialiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Thomas Akehurst
+ * Copyright (C) 2022-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,7 @@ public class NetworkAddressRules {
   private final Set<NetworkAddressRange> allowed;
   private final Set<NetworkAddressRange> denied;
 
-  public static NetworkAddressRules ALLOW_ALL =
-      new NetworkAddressRules(Set.of(ALL), emptySet());
+  public static NetworkAddressRules ALLOW_ALL = new NetworkAddressRules(Set.of(ALL), emptySet());
 
   public NetworkAddressRules(Set<NetworkAddressRange> allowed, Set<NetworkAddressRange> denied) {
     this.allowed = allowed;

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -31,7 +31,7 @@ public class NetworkAddressRules {
   private final Set<NetworkAddressRange> denied;
 
   public static NetworkAddressRules ALLOW_ALL =
-      new NetworkAddressRules(ImmutableSet.of(ALL), emptySet());
+      new NetworkAddressRules(Set.of(ALL), emptySet());
 
   public NetworkAddressRules(Set<NetworkAddressRange> allowed, Set<NetworkAddressRange> denied) {
     this.allowed = allowed;
@@ -60,7 +60,7 @@ public class NetworkAddressRules {
     public NetworkAddressRules build() {
       Set<NetworkAddressRange> allowedRanges = allowed.build();
       if (allowedRanges.isEmpty()) {
-        allowedRanges = ImmutableSet.of(ALL);
+        allowedRanges = Set.of(ALL);
       }
       return new NetworkAddressRules(allowedRanges, denied.build());
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/ssl/KeyStoreSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/ssl/KeyStoreSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Thomas Akehurst
+ * Copyright (C) 2020-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/tomakehurst/wiremock/common/url/PathTemplate.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/url/PathTemplate.java
@@ -102,12 +102,12 @@ public class PathTemplate {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     PathTemplate that = (PathTemplate) o;
-    return Objects.equal(templateString, that.templateString);
+    return Objects.equals(templateString, that.templateString);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(templateString);
+    return Objects.hash(templateString);
   }
 }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/common/url/PathTemplate.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/url/PathTemplate.java
@@ -17,10 +17,10 @@ package com.github.tomakehurst.wiremock.common.url;
 
 import static java.lang.String.format;
 
-import com.google.common.base.Objects;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/Parameters.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/Parameters.java
@@ -17,7 +17,6 @@ package com.github.tomakehurst.wiremock.extension;
 
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Metadata;
-import com.google.common.collect.ImmutableMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -34,7 +33,7 @@ public class Parameters extends Metadata {
   }
 
   public static Parameters one(String name, Object value) {
-    return from(ImmutableMap.of(name, value));
+    return from(Map.of(name, value));
   }
 
   public static <T> Parameters of(T myData) {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/Parameters.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Thomas Akehurst
+ * Copyright (C) 2015-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapper.java
@@ -17,7 +17,6 @@ package com.github.tomakehurst.wiremock.extension.requestfilter;
 
 import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
 import static org.apache.commons.lang3.StringUtils.countMatches;
 import static org.apache.commons.lang3.StringUtils.ordinalIndexOf;
@@ -282,13 +281,13 @@ public class RequestWrapper implements Request {
     private RequestMethod requestMethod;
     private FieldTransformer<String> absoluteUrlTransformer;
 
-    private final List<HttpHeader> additionalHeaders = newArrayList();
-    private final List<String> headersToRemove = newArrayList();
+    private final List<HttpHeader> additionalHeaders = new ArrayList<>();
+    private final List<String> headersToRemove = new ArrayList<>();
     private final Map<CaseInsensitiveKey, FieldTransformer<List<String>>> headerTransformers =
         newHashMap();
 
     private final Map<String, Cookie> additionalCookies = newHashMap();
-    private final List<String> cookiesToRemove = newArrayList();
+    private final List<String> cookiesToRemove = new ArrayList<>();
     private final Map<String, FieldTransformer<Cookie>> cookieTransformers = newHashMap();
 
     private FieldTransformer<Body> bodyTransformer;

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -56,7 +56,7 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer
   }
 
   public ResponseTemplateTransformer(boolean global, String helperName, Helper<?> helper) {
-    this(global, ImmutableMap.of(helperName, helper));
+    this(global, Map.of(helperName, helper));
   }
 
   public ResponseTemplateTransformer(boolean global, Map<String, Helper<?>> helpers) {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/SystemKeyAuthoriser.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/SystemKeyAuthoriser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/SystemKeyAuthoriser.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/SystemKeyAuthoriser.java
@@ -27,7 +27,7 @@ public class SystemKeyAuthoriser {
 
   public SystemKeyAuthoriser(Set<String> patterns) {
     if (patterns == null || patterns.isEmpty()) {
-      patterns = ImmutableSet.of("wiremock.*");
+      patterns = Set.of("wiremock.*");
     }
 
     ImmutableSet.Builder<Pattern> builder = ImmutableSet.builder();

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ArrayHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ArrayHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ArrayHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ArrayHelper.java
@@ -20,13 +20,14 @@ import static java.util.Arrays.asList;
 import com.github.jknack.handlebars.Options;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.util.List;
 
 public class ArrayHelper extends HandlebarsHelper<Object> {
 
   @Override
   public Object apply(Object context, Options options) throws IOException {
     if (context == null || context == options.context.model()) {
-      return ImmutableList.of();
+      return List.of();
     }
 
     return ImmutableList.builder().add(context).addAll(asList(options.params)).build();

--- a/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
@@ -17,7 +17,6 @@ package com.github.tomakehurst.wiremock.http;
 
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static com.github.tomakehurst.wiremock.extension.requestfilter.FilterProcessor.processFilters;
-import static com.google.common.collect.Lists.newArrayList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.github.tomakehurst.wiremock.common.DataTruncationSettings;
@@ -25,11 +24,12 @@ import com.github.tomakehurst.wiremock.extension.requestfilter.*;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.common.base.Stopwatch;
+import java.util.ArrayList;
 import java.util.List;
 
 public abstract class AbstractRequestHandler implements RequestHandler, RequestEventSource {
 
-  protected List<RequestListener> listeners = newArrayList();
+  protected List<RequestListener> listeners = new ArrayList<>();
   protected final ResponseRenderer responseRenderer;
   protected final List<RequestFilter> requestFilters;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
@@ -16,7 +16,6 @@
 package com.github.tomakehurst.wiremock.http;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Arrays.asList;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -24,10 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @JsonSerialize(using = HttpHeadersJsonSerializer.class)
@@ -80,7 +76,7 @@ public class HttpHeaders {
   }
 
   public Collection<HttpHeader> all() {
-    List<HttpHeader> httpHeaderList = newArrayList();
+    List<HttpHeader> httpHeaderList = new ArrayList<>();
     for (CaseInsensitiveKey key : headers.keySet()) {
       httpHeaderList.add(new HttpHeader(key.value(), headers.get(key)));
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServer.java
@@ -379,7 +379,15 @@ public abstract class JettyHttpServer implements HttpServer {
   private FilterHolder buildCorsFilter() {
     FilterHolder filterHolder = new FilterHolder(CrossOriginFilter.class);
     filterHolder.setInitParameters(
-        Map.of("chainPreflight", "false", "allowedOrigins", "*", "allowedHeaders", "*", "allowedMethods", "OPTIONS,GET,POST,PUT,PATCH,DELETE"));
+        Map.of(
+            "chainPreflight",
+            "false",
+            "allowedOrigins",
+            "*",
+            "allowedHeaders",
+            "*",
+            "allowedMethods",
+            "OPTIONS,GET,POST,PUT,PATCH,DELETE"));
     return filterHolder;
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServer.java
@@ -28,7 +28,6 @@ import com.github.tomakehurst.wiremock.http.RequestHandler;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.servlet.*;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletRequest;
@@ -36,6 +35,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
@@ -379,11 +379,7 @@ public abstract class JettyHttpServer implements HttpServer {
   private FilterHolder buildCorsFilter() {
     FilterHolder filterHolder = new FilterHolder(CrossOriginFilter.class);
     filterHolder.setInitParameters(
-        ImmutableMap.of(
-            "chainPreflight", "false",
-            "allowedOrigins", "*",
-            "allowedHeaders", "*",
-            "allowedMethods", "OPTIONS,GET,POST,PUT,PATCH,DELETE"));
+        Map.of("chainPreflight", "false", "allowedOrigins", "*", "allowedHeaders", "*", "allowedMethods", "OPTIONS,GET,POST,PUT,PATCH,DELETE"));
     return filterHolder;
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MemoizingMatchResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MemoizingMatchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Thomas Akehurst
+ * Copyright (C) 2020-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import com.google.common.base.Suppliers;
 import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 
 public class MemoizingMatchResult extends MatchResult {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MemoizingMatchResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MemoizingMatchResult.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.matching;
 
 import com.google.common.base.Suppliers;
-import java.util.function.Supplier;
+import com.google.common.base.Supplier;
 
 public class MemoizingMatchResult extends MatchResult {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MemoizingMatchResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MemoizingMatchResult.java
@@ -15,8 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import java.util.function.Supplier;
 
 public class MemoizingMatchResult extends MatchResult {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -15,8 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Lists.newLinkedList;
 import static com.google.common.collect.Maps.newLinkedHashMap;
 
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
@@ -26,6 +24,8 @@ import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
+import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -41,10 +41,10 @@ public class RequestPatternBuilder {
 
   private Map<String, MultiValuePattern> formParams = newLinkedHashMap();
   private Map<String, StringValuePattern> pathParams = newLinkedHashMap();
-  private List<ContentPattern<?>> bodyPatterns = newArrayList();
+  private List<ContentPattern<?>> bodyPatterns = new ArrayList<>();
   private Map<String, StringValuePattern> cookies = newLinkedHashMap();
   private BasicCredentials basicCredentials;
-  private List<MultipartValuePattern> multiparts = newLinkedList();
+  private List<MultipartValuePattern> multiparts = new LinkedList<>();
 
   private ValueMatcher<Request> customMatcher;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/SingleMatchMultiValuePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/SingleMatchMultiValuePattern.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.tomakehurst.wiremock.http.MultiValue;
-import com.google.common.base.Objects;
 import java.util.List;
+import java.util.Objects;
 
 @JsonDeserialize(as = SingleMatchMultiValuePattern.class)
 public class SingleMatchMultiValuePattern extends MultiValuePattern {

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/SingleMatchMultiValuePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/SingleMatchMultiValuePattern.java
@@ -64,11 +64,11 @@ public class SingleMatchMultiValuePattern extends MultiValuePattern {
       return false;
     }
     SingleMatchMultiValuePattern that = (SingleMatchMultiValuePattern) o;
-    return Objects.equal(valuePattern, that.valuePattern);
+    return Objects.equals(valuePattern, that.valuePattern);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(valuePattern);
+    return Objects.hash(valuePattern);
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePattern.java
@@ -85,11 +85,11 @@ public abstract class StringValuePattern extends ContentPattern<String> {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     StringValuePattern that = (StringValuePattern) o;
-    return Objects.equal(expectedValue, that.expectedValue);
+    return Objects.equals(expectedValue, that.expectedValue);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(expectedValue);
+    return Objects.hash(expectedValue);
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePattern.java
@@ -18,9 +18,9 @@ package com.github.tomakehurst.wiremock.matching;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.base.Objects;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
+import java.util.Objects;
 
 @JsonDeserialize(using = StringValuePatternJsonDeserializer.class)
 public abstract class StringValuePattern extends ContentPattern<String> {

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/UrlPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/UrlPattern.java
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock.matching;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.url.PathTemplate;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 public class UrlPattern implements NamedValueMatcher<String> {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/UrlPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/UrlPattern.java
@@ -91,12 +91,12 @@ public class UrlPattern implements NamedValueMatcher<String> {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     UrlPattern that = (UrlPattern) o;
-    return regex == that.regex && Objects.equal(pattern, that.pattern);
+    return regex == that.regex && Objects.equals(pattern, that.pattern);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(pattern, regex);
+    return Objects.hash(pattern, regex);
   }
 
   public boolean isSpecified() {

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -21,7 +21,6 @@ import static com.github.tomakehurst.wiremock.common.Urls.splitQuery;
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.io.ByteStreams.toByteArray;
 import static java.util.Collections.list;
 
@@ -36,7 +35,6 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.http.multipart.PartParser;
 import com.github.tomakehurst.wiremock.jetty.JettyUtils;
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
@@ -45,6 +43,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class WireMockHttpServletRequestAdapter implements Request {
@@ -224,7 +223,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
   }
 
   private HttpHeaders getHeadersQuadratic() {
-    List<HttpHeader> headerList = newArrayList();
+    List<HttpHeader> headerList = new ArrayList<>();
     for (String key : getAllHeaderKeys()) {
       headerList.add(header(key));
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -41,7 +41,6 @@ import com.github.tomakehurst.wiremock.junit.Stubbing;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
-import com.google.common.collect.ImmutableMap;
 import com.toomuchcoding.jsonassert.JsonAssertion;
 import com.toomuchcoding.jsonassert.JsonVerifiable;
 import java.io.File;
@@ -934,15 +933,7 @@ public class AdminApiTest extends AcceptanceTestBase {
         get("/with-metadata")
             .withId(id)
             .withMetadata(
-                ImmutableMap.<String, Object>of(
-                    "one",
-                    1,
-                    "two",
-                    "2",
-                    "three",
-                    true,
-                    "four",
-                    ImmutableMap.of("five", "55555"))));
+            Map.of("one", 1, "two", "2", "three", true, "four", Map.of("five", "55555"))));
 
     WireMockResponse response = testClient.get("/__admin/mappings/" + id);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -933,7 +933,7 @@ public class AdminApiTest extends AcceptanceTestBase {
         get("/with-metadata")
             .withId(id)
             .withMetadata(
-            Map.of("one", 1, "two", "2", "three", true, "four", Map.of("five", "55555"))));
+                Map.of("one", 1, "two", "2", "three", true, "four", Map.of("five", "55555"))));
 
     WireMockResponse response = testClient.get("/__admin/mappings/" + id);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/ConcurrentProxyingTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ConcurrentProxyingTest.java
@@ -18,12 +18,12 @@ package com.github.tomakehurst.wiremock;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.defaultTestFilesRoot;
-import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -57,7 +57,7 @@ public class ConcurrentProxyingTest {
 
     ExecutorService executor = Executors.newFixedThreadPool(20);
 
-    List<Future<?>> results = newArrayList();
+    List<Future<?>> results = new ArrayList<>();
     for (int i = 0; i < 100; i++) {
       results.add(
           executor.submit(

--- a/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
@@ -281,8 +281,7 @@ public class SnapshotDslAcceptanceTest extends AcceptanceTestBase {
             recordSpec()
                 .transformers("test-transformer")
                 .transformerParameters(
-                    Parameters.from(
-                        Map.of("headerKey", "X-Key", "headerValue", "My value"))));
+                    Parameters.from(Map.of("headerKey", "X-Key", "headerValue", "My value"))));
 
     assertThat(
         mappings.get(0).getResponse().getHeaders().getHeader("X-Key").firstValue(), is("My value"));

--- a/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
@@ -37,8 +37,8 @@ import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import com.google.common.collect.ImmutableMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -282,9 +282,7 @@ public class SnapshotDslAcceptanceTest extends AcceptanceTestBase {
                 .transformers("test-transformer")
                 .transformerParameters(
                     Parameters.from(
-                        ImmutableMap.<String, Object>of(
-                            "headerKey", "X-Key",
-                            "headerValue", "My value"))));
+                        Map.of("headerKey", "X-Key", "headerValue", "My value"))));
 
     assertThat(
         mappings.get(0).getResponse().getHeaders().getHeader("X-Key").firstValue(), is("My value"));

--- a/src/test/java/com/github/tomakehurst/wiremock/common/ssl/KeyStoreSettingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/ssl/KeyStoreSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Thomas Akehurst
+ * Copyright (C) 2018-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/ParametersTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/ParametersTest.java
@@ -20,8 +20,8 @@ import static org.hamcrest.Matchers.is;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 import java.time.LocalDate;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class ParametersTest {
@@ -29,7 +29,7 @@ public class ParametersTest {
   @Test
   public void convertsParametersToAnObject() {
     MyData myData =
-        Parameters.from(ImmutableMap.of("name", "Tom", "num", 27, "date", "2023-01-01"))
+        Parameters.from(Map.of("name", "Tom", "num", 27, "date", "2023-01-01"))
             .as(MyData.class);
 
     assertThat(myData.getName(), is("Tom"));

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/ParametersTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/ParametersTest.java
@@ -29,8 +29,7 @@ public class ParametersTest {
   @Test
   public void convertsParametersToAnObject() {
     MyData myData =
-        Parameters.from(Map.of("name", "Tom", "num", 27, "date", "2023-01-01"))
-            .as(MyData.class);
+        Parameters.from(Map.of("name", "Tom", "num", 27, "date", "2023-01-01")).as(MyData.class);
 
     assertThat(myData.getName(), is("Tom"));
     assertThat(myData.getNum(), is(27));

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/SystemKeyAuthorisorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/SystemKeyAuthorisorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Thomas Akehurst
+ * Copyright (C) 2019-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,7 @@ public class SystemKeyAuthorisorTest {
 
   @Test
   public void permitsAllowedKeys() {
-    SystemKeyAuthoriser authoriser =
-        new SystemKeyAuthoriser(Set.of("allowed_.*", "permitted_.*"));
+    SystemKeyAuthoriser authoriser = new SystemKeyAuthoriser(Set.of("allowed_.*", "permitted_.*"));
 
     assertTrue(authoriser.isPermitted("allowed_key_1"));
     assertTrue(authoriser.isPermitted("ALLOWED_KEY_2"));
@@ -35,8 +34,7 @@ public class SystemKeyAuthorisorTest {
 
   @Test
   public void forbidsNonAllowedKeys() {
-    SystemKeyAuthoriser authoriser =
-        new SystemKeyAuthoriser(Set.of("allowed_.*", "permitted_.*"));
+    SystemKeyAuthoriser authoriser = new SystemKeyAuthoriser(Set.of("allowed_.*", "permitted_.*"));
 
     assertFalse(authoriser.isPermitted("forbidden_key_1"));
     assertFalse(authoriser.isPermitted("notallowed_key_2"));

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/SystemKeyAuthorisorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/SystemKeyAuthorisorTest.java
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 public class SystemKeyAuthorisorTest {
@@ -26,7 +26,7 @@ public class SystemKeyAuthorisorTest {
   @Test
   public void permitsAllowedKeys() {
     SystemKeyAuthoriser authoriser =
-        new SystemKeyAuthoriser(ImmutableSet.of("allowed_.*", "permitted_.*"));
+        new SystemKeyAuthoriser(Set.of("allowed_.*", "permitted_.*"));
 
     assertTrue(authoriser.isPermitted("allowed_key_1"));
     assertTrue(authoriser.isPermitted("ALLOWED_KEY_2"));
@@ -36,7 +36,7 @@ public class SystemKeyAuthorisorTest {
   @Test
   public void forbidsNonAllowedKeys() {
     SystemKeyAuthoriser authoriser =
-        new SystemKeyAuthoriser(ImmutableSet.of("allowed_.*", "permitted_.*"));
+        new SystemKeyAuthoriser(Set.of("allowed_.*", "permitted_.*"));
 
     assertFalse(authoriser.isPermitted("forbidden_key_1"));
     assertFalse(authoriser.isPermitted("notallowed_key_2"));

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
@@ -30,7 +30,6 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -53,7 +52,7 @@ public class HandlebarsCurrentDateHelperTest {
 
   @Test
   public void rendersNowDateTime() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of();
+    Map<String, Object> optionsHash = Map.of();
 
     Object output = render(optionsHash);
 
@@ -63,7 +62,7 @@ public class HandlebarsCurrentDateHelperTest {
 
   @Test
   public void rendersNowDateTimeWithCustomFormat() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("format", "yyyy/mm/dd");
+    Map<String, Object> optionsHash = Map.of("format", "yyyy/mm/dd");
 
     Object output = render(optionsHash);
 
@@ -75,7 +74,7 @@ public class HandlebarsCurrentDateHelperTest {
   public void rendersPassedDateTimeWithDayOffset() throws Exception {
     String format = "yyyy-MM-dd";
     SimpleDateFormat df = new SimpleDateFormat(format);
-    ImmutableMap<String, Object> optionsHash = Map.of("format", format, "offset", "5 days");
+    Map<String, Object> optionsHash = Map.of("format", format, "offset", "5 days");
 
     Object output = render(df.parse("2018-04-16"), optionsHash);
 
@@ -84,7 +83,7 @@ public class HandlebarsCurrentDateHelperTest {
 
   @Test
   public void rendersNowWithDayOffset() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("offset", "6 months");
+    Map<String, Object> optionsHash = Map.of("offset", "6 months");
 
     Object output = render(optionsHash);
 
@@ -93,7 +92,7 @@ public class HandlebarsCurrentDateHelperTest {
 
   @Test
   public void rendersNowAsUnixEpochInMilliseconds() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("format", "epoch");
+    Map<String, Object> optionsHash = Map.of("format", "epoch");
 
     Date date = new Date();
     Object output = render(date, optionsHash);
@@ -103,7 +102,7 @@ public class HandlebarsCurrentDateHelperTest {
 
   @Test
   public void rendersNowAsUnixEpochInSeconds() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("format", "unix");
+    Map<String, Object> optionsHash = Map.of("format", "unix");
 
     Date date = new Date();
     Object output = render(date, optionsHash);
@@ -113,8 +112,7 @@ public class HandlebarsCurrentDateHelperTest {
 
   @Test
   public void adjustsISO8601ToSpecfiedTimezone() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("offset", "3 days", "timezone", "Australia/Sydney");
+    Map<String, Object> optionsHash = Map.of("offset", "3 days", "timezone", "Australia/Sydney");
 
     Date inputDate = new ISO8601DateFormat().parse("2014-10-09T06:06:01Z");
     Object output = render(inputDate, optionsHash);
@@ -124,7 +122,7 @@ public class HandlebarsCurrentDateHelperTest {
 
   @Test
   public void adjustsCustomFormatToSpecfiedTimezone() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
+    Map<String, Object> optionsHash =
         Map.of(
             "offset", "3 days", "timezone", "Australia/Sydney", "format", "yyyy-MM-dd HH:mm:ssZ");
 
@@ -175,11 +173,11 @@ public class HandlebarsCurrentDateHelperTest {
     assertThat(body, is("2018-05-04T10:11:12Z"));
   }
 
-  private Object render(ImmutableMap<String, Object> optionsHash) throws IOException {
+  private Object render(Map<String, Object> optionsHash) throws IOException {
     return render(null, optionsHash);
   }
 
-  private Object render(Date context, ImmutableMap<String, Object> optionsHash) throws IOException {
+  private Object render(Date context, Map<String, Object> optionsHash) throws IOException {
     return helper.apply(
         context, new Options.Builder(null, null, null, null, null).setHash(optionsHash).build());
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +53,7 @@ public class HandlebarsCurrentDateHelperTest {
 
   @Test
   public void rendersNowDateTime() throws Exception {
-    ImmutableMap<String, Object> optionsHash = ImmutableMap.<String, Object>of();
+    ImmutableMap<String, Object> optionsHash = Map.of();
 
     Object output = render(optionsHash);
 
@@ -63,7 +64,7 @@ public class HandlebarsCurrentDateHelperTest {
   @Test
   public void rendersNowDateTimeWithCustomFormat() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of("format", "yyyy/mm/dd");
+        Map.of("format", "yyyy/mm/dd");
 
     Object output = render(optionsHash);
 
@@ -76,7 +77,7 @@ public class HandlebarsCurrentDateHelperTest {
     String format = "yyyy-MM-dd";
     SimpleDateFormat df = new SimpleDateFormat(format);
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of("format", format, "offset", "5 days");
+        Map.of("format", format, "offset", "5 days");
 
     Object output = render(df.parse("2018-04-16"), optionsHash);
 
@@ -86,7 +87,7 @@ public class HandlebarsCurrentDateHelperTest {
   @Test
   public void rendersNowWithDayOffset() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of("offset", "6 months");
+        Map.of("offset", "6 months");
 
     Object output = render(optionsHash);
 
@@ -95,7 +96,7 @@ public class HandlebarsCurrentDateHelperTest {
 
   @Test
   public void rendersNowAsUnixEpochInMilliseconds() throws Exception {
-    ImmutableMap<String, Object> optionsHash = ImmutableMap.<String, Object>of("format", "epoch");
+    ImmutableMap<String, Object> optionsHash = Map.of("format", "epoch");
 
     Date date = new Date();
     Object output = render(date, optionsHash);
@@ -105,7 +106,7 @@ public class HandlebarsCurrentDateHelperTest {
 
   @Test
   public void rendersNowAsUnixEpochInSeconds() throws Exception {
-    ImmutableMap<String, Object> optionsHash = ImmutableMap.<String, Object>of("format", "unix");
+    ImmutableMap<String, Object> optionsHash = Map.of("format", "unix");
 
     Date date = new Date();
     Object output = render(date, optionsHash);
@@ -116,9 +117,7 @@ public class HandlebarsCurrentDateHelperTest {
   @Test
   public void adjustsISO8601ToSpecfiedTimezone() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of(
-            "offset", "3 days",
-            "timezone", "Australia/Sydney");
+        Map.of("offset", "3 days", "timezone", "Australia/Sydney");
 
     Date inputDate = new ISO8601DateFormat().parse("2014-10-09T06:06:01Z");
     Object output = render(inputDate, optionsHash);
@@ -129,10 +128,7 @@ public class HandlebarsCurrentDateHelperTest {
   @Test
   public void adjustsCustomFormatToSpecfiedTimezone() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of(
-            "offset", "3 days",
-            "timezone", "Australia/Sydney",
-            "format", "yyyy-MM-dd HH:mm:ssZ");
+        Map.of("offset", "3 days", "timezone", "Australia/Sydney", "format", "yyyy-MM-dd HH:mm:ssZ");
 
     Date inputDate = new ISO8601DateFormat().parse("2014-10-09T06:06:01Z");
     Object output = render(inputDate, optionsHash);

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Thomas Akehurst
+ * Copyright (C) 2018-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,8 +63,7 @@ public class HandlebarsCurrentDateHelperTest {
 
   @Test
   public void rendersNowDateTimeWithCustomFormat() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("format", "yyyy/mm/dd");
+    ImmutableMap<String, Object> optionsHash = Map.of("format", "yyyy/mm/dd");
 
     Object output = render(optionsHash);
 
@@ -76,8 +75,7 @@ public class HandlebarsCurrentDateHelperTest {
   public void rendersPassedDateTimeWithDayOffset() throws Exception {
     String format = "yyyy-MM-dd";
     SimpleDateFormat df = new SimpleDateFormat(format);
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("format", format, "offset", "5 days");
+    ImmutableMap<String, Object> optionsHash = Map.of("format", format, "offset", "5 days");
 
     Object output = render(df.parse("2018-04-16"), optionsHash);
 
@@ -86,8 +84,7 @@ public class HandlebarsCurrentDateHelperTest {
 
   @Test
   public void rendersNowWithDayOffset() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("offset", "6 months");
+    ImmutableMap<String, Object> optionsHash = Map.of("offset", "6 months");
 
     Object output = render(optionsHash);
 
@@ -128,7 +125,8 @@ public class HandlebarsCurrentDateHelperTest {
   @Test
   public void adjustsCustomFormatToSpecfiedTimezone() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        Map.of("offset", "3 days", "timezone", "Australia/Sydney", "format", "yyyy-MM-dd HH:mm:ssZ");
+        Map.of(
+            "offset", "3 days", "timezone", "Australia/Sydney", "format", "yyyy-MM-dd HH:mm:ssZ");
 
     Date inputDate = new ISO8601DateFormat().parse("2014-10-09T06:06:01Z");
     Object output = render(inputDate, optionsHash);

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelperTest.java
@@ -31,7 +31,6 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
@@ -215,42 +214,42 @@ public class HandlebarsJsonPathHelperTest extends HandlebarsHelperTestBase {
 
   @Test
   public void rendersAnEmptyStringWhenJsonValueUndefinedAndOptionsEmpty() throws Exception {
-    Map<String, Object> options = ImmutableMap.<String, Object>of();
+    Map<String, Object> options = Map.of();
     String output = render("{\"test\":\"success\"}", "$.test2", options);
     assertThat(output, is(""));
   }
 
   @Test
   public void rendersDefaultValueWhenShallowJsonValueUndefined() throws Exception {
-    Map<String, Object> options = ImmutableMap.<String, Object>of("default", "0");
+    Map<String, Object> options = Map.of("default", "0");
     String output = render("{}", "$.test", options);
     assertThat(output, is("0"));
   }
 
   @Test
   public void rendersDefaultValueWhenDeepJsonValueUndefined() throws Exception {
-    Map<String, Object> options = ImmutableMap.<String, Object>of("default", "0");
+    Map<String, Object> options = Map.of("default", "0");
     String output = render("{}", "$.outer.inner[0]", options);
     assertThat(output, is("0"));
   }
 
   @Test
   public void rendersDefaultValueWhenJsonValueNull() throws Exception {
-    Map<String, Object> options = ImmutableMap.<String, Object>of("default", "0");
+    Map<String, Object> options = Map.of("default", "0");
     String output = render("{\"test\":null}", "$.test", options);
     assertThat(output, is("0"));
   }
 
   @Test
   public void ignoresDefaultWhenJsonValueEmpty() throws Exception {
-    Map<String, Object> options = ImmutableMap.<String, Object>of("default", "0");
+    Map<String, Object> options = Map.of("default", "0");
     String output = render("{\"test\":\"\"}", "$.test", options);
     assertThat(output, is(""));
   }
 
   @Test
   public void ignoresDefaultWhenJsonValueZero() throws Exception {
-    Map<String, Object> options = ImmutableMap.<String, Object>of("default", "1");
+    Map<String, Object> options = Map.of("default", "1");
     String output = render("{\"test\":0}", "$.test", options);
     assertThat(output, is("0"));
   }
@@ -288,7 +287,7 @@ public class HandlebarsJsonPathHelperTest extends HandlebarsHelperTestBase {
               ResponseDefinition responseDefinition,
               FileSource files,
               Parameters parameters) {
-            return ImmutableMap.<String, Object>of("mapData", ImmutableMap.of("things", "abc"));
+            return Map.of("mapData", Map.of("things", "abc"));
           }
         };
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsRandomValuesHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsRandomValuesHelperTest.java
@@ -30,6 +30,7 @@ import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,7 +49,7 @@ public class HandlebarsRandomValuesHelperTest {
 
   @Test
   public void generatesRandomAlphaNumericOfSpecifiedLength() throws Exception {
-    ImmutableMap<String, Object> optionsHash = ImmutableMap.<String, Object>of("length", 36);
+    ImmutableMap<String, Object> optionsHash = Map.of("length", 36);
 
     String output = render(optionsHash);
 
@@ -59,7 +60,7 @@ public class HandlebarsRandomValuesHelperTest {
   @Test
   public void generatesUppercaseRandomAlphaNumericOfSpecifiedLength() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of("length", 36, "uppercase", true);
+        Map.of("length", 36, "uppercase", true);
 
     String output = render(optionsHash);
 
@@ -70,7 +71,7 @@ public class HandlebarsRandomValuesHelperTest {
   @Test
   public void generatesRandomAlphabeticOfSpecifiedLength() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of("length", 43, "type", "ALPHABETIC", "uppercase", true);
+        Map.of("length", 43, "type", "ALPHABETIC", "uppercase", true);
 
     String output = render(optionsHash);
 
@@ -81,7 +82,7 @@ public class HandlebarsRandomValuesHelperTest {
   @Test
   public void generatesRandomNumericOfSpecifiedLength() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of("length", 55, "type", "NUMERIC");
+        Map.of("length", 55, "type", "NUMERIC");
 
     String output = render(optionsHash);
 
@@ -92,7 +93,7 @@ public class HandlebarsRandomValuesHelperTest {
   @Test
   public void generatesRandomStringOfSpecifiedLength() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of("length", 67, "type", "ALPHANUMERIC_AND_SYMBOLS");
+        Map.of("length", 67, "type", "ALPHANUMERIC_AND_SYMBOLS");
 
     String output = render(optionsHash);
 
@@ -103,7 +104,7 @@ public class HandlebarsRandomValuesHelperTest {
   @Test
   public void generatesRandomHexadecimalOfSpecifiedLength() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of("length", 64, "type", "HEXADECIMAL");
+        Map.of("length", 64, "type", "HEXADECIMAL");
 
     String output = render(optionsHash);
 
@@ -132,7 +133,7 @@ public class HandlebarsRandomValuesHelperTest {
 
   @Test
   public void generatesRandomUUID() throws Exception {
-    ImmutableMap<String, Object> optionsHash = ImmutableMap.<String, Object>of("type", "UUID");
+    ImmutableMap<String, Object> optionsHash = Map.of("type", "UUID");
 
     String output = render(optionsHash);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsRandomValuesHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsRandomValuesHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Thomas Akehurst
+ * Copyright (C) 2018-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,8 +59,7 @@ public class HandlebarsRandomValuesHelperTest {
 
   @Test
   public void generatesUppercaseRandomAlphaNumericOfSpecifiedLength() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("length", 36, "uppercase", true);
+    ImmutableMap<String, Object> optionsHash = Map.of("length", 36, "uppercase", true);
 
     String output = render(optionsHash);
 
@@ -81,8 +80,7 @@ public class HandlebarsRandomValuesHelperTest {
 
   @Test
   public void generatesRandomNumericOfSpecifiedLength() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("length", 55, "type", "NUMERIC");
+    ImmutableMap<String, Object> optionsHash = Map.of("length", 55, "type", "NUMERIC");
 
     String output = render(optionsHash);
 
@@ -103,8 +101,7 @@ public class HandlebarsRandomValuesHelperTest {
 
   @Test
   public void generatesRandomHexadecimalOfSpecifiedLength() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("length", 64, "type", "HEXADECIMAL");
+    ImmutableMap<String, Object> optionsHash = Map.of("length", 64, "type", "HEXADECIMAL");
 
     String output = render(optionsHash);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsRandomValuesHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsRandomValuesHelperTest.java
@@ -28,7 +28,6 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,7 +48,7 @@ public class HandlebarsRandomValuesHelperTest {
 
   @Test
   public void generatesRandomAlphaNumericOfSpecifiedLength() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("length", 36);
+    Map<String, Object> optionsHash = Map.of("length", 36);
 
     String output = render(optionsHash);
 
@@ -59,7 +58,7 @@ public class HandlebarsRandomValuesHelperTest {
 
   @Test
   public void generatesUppercaseRandomAlphaNumericOfSpecifiedLength() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("length", 36, "uppercase", true);
+    Map<String, Object> optionsHash = Map.of("length", 36, "uppercase", true);
 
     String output = render(optionsHash);
 
@@ -69,8 +68,7 @@ public class HandlebarsRandomValuesHelperTest {
 
   @Test
   public void generatesRandomAlphabeticOfSpecifiedLength() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("length", 43, "type", "ALPHABETIC", "uppercase", true);
+    Map<String, Object> optionsHash = Map.of("length", 43, "type", "ALPHABETIC", "uppercase", true);
 
     String output = render(optionsHash);
 
@@ -80,7 +78,7 @@ public class HandlebarsRandomValuesHelperTest {
 
   @Test
   public void generatesRandomNumericOfSpecifiedLength() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("length", 55, "type", "NUMERIC");
+    Map<String, Object> optionsHash = Map.of("length", 55, "type", "NUMERIC");
 
     String output = render(optionsHash);
 
@@ -90,8 +88,7 @@ public class HandlebarsRandomValuesHelperTest {
 
   @Test
   public void generatesRandomStringOfSpecifiedLength() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("length", 67, "type", "ALPHANUMERIC_AND_SYMBOLS");
+    Map<String, Object> optionsHash = Map.of("length", 67, "type", "ALPHANUMERIC_AND_SYMBOLS");
 
     String output = render(optionsHash);
 
@@ -101,7 +98,7 @@ public class HandlebarsRandomValuesHelperTest {
 
   @Test
   public void generatesRandomHexadecimalOfSpecifiedLength() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("length", 64, "type", "HEXADECIMAL");
+    Map<String, Object> optionsHash = Map.of("length", 64, "type", "HEXADECIMAL");
 
     String output = render(optionsHash);
 
@@ -130,7 +127,7 @@ public class HandlebarsRandomValuesHelperTest {
 
   @Test
   public void generatesRandomUUID() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("type", "UUID");
+    Map<String, Object> optionsHash = Map.of("type", "UUID");
 
     String output = render(optionsHash);
 
@@ -138,7 +135,7 @@ public class HandlebarsRandomValuesHelperTest {
     assertThat(output, WireMatchers.matches("^[a-z0-9\\-]+$"));
   }
 
-  private String render(ImmutableMap<String, Object> optionsHash) throws IOException {
+  private String render(Map<String, Object> optionsHash) throws IOException {
     return helper
         .apply(null, new Options.Builder(null, null, null, null, null).setHash(optionsHash).build())
         .toString();

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HostnameHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HostnameHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Thomas Akehurst
+ * Copyright (C) 2019-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HostnameHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HostnameHelperTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +44,7 @@ public class HostnameHelperTest {
 
   @Test
   public void generatesHostname() throws Exception {
-    ImmutableMap<String, Object> optionsHash = ImmutableMap.<String, Object>of();
+    ImmutableMap<String, Object> optionsHash = Map.of();
 
     String output = render(optionsHash);
     assertThat(output, equalToCompressingWhiteSpace(hostname));

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HostnameHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HostnameHelperTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import com.github.jknack.handlebars.Options;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.common.LocalNotifier;
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -44,13 +43,13 @@ public class HostnameHelperTest {
 
   @Test
   public void generatesHostname() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of();
+    Map<String, Object> optionsHash = Map.of();
 
     String output = render(optionsHash);
     assertThat(output, equalToCompressingWhiteSpace(hostname));
   }
 
-  private String render(ImmutableMap<String, Object> optionsHash) throws IOException {
+  private String render(Map<String, Object> optionsHash) throws IOException {
     return helper
         .apply(null, new Options.Builder(null, null, null, null, null).setHash(optionsHash).build())
         .toString();

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
@@ -26,6 +26,7 @@ import java.text.DateFormat;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +43,7 @@ public class ParseDateHelperTest {
 
   @Test
   public void parsesAnISO8601DateWhenNoFormatSpecified() throws Exception {
-    ImmutableMap<String, Object> optionsHash = ImmutableMap.of();
+    ImmutableMap<String, Object> optionsHash = Map.of();
 
     String inputDate = "2018-05-01T01:02:03Z";
     Object output = render(inputDate, optionsHash);
@@ -54,7 +55,7 @@ public class ParseDateHelperTest {
 
   @Test
   public void parsesAnRFC1123DateWhenNoFormatSpecified() throws Exception {
-    ImmutableMap<String, Object> optionsHash = ImmutableMap.of();
+    ImmutableMap<String, Object> optionsHash = Map.of();
 
     String inputDate = "Tue, 01 Jun 2021 15:16:17 GMT";
     Object output = render(inputDate, optionsHash);
@@ -68,7 +69,7 @@ public class ParseDateHelperTest {
   @Test
   public void parsesDateWithSuppliedFormat() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of("format", "dd/MM/yyyy");
+        Map.of("format", "dd/MM/yyyy");
 
     String inputDate = "01/02/2003";
     Object output = render(inputDate, optionsHash);
@@ -81,7 +82,7 @@ public class ParseDateHelperTest {
   @Test
   public void parsesLocalDateTimeWithSuppliedFormat() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of("format", "dd/MM/yyyy HH:mm:ss");
+        Map.of("format", "dd/MM/yyyy HH:mm:ss");
 
     String inputDate = "01/02/2003 05:06:07";
     Object output = render(inputDate, optionsHash);
@@ -93,7 +94,7 @@ public class ParseDateHelperTest {
 
   @Test
   public void parsesDateTimeWithEpochFormat() throws Exception {
-    ImmutableMap<String, Object> optionsHash = ImmutableMap.<String, Object>of("format", "epoch");
+    ImmutableMap<String, Object> optionsHash = Map.of("format", "epoch");
 
     String inputDate = "1577964091000";
     Object output = render(inputDate, optionsHash);

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.*;
 
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.github.jknack.handlebars.Options;
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.time.Instant;
@@ -43,7 +42,7 @@ public class ParseDateHelperTest {
 
   @Test
   public void parsesAnISO8601DateWhenNoFormatSpecified() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of();
+    Map<String, Object> optionsHash = Map.of();
 
     String inputDate = "2018-05-01T01:02:03Z";
     Object output = render(inputDate, optionsHash);
@@ -55,7 +54,7 @@ public class ParseDateHelperTest {
 
   @Test
   public void parsesAnRFC1123DateWhenNoFormatSpecified() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of();
+    Map<String, Object> optionsHash = Map.of();
 
     String inputDate = "Tue, 01 Jun 2021 15:16:17 GMT";
     Object output = render(inputDate, optionsHash);
@@ -68,7 +67,7 @@ public class ParseDateHelperTest {
 
   @Test
   public void parsesDateWithSuppliedFormat() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("format", "dd/MM/yyyy");
+    Map<String, Object> optionsHash = Map.of("format", "dd/MM/yyyy");
 
     String inputDate = "01/02/2003";
     Object output = render(inputDate, optionsHash);
@@ -80,7 +79,7 @@ public class ParseDateHelperTest {
 
   @Test
   public void parsesLocalDateTimeWithSuppliedFormat() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("format", "dd/MM/yyyy HH:mm:ss");
+    Map<String, Object> optionsHash = Map.of("format", "dd/MM/yyyy HH:mm:ss");
 
     String inputDate = "01/02/2003 05:06:07";
     Object output = render(inputDate, optionsHash);
@@ -92,7 +91,7 @@ public class ParseDateHelperTest {
 
   @Test
   public void parsesDateTimeWithEpochFormat() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("format", "epoch");
+    Map<String, Object> optionsHash = Map.of("format", "epoch");
 
     String inputDate = "1577964091000";
     Object output = render(inputDate, optionsHash);
@@ -102,8 +101,7 @@ public class ParseDateHelperTest {
     assertThat(((Date) output), is((expectedDate)));
   }
 
-  private Object render(String context, ImmutableMap<String, Object> optionsHash)
-      throws IOException {
+  private Object render(String context, Map<String, Object> optionsHash) throws IOException {
     return helper.apply(
         context, new Options.Builder(null, null, null, null, null).setHash(optionsHash).build());
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Thomas Akehurst
+ * Copyright (C) 2018-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,8 +68,7 @@ public class ParseDateHelperTest {
 
   @Test
   public void parsesDateWithSuppliedFormat() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("format", "dd/MM/yyyy");
+    ImmutableMap<String, Object> optionsHash = Map.of("format", "dd/MM/yyyy");
 
     String inputDate = "01/02/2003";
     Object output = render(inputDate, optionsHash);
@@ -81,8 +80,7 @@ public class ParseDateHelperTest {
 
   @Test
   public void parsesLocalDateTimeWithSuppliedFormat() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("format", "dd/MM/yyyy HH:mm:ss");
+    ImmutableMap<String, Object> optionsHash = Map.of("format", "dd/MM/yyyy HH:mm:ss");
 
     String inputDate = "01/02/2003 05:06:07";
     Object output = render(inputDate, optionsHash);

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Thomas Akehurst
+ * Copyright (C) 2019-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,7 @@ public class SystemValueHelperTest {
 
   @Test
   public void getExistingEnvironmentVariableShouldNotNull() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("key", "PATH", "type", "ENVIRONMENT");
+    ImmutableMap<String, Object> optionsHash = Map.of("key", "PATH", "type", "ENVIRONMENT");
 
     String output = render(optionsHash);
     assertNotNull(output);
@@ -61,16 +60,14 @@ public class SystemValueHelperTest {
   public void getForbiddenEnvironmentVariableShouldReturnError() throws Exception {
     helper = new SystemValueHelper(new SystemKeyAuthoriser(Set.of("JAVA*")));
 
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("key", "TEST_VAR", "type", "ENVIRONMENT");
+    ImmutableMap<String, Object> optionsHash = Map.of("key", "TEST_VAR", "type", "ENVIRONMENT");
     String value = render(optionsHash);
     assertEquals("[ERROR: Access to TEST_VAR is denied]", value);
   }
 
   @Test
   public void getEmptyKeyShouldReturnError() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("key", "", "type", "PROPERTY");
+    ImmutableMap<String, Object> optionsHash = Map.of("key", "", "type", "PROPERTY");
     String value = render(optionsHash);
     assertEquals("[ERROR: The key cannot be empty]", value);
   }
@@ -80,8 +77,7 @@ public class SystemValueHelperTest {
     helper = new SystemValueHelper(new SystemKeyAuthoriser(Set.of("test.*")));
     System.setProperty("test.key", "aaa");
     assertEquals("aaa", System.getProperty("test.key"));
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("key", "test.key", "type", "PROPERTY");
+    ImmutableMap<String, Object> optionsHash = Map.of("key", "test.key", "type", "PROPERTY");
     String value = render(optionsHash);
     assertEquals("aaa", value);
   }
@@ -90,8 +86,7 @@ public class SystemValueHelperTest {
   public void getForbiddenPropertyShouldReturnError() throws Exception {
     helper = new SystemValueHelper(new SystemKeyAuthoriser(Set.of("JAVA.*")));
     System.setProperty("test.key", "aaa");
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("key", "test.key", "type", "PROPERTY");
+    ImmutableMap<String, Object> optionsHash = Map.of("key", "test.key", "type", "PROPERTY");
     String value = render(optionsHash);
     assertEquals("[ERROR: Access to test.key is denied]", value);
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelperTest.java
@@ -22,8 +22,9 @@ import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.common.LocalNotifier;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.SystemKeyAuthoriser;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,16 +34,14 @@ public class SystemValueHelperTest {
 
   @BeforeEach
   public void init() {
-    helper = new SystemValueHelper(new SystemKeyAuthoriser(ImmutableSet.of(".*")));
+    helper = new SystemValueHelper(new SystemKeyAuthoriser(Set.of(".*")));
     LocalNotifier.set(new ConsoleNotifier(true));
   }
 
   @Test
   public void getExistingEnvironmentVariableShouldNotNull() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of(
-            "key", "PATH",
-            "type", "ENVIRONMENT");
+        Map.of("key", "PATH", "type", "ENVIRONMENT");
 
     String output = render(optionsHash);
     assertNotNull(output);
@@ -52,9 +51,7 @@ public class SystemValueHelperTest {
   @Test
   public void getNonExistingEnvironmentVariableShouldNull() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of(
-            "key", "NON_EXISTING_VAR",
-            "type", "ENVIRONMENT");
+        Map.of("key", "NON_EXISTING_VAR", "type", "ENVIRONMENT");
 
     String output = render(optionsHash);
     assertNull(output);
@@ -62,12 +59,10 @@ public class SystemValueHelperTest {
 
   @Test
   public void getForbiddenEnvironmentVariableShouldReturnError() throws Exception {
-    helper = new SystemValueHelper(new SystemKeyAuthoriser(ImmutableSet.of("JAVA*")));
+    helper = new SystemValueHelper(new SystemKeyAuthoriser(Set.of("JAVA*")));
 
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of(
-            "key", "TEST_VAR",
-            "type", "ENVIRONMENT");
+        Map.of("key", "TEST_VAR", "type", "ENVIRONMENT");
     String value = render(optionsHash);
     assertEquals("[ERROR: Access to TEST_VAR is denied]", value);
   }
@@ -75,34 +70,28 @@ public class SystemValueHelperTest {
   @Test
   public void getEmptyKeyShouldReturnError() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of(
-            "key", "",
-            "type", "PROPERTY");
+        Map.of("key", "", "type", "PROPERTY");
     String value = render(optionsHash);
     assertEquals("[ERROR: The key cannot be empty]", value);
   }
 
   @Test
   public void getAllowedPropertyShouldSuccess() throws Exception {
-    helper = new SystemValueHelper(new SystemKeyAuthoriser(ImmutableSet.of("test.*")));
+    helper = new SystemValueHelper(new SystemKeyAuthoriser(Set.of("test.*")));
     System.setProperty("test.key", "aaa");
     assertEquals("aaa", System.getProperty("test.key"));
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of(
-            "key", "test.key",
-            "type", "PROPERTY");
+        Map.of("key", "test.key", "type", "PROPERTY");
     String value = render(optionsHash);
     assertEquals("aaa", value);
   }
 
   @Test
   public void getForbiddenPropertyShouldReturnError() throws Exception {
-    helper = new SystemValueHelper(new SystemKeyAuthoriser(ImmutableSet.of("JAVA.*")));
+    helper = new SystemValueHelper(new SystemKeyAuthoriser(Set.of("JAVA.*")));
     System.setProperty("test.key", "aaa");
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of(
-            "key", "test.key",
-            "type", "PROPERTY");
+        Map.of("key", "test.key", "type", "PROPERTY");
     String value = render(optionsHash);
     assertEquals("[ERROR: Access to test.key is denied]", value);
   }
@@ -110,9 +99,7 @@ public class SystemValueHelperTest {
   @Test
   public void getNonExistingSystemPropertyShouldNull() throws Exception {
     ImmutableMap<String, Object> optionsHash =
-        ImmutableMap.<String, Object>of(
-            "key", "not.existing.prop",
-            "type", "PROPERTY");
+        Map.of("key", "not.existing.prop", "type", "PROPERTY");
     String output = render(optionsHash);
     assertNull(output);
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelperTest.java
@@ -21,7 +21,6 @@ import com.github.jknack.handlebars.Options;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.common.LocalNotifier;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.SystemKeyAuthoriser;
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
@@ -40,7 +39,7 @@ public class SystemValueHelperTest {
 
   @Test
   public void getExistingEnvironmentVariableShouldNotNull() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("key", "PATH", "type", "ENVIRONMENT");
+    Map<String, Object> optionsHash = Map.of("key", "PATH", "type", "ENVIRONMENT");
 
     String output = render(optionsHash);
     assertNotNull(output);
@@ -49,8 +48,7 @@ public class SystemValueHelperTest {
 
   @Test
   public void getNonExistingEnvironmentVariableShouldNull() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("key", "NON_EXISTING_VAR", "type", "ENVIRONMENT");
+    Map<String, Object> optionsHash = Map.of("key", "NON_EXISTING_VAR", "type", "ENVIRONMENT");
 
     String output = render(optionsHash);
     assertNull(output);
@@ -60,14 +58,14 @@ public class SystemValueHelperTest {
   public void getForbiddenEnvironmentVariableShouldReturnError() throws Exception {
     helper = new SystemValueHelper(new SystemKeyAuthoriser(Set.of("JAVA*")));
 
-    ImmutableMap<String, Object> optionsHash = Map.of("key", "TEST_VAR", "type", "ENVIRONMENT");
+    Map<String, Object> optionsHash = Map.of("key", "TEST_VAR", "type", "ENVIRONMENT");
     String value = render(optionsHash);
     assertEquals("[ERROR: Access to TEST_VAR is denied]", value);
   }
 
   @Test
   public void getEmptyKeyShouldReturnError() throws Exception {
-    ImmutableMap<String, Object> optionsHash = Map.of("key", "", "type", "PROPERTY");
+    Map<String, Object> optionsHash = Map.of("key", "", "type", "PROPERTY");
     String value = render(optionsHash);
     assertEquals("[ERROR: The key cannot be empty]", value);
   }
@@ -77,7 +75,7 @@ public class SystemValueHelperTest {
     helper = new SystemValueHelper(new SystemKeyAuthoriser(Set.of("test.*")));
     System.setProperty("test.key", "aaa");
     assertEquals("aaa", System.getProperty("test.key"));
-    ImmutableMap<String, Object> optionsHash = Map.of("key", "test.key", "type", "PROPERTY");
+    Map<String, Object> optionsHash = Map.of("key", "test.key", "type", "PROPERTY");
     String value = render(optionsHash);
     assertEquals("aaa", value);
   }
@@ -86,20 +84,19 @@ public class SystemValueHelperTest {
   public void getForbiddenPropertyShouldReturnError() throws Exception {
     helper = new SystemValueHelper(new SystemKeyAuthoriser(Set.of("JAVA.*")));
     System.setProperty("test.key", "aaa");
-    ImmutableMap<String, Object> optionsHash = Map.of("key", "test.key", "type", "PROPERTY");
+    Map<String, Object> optionsHash = Map.of("key", "test.key", "type", "PROPERTY");
     String value = render(optionsHash);
     assertEquals("[ERROR: Access to test.key is denied]", value);
   }
 
   @Test
   public void getNonExistingSystemPropertyShouldNull() throws Exception {
-    ImmutableMap<String, Object> optionsHash =
-        Map.of("key", "not.existing.prop", "type", "PROPERTY");
+    Map<String, Object> optionsHash = Map.of("key", "not.existing.prop", "type", "PROPERTY");
     String output = render(optionsHash);
     assertNull(output);
   }
 
-  private String render(ImmutableMap<String, Object> optionsHash) throws IOException {
+  private String render(Map<String, Object> optionsHash) throws IOException {
     return helper.apply(
         null, new Options.Builder(null, null, null, null, null).setHash(optionsHash).build());
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.xmlunit.diff.ComparisonType;
 
 public class EqualToXmlPatternTest {
@@ -428,8 +429,9 @@ public class EqualToXmlPatternTest {
                 + "  \"enablePlaceholders\": true,\n"
                 + "  \"placeholderOpeningDelimiterRegex\": \"[\",\n"
                 + "  \"placeholderClosingDelimiterRegex\": \"]\",\n"
-                + "  \"exemptedComparisons\": [\"SCHEMA_LOCATION\", \"NAMESPACE_URI\", \"ATTR_VALUE\"]\n"
-                + "}"));
+                + "  \"exemptedComparisons\": [\"SCHEMA_LOCATION\", \"ATTR_VALUE\", \"NAMESPACE_URI\"]\n"
+                + "}",
+            JSONCompareMode.NON_EXTENSIBLE));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -35,7 +35,6 @@ import com.github.tomakehurst.wiremock.common.LocalNotifier;
 import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
-import com.google.common.collect.ImmutableSet;
 import java.util.Locale;
 import java.util.Set;
 import org.hamcrest.Matchers;
@@ -402,7 +401,7 @@ public class EqualToXmlPatternTest {
     assertThat(
         equalToXmlPattern.getExemptedComparisons(),
         Matchers.<Set<ComparisonType>>is(
-            ImmutableSet.of(SCHEMA_LOCATION, NAMESPACE_URI, ATTR_VALUE)));
+            Set.of(SCHEMA_LOCATION, NAMESPACE_URI, ATTR_VALUE)));
   }
 
   @Test
@@ -418,7 +417,7 @@ public class EqualToXmlPatternTest {
             enablePlaceholders,
             placeholderOpeningDelimiterRegex,
             placeholderClosingDelimiterRegex,
-            ImmutableSet.of(SCHEMA_LOCATION, NAMESPACE_URI, ATTR_VALUE));
+            Set.of(SCHEMA_LOCATION, NAMESPACE_URI, ATTR_VALUE));
 
     String json = Json.write(pattern);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -400,8 +400,7 @@ public class EqualToXmlPatternTest {
         placeholderClosingDelimiterRegex, equalToXmlPattern.getPlaceholderClosingDelimiterRegex());
     assertThat(
         equalToXmlPattern.getExemptedComparisons(),
-        Matchers.<Set<ComparisonType>>is(
-            Set.of(SCHEMA_LOCATION, NAMESPACE_URI, ATTR_VALUE)));
+        Matchers.<Set<ComparisonType>>is(Set.of(SCHEMA_LOCATION, NAMESPACE_URI, ATTR_VALUE)));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -289,7 +289,7 @@ public class EqualToXmlPatternTest {
   }
 
   @Test
-  public void returnsNoMatchWhenTagNamesDifferAndContentIsSame() throws Exception {
+  public void returnsNoMatchWhenTagNamesDifferAndContentIsSame() {
     final EqualToXmlPattern pattern = new EqualToXmlPattern("<one>Hello</one>");
     final MatchResult matchResult = pattern.match("<two>Hello</two>");
 
@@ -306,7 +306,7 @@ public class EqualToXmlPatternTest {
   }
 
   @Test
-  public void doesNotFetchDtdBecauseItCouldResultInAFailedMatch() throws Exception {
+  public void doesNotFetchDtdBecauseItCouldResultInAFailedMatch() {
     String xmlWithDtdThatCannotBeFetched =
         "<!DOCTYPE my_request SYSTEM \"https://thishostname.doesnotexist.com/one.dtd\"><do_request/>";
     EqualToXmlPattern pattern = new EqualToXmlPattern(xmlWithDtdThatCannotBeFetched);

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
@@ -23,8 +23,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
-import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
+import java.util.Map;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -95,7 +95,7 @@ public class MatchesXPathPatternTest {
     StringValuePattern pattern =
         WireMock.matchingXPath(
             "//sub:subThing[.='The stuff']",
-            ImmutableMap.of("sub", "http://subthings", "t", "http://things"));
+            Map.of("sub", "http://subthings", "t", "http://things"));
 
     MatchResult match = pattern.match(xml);
     assertTrue(match.isExactMatch());
@@ -255,9 +255,7 @@ public class MatchesXPathPatternTest {
     MatchesXPathPattern pattern =
         new MatchesXPathPattern(
             "//*",
-            ImmutableMap.of(
-                "one", "http://one.com/",
-                "two", "http://two.com/"));
+            Map.of("one", "http://one.com/", "two", "http://two.com/"));
 
     String json = Json.write(pattern);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
@@ -253,9 +253,7 @@ public class MatchesXPathPatternTest {
   @Test
   public void serialisesCorrectlyWithNamspaces() throws JSONException {
     MatchesXPathPattern pattern =
-        new MatchesXPathPattern(
-            "//*",
-            Map.of("one", "http://one.com/", "two", "http://two.com/"));
+        new MatchesXPathPattern("//*", Map.of("one", "http://one.com/", "two", "http://two.com/"));
 
     String json = Json.write(pattern);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockMultipart.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockMultipart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Thomas Akehurst
+ * Copyright (C) 2018-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockMultipart.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockMultipart.java
@@ -15,19 +15,18 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import static com.google.common.collect.Lists.newArrayList;
-
 import com.github.tomakehurst.wiremock.http.Body;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.Request;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 public class MockMultipart implements Request.Part {
 
   private String name;
-  private List<HttpHeader> headers = newArrayList();
+  private List<HttpHeader> headers = new ArrayList<>();
   private Body body;
 
   public static MockMultipart mockPart() {

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
@@ -19,7 +19,6 @@ import static com.github.tomakehurst.wiremock.common.Strings.bytesFromString;
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
 import static java.util.Arrays.asList;
 
@@ -29,11 +28,7 @@ import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.jetty11.MultipartParser;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import java.net.URI;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 public class MockRequest implements Request {
 
@@ -115,7 +110,7 @@ public class MockRequest implements Request {
 
   public MockRequest part(MockMultipart part) {
     if (multiparts == null) {
-      multiparts = newArrayList();
+      multiparts = new ArrayList<>();
     }
 
     multiparts.add(part);

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
@@ -32,8 +32,8 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class RequestPatternBuilderTest {
@@ -59,13 +59,13 @@ public class RequestPatternBuilderTest {
             1234,
             WireMock.urlEqualTo("/foo"),
             RequestMethod.POST,
-            ImmutableMap.of("X-Header", MultiValuePattern.of(WireMock.equalTo("bar"))),
+            Map.of("X-Header", MultiValuePattern.of(WireMock.equalTo("bar"))),
             emptyMap(),
-            ImmutableMap.of("query_param", MultiValuePattern.of(WireMock.equalTo("bar"))),
-            ImmutableMap.of("form_param", MultiValuePattern.of(WireMock.equalTo("bar"))),
-            ImmutableMap.of("cookie", WireMock.equalTo("yum")),
+            Map.of("query_param", MultiValuePattern.of(WireMock.equalTo("bar"))),
+            Map.of("form_param", MultiValuePattern.of(WireMock.equalTo("bar"))),
+            Map.of("cookie", WireMock.equalTo("yum")),
             new BasicCredentials("user", "pass"),
-            ImmutableList.<ContentPattern<?>>of(WireMock.equalTo("BODY")),
+            List.of(WireMock.equalTo("BODY")),
             null,
             null,
             null);
@@ -119,13 +119,13 @@ public class RequestPatternBuilderTest {
             1234,
             WireMock.urlEqualTo("/foo"),
             RequestMethod.POST,
-            ImmutableMap.of("X-Header", MultiValuePattern.of(WireMock.equalTo("bar"))),
+            Map.of("X-Header", MultiValuePattern.of(WireMock.equalTo("bar"))),
             emptyMap(),
-            ImmutableMap.of("query_param", MultiValuePattern.of(WireMock.equalTo("bar"))),
-            ImmutableMap.of("form_param", MultiValuePattern.of(WireMock.equalTo("bar"))),
-            ImmutableMap.of("cookie", WireMock.equalTo("yum")),
+            Map.of("query_param", MultiValuePattern.of(WireMock.equalTo("bar"))),
+            Map.of("form_param", MultiValuePattern.of(WireMock.equalTo("bar"))),
+            Map.of("cookie", WireMock.equalTo("yum")),
             new BasicCredentials("user", "pass"),
-            ImmutableList.<ContentPattern<?>>of(WireMock.equalTo("BODY")),
+            List.of(WireMock.equalTo("BODY")),
             null,
             null,
             asList(multipartPattern));

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/StringValuePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/StringValuePatternTest.java
@@ -19,14 +19,14 @@ import static com.google.common.collect.FluentIterable.from;
 import static java.util.Arrays.asList;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.reflect.ClassPath;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
 public class StringValuePatternTest {

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/StringValuePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/StringValuePatternTest.java
@@ -18,11 +18,10 @@ package com.github.tomakehurst.wiremock.matching;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.ClassPath;
-import org.junit.jupiter.api.Test;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import org.junit.jupiter.api.Test;
 
 public class StringValuePatternTest {
 
@@ -32,33 +31,38 @@ public class StringValuePatternTest {
         ClassPath.from(Thread.currentThread().getContextClassLoader()).getAllClasses();
 
     allClasses.stream()
-            .filter(classInfo ->
-                classInfo
-                    .getPackageName()
-                    .startsWith("com.github.tomakehurst.wiremock.matching"))
-            .map(input -> {
-                try {
-                    return input.load();
-                } catch (Throwable e) {
-                    return Object.class;
-                }
+        .filter(
+            classInfo ->
+                classInfo.getPackageName().startsWith("com.github.tomakehurst.wiremock.matching"))
+        .map(
+            input -> {
+              try {
+                return input.load();
+              } catch (Throwable e) {
+                return Object.class;
+              }
             })
-            .filter(clazz -> clazz.isAssignableFrom(StringValuePattern.class))
-            .filter(clazz -> !Modifier.isAbstract(clazz.getModifiers()))
-            .forEach(this::findConstructorWithStringParamInFirstPosition);
+        .filter(clazz -> clazz.isAssignableFrom(StringValuePattern.class))
+        .filter(clazz -> !Modifier.isAbstract(clazz.getModifiers()))
+        .forEach(this::findConstructorWithStringParamInFirstPosition);
   }
 
   private Constructor<?> findConstructorWithStringParamInFirstPosition(Class<?> clazz) {
-      return Arrays.stream(clazz.getConstructors())
-              .filter(constructor -> constructor.getParameterTypes().length > 0
-                      && constructor.getParameterTypes()[0].equals(String.class)
-                      && constructor.getParameterAnnotations().length > 0
-                      && constructor.getParameterAnnotations()[0].length > 0
-                      && constructor
-                      .getParameterAnnotations()[0][0]
-                      .annotationType()
-                      .equals(JsonProperty.class))
-              .findFirst()
-              .orElseThrow(() -> new AssertionError("No constructor found with @JsonProperty annotated name parameter"));
+    return Arrays.stream(clazz.getConstructors())
+        .filter(
+            constructor ->
+                constructor.getParameterTypes().length > 0
+                    && constructor.getParameterTypes()[0].equals(String.class)
+                    && constructor.getParameterAnnotations().length > 0
+                    && constructor.getParameterAnnotations()[0].length > 0
+                    && constructor
+                        .getParameterAnnotations()[0][0]
+                        .annotationType()
+                        .equals(JsonProperty.class))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new AssertionError(
+                    "No constructor found with @JsonProperty annotated name parameter"));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/StringValuePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/StringValuePatternTest.java
@@ -31,7 +31,6 @@ public class StringValuePatternTest {
     ImmutableSet<ClassPath.ClassInfo> allClasses =
         ClassPath.from(Thread.currentThread().getContextClassLoader()).getAllClasses();
 
-
     allClasses.stream()
             .filter(classInfo ->
                 classInfo

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/StringValuePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/StringValuePatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformerTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
-import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -59,9 +58,7 @@ public class RequestPatternTransformerTest {
             .withHeader("X-CaseInsensitive", equalToIgnoreCase("Baz"));
 
     Map<String, CaptureHeadersSpec> headers =
-        ImmutableMap.of(
-            "X-CaseSensitive", new CaptureHeadersSpec(false),
-            "X-CaseInsensitive", new CaptureHeadersSpec(true));
+        Map.of("X-CaseSensitive", new CaptureHeadersSpec(false), "X-CaseInsensitive", new CaptureHeadersSpec(true));
 
     assertEquals(
         expected.build(), new RequestPatternTransformer(headers, null).apply(request).build());

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,11 @@ public class RequestPatternTransformerTest {
             .withHeader("X-CaseInsensitive", equalToIgnoreCase("Baz"));
 
     Map<String, CaptureHeadersSpec> headers =
-        Map.of("X-CaseSensitive", new CaptureHeadersSpec(false), "X-CaseInsensitive", new CaptureHeadersSpec(true));
+        Map.of(
+            "X-CaseSensitive",
+            new CaptureHeadersSpec(false),
+            "X-CaseInsensitive",
+            new CaptureHeadersSpec(true));
 
     assertEquals(
         expected.build(), new RequestPatternTransformer(headers, null).apply(request).build());

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,8 @@ import org.junit.jupiter.api.Test;
 
 public class SnapshotStubMappingPostProcessorTest {
   private static final List<StubMapping> TEST_STUB_MAPPINGS =
-      List.of(WireMock.get("/foo").build(), WireMock.get("/bar").build(), WireMock.get("/foo").build());
+      List.of(
+          WireMock.get("/foo").build(), WireMock.get("/bar").build(), WireMock.get("/foo").build());
 
   @Test
   public void processFiltersRepeatedRequestsWhenNotRecordingScenarios() {

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessorTest.java
@@ -23,14 +23,12 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class SnapshotStubMappingPostProcessorTest {
   private static final List<StubMapping> TEST_STUB_MAPPINGS =
-      ImmutableList.of(
-          WireMock.get("/foo").build(), WireMock.get("/bar").build(), WireMock.get("/foo").build());
+      List.of(WireMock.get("/foo").build(), WireMock.get("/bar").build(), WireMock.get("/foo").build());
 
   @Test
   public void processFiltersRepeatedRequestsWhenNotRecordingScenarios() {

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
@@ -29,7 +29,7 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -53,7 +53,7 @@ public class ResponseDefinitionTest {
             "http://base.com",
             null,
             Fault.EMPTY_RESPONSE,
-            ImmutableList.of("transformer-1"),
+            List.of("transformer-1"),
             Parameters.one("name", "Jeff"),
             true);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Thomas Akehurst
+ * Copyright (C) 2012-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
@@ -17,16 +17,11 @@ package com.github.tomakehurst.wiremock.testsupport;
 
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
-import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
-import static com.google.common.collect.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.http.*;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import org.mockito.Mockito;
 
 public class MockRequestBuilder {
@@ -34,14 +29,14 @@ public class MockRequestBuilder {
   private String url = "/";
   private RequestMethod method = GET;
   private String clientIp = "x.x.x.x";
-  private List<HttpHeader> individualHeaders = newArrayList();
+  private List<HttpHeader> individualHeaders = new ArrayList<>();
   private Map<String, Cookie> cookies = newHashMap();
-  private List<QueryParameter> queryParameters = newArrayList();
+  private List<QueryParameter> queryParameters = new ArrayList<>();
 
-  private List<FormParameter> formParameters = newArrayList();
+  private List<FormParameter> formParameters = new ArrayList<>();
   private String body = "";
   private String bodyAsBase64 = "";
-  private Collection<Request.Part> multiparts = newArrayList();
+  private Collection<Request.Part> multiparts = new ArrayList<>();
   private String protocol = "HTTP/1.1";
 
   private boolean browserProxyRequest = false;
@@ -152,7 +147,7 @@ public class MockRequestBuilder {
     when(request.header(Mockito.any(String.class))).thenReturn(httpHeader("key", "value"));
 
     when(request.getHeaders()).thenReturn(headers);
-    when(request.getAllHeaderKeys()).thenReturn(newLinkedHashSet(headers.keys()));
+    when(request.getAllHeaderKeys()).thenReturn(new LinkedHashSet<>(headers.keys()));
     when(request.containsHeader(Mockito.any(String.class))).thenReturn(false);
     when(request.getCookies()).thenReturn(cookies);
     when(request.getBody()).thenReturn(body.getBytes());

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/TestFiles.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/TestFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/InMemoryRequestJournalTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/InMemoryRequestJournalTest.java
@@ -88,8 +88,7 @@ public class InMemoryRequestJournalTest {
 
   @Test
   public void matchesRequestWithCustomMatcherDefinition() throws Exception {
-    RequestJournal journal =
-        new InMemoryRequestJournal(null, Map.of(ALWAYS.getName(), ALWAYS));
+    RequestJournal journal = new InMemoryRequestJournal(null, Map.of(ALWAYS.getName(), ALWAYS));
 
     journal.requestReceived(serveEvent1);
     journal.requestReceived(serveEvent2);

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/InMemoryRequestJournalTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/InMemoryRequestJournalTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.Matchers.is;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,7 +89,7 @@ public class InMemoryRequestJournalTest {
   @Test
   public void matchesRequestWithCustomMatcherDefinition() throws Exception {
     RequestJournal journal =
-        new InMemoryRequestJournal(null, ImmutableMap.of(ALWAYS.getName(), ALWAYS));
+        new InMemoryRequestJournal(null, Map.of(ALWAYS.getName(), ALWAYS));
 
     journal.requestReceived(serveEvent1);
     journal.requestReceived(serveEvent2);

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
@@ -30,7 +30,6 @@ import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.http.Cookie;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
@@ -103,9 +102,7 @@ public class LoggedRequestTest {
   public void jsonRepresentation() throws Exception {
     HttpHeaders headers = new HttpHeaders(httpHeader("Accept-Language", "en-us,en;q=0.5"));
     Map<String, Cookie> cookies =
-        ImmutableMap.of(
-            "first_cookie", new Cookie("yum"),
-            "monster_cookie", new Cookie("COOKIIIEESS"));
+        Map.of("first_cookie", new Cookie("yum"), "monster_cookie", new Cookie("COOKIIIEESS"));
 
     Date loggedDate = Dates.parse(DATE);
 

--- a/src/test/java/ignored/Examples.java
+++ b/src/test/java/ignored/Examples.java
@@ -44,8 +44,8 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import com.google.common.collect.ImmutableMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
@@ -296,14 +296,14 @@ public class Examples extends AcceptanceTestBase {
             .willReturn(
                 aResponse()
                     .withTransformerParameter("newValue", 66)
-                    .withTransformerParameter("inner", ImmutableMap.of("thing", "value"))));
+                    .withTransformerParameter("inner", Map.of("thing", "value"))));
 
     System.out.println(
         get(urlEqualTo("/transform"))
             .willReturn(
                 aResponse()
                     .withTransformerParameter("newValue", 66)
-                    .withTransformerParameter("inner", ImmutableMap.of("thing", "value")))
+                    .withTransformerParameter("inner", Map.of("thing", "value")))
             .build());
   }
 

--- a/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
+++ b/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
@@ -16,7 +16,6 @@
 package org.wiremock.webhooks;
 
 import static com.github.tomakehurst.wiremock.common.Encoding.decodeBase64;
-import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.singletonList;
 
 import com.fasterxml.jackson.annotation.*;
@@ -175,7 +174,7 @@ public class WebhookDefinition {
 
   public WebhookDefinition withHeader(String key, String... values) {
     if (headers == null) {
-      headers = newArrayList();
+      headers = new ArrayList<>();
     }
 
     headers.add(new HttpHeader(key, values));

--- a/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
+++ b/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Run https://public.moderne.io/recipes/org.openrewrite.java.migrate.guava.NoGuava to remove Guava where it can be replaced with standard JDK calls.

Started with an automated change in 66a62fd25cea1cf483ebe9f554614e918aafc4d1 ; then some manual fixes on top of that.

## References

https://github.com/wiremock/wiremock/issues/2111

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)