### PR TITLE
Add WireMock co-maintainers role and document the merge process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,3 +106,45 @@ The website sources are located here: [wiremock/wiremock.org](https://github.com
 All the documentation is located under the `_docs` directory as Markdown files,
 and it can be edited with all modern text editors and IDEs.
 See the repository's contributor guide for more information.
+
+## Merge process
+
+Merges to this repository can be performed by the WireMock maintainer ([Tom Akehurst](https://github.com/tomakehurst))
+and by _co-maintainers_ assigned by him.
+This is a [community role](https://github.com/wiremock/community/blob/main/governance/README.md)
+designed for WireMock itself and other key repositories,
+specifically to facilitate review and changes while WireMock 3 is in beta
+and receives a lot of incremental patches.
+
+- The maintainers are responsible to verify the pull request readiness
+  in accordance with contributing guidelines (e.g. code quality, test automation, documentation, etc.).
+  The pull request can only be approved if these requirements are met
+- In the beginning, a review by one co-maintainer is required for the merge,
+  unless there are negative reviews and unaddressed comments by other contributors
+- After the approval, it is generally recommended to give at least 24 hours for reviews before merging
+
+Beyond WireMock 3.x Beta releases, the scope of responsibilities for co-maintainers
+is yet to be determined based on the experiences with this role for the Beta versions.
+
+### What can be merged by co-maintainers
+
+While WireMock 3.x is in Beta, co-maintainers can merge the following pull requests:
+
+- Minor features and improvements that do not impact the WireMock architecture
+- Refactorings, including the major ones, e.g. Guava replacement
+- Test Automation
+- Non-production repository changes: documentation (including Javadoc), GitHub Actions, bots and automation
+- Dependency updates for shaded dependencies, patch/minor versions for projects following the Semantic Versioning notation
+
+### What CANNOT be merged by co-maintainers without BDFL’s approval
+
+The following changes need a review by Tom Akehurst before being merged.
+
+- Any compatibility breaking changes, including binary API and REST API,
+  unless pre-approved by the BDFL in the associated GitHub issue
+- New request matchers (patterns)
+- Substantial changes to WireMock Architecture and API.
+  Examples: New REST API end-points, major features like GraphQL fetching
+- Inclusion of new libraries, even if shaded
+- Major version Dependency updates, e.g. Jetty 11 => 12
+- Changes in the deliverable artefacts, e.g. new modules


### PR DESCRIPTION
This change should help us to increase velocity of changes

- [x] Add a role of a WireMock Co-maintainer, which also stems from a co-maintainer in the [Community charter](https://github.com/wiremock/community/blob/main/governance/README.md)
- [x] Document the Merge process for WireMock 3,x Beta
- [x] Document the process in the community repo, e.g. make a call regarding the CLA for co-maintainers

## Motivation

There are a lot of open pull requests that are important to end users and contribute to the WireMock 3.x scope. They keep accumulating overlaps and potential merge conflicts, and also do not get evaluation in the Beta releases.

The only current maintainer, Tom Akehurst, combines a number of roles and does not have much bandwidth to review and merge pull requests. So we need more review and maintainer bandwidth

## Nominated co-maintainers

I would suggest to make the following contributors co-maintainers, or to work towards enabling them.

- @oleg-nenashev 
- @Mahoney 
- @timtebeek 
- @oleg-nenashev 
- @rodolpheche - if we include WireMock Docker into the scope now or later