### PR TITLE
Improve handlebars performance on large templates

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/HandlebarsOptimizedTemplate.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/HandlebarsOptimizedTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Thomas Akehurst
+ * Copyright (C) 2019-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
 import com.github.tomakehurst.wiremock.common.Exceptions;
 import java.io.IOException;
+import java.io.Writer;
+import org.apache.commons.io.output.StringBuilderWriter;
 
 public class HandlebarsOptimizedTemplate {
 
@@ -63,8 +65,16 @@ public class HandlebarsOptimizedTemplate {
     final RenderCache renderCache = new RenderCache();
     Context context = Context.newBuilder(contextData).combine("renderCache", renderCache).build();
 
-    return startContent
-        + Exceptions.uncheck(() -> template.apply(context), String.class)
-        + endContent;
+    return startContent + applyTemplate(context) + endContent;
+  }
+
+  private String applyTemplate(Context context) {
+    return Exceptions.uncheck(
+        () -> {
+          Writer stringWriter = new StringBuilderWriter(template.text().length() * 2);
+          template.apply(context, stringWriter);
+          return stringWriter.toString();
+        },
+        String.class);
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -30,6 +30,8 @@ import com.github.tomakehurst.wiremock.common.ClasspathFileSource;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAdjusters;
@@ -1007,6 +1009,18 @@ public class ResponseTemplateTransformerTest {
     String result = transform("{{date (parseDate '2021' format='yyyy') format='yyyy-MM'}}");
     String expected = YearMonth.of(2021, 1).toString();
     assertThat(result, is(expected));
+  }
+
+  @Test
+  public void canHandleALargeTemplateReasonablyFast() {
+    String template = "{{#each (range 100000 199999) as |index|}}Line {{index}}\n{{/each}}";
+    Instant start = Instant.now();
+    String result = transform(template);
+    Duration timeTaken = Duration.between(start, Instant.now());
+
+    assertThat(result.substring(0, 100), startsWith("Line 100000\nLine 100001\nLine 100002\n"));
+    assertThat(result.length(), equalTo(1_200_000));
+    assertThat(timeTaken, lessThan(Duration.ofSeconds(5)));
   }
 
   private Integer transformToInt(String responseBodyTemplate) {


### PR DESCRIPTION
Handlebars `TextStringBuilder` has a very poor buffer growth strategy.

It increases it by the length of the string to be appended, so *every* append causes *all* the existing data to be copied to a new location in memory.

`java.io.StringBuilder` has a much better approach of doubling the capacity of the buffer each time it is too small, resulting in far fewer copies.

Additionally, it seems to me that setting the initial capacity to double the size of the template will minimise the chances of a copy being needed at all.

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] ~For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)~

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
