### PR TITLE
Fixed @WireMockTest not working with @DisabledInNativeImage

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -37,8 +37,6 @@ public class WireMockExtension extends DslWrapper
         AfterEachCallback,
         AfterAllCallback {
 
-  private static final Options DEFAULT_OPTIONS = WireMockConfiguration.options().dynamicPort();
-
   private final boolean configureStaticDsl;
   private final boolean failOnUnmatchedRequests;
 
@@ -189,6 +187,7 @@ public class WireMockExtension extends DslWrapper
   }
 
   private Options resolveOptions(ExtensionContext extensionContext) {
+    final Options defaultOptions = WireMockConfiguration.options().dynamicPort();
     return extensionContext
         .getElement()
         .flatMap(
@@ -196,8 +195,8 @@ public class WireMockExtension extends DslWrapper
                 this.isDeclarative
                     ? AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class)
                     : Optional.empty())
-        .<Options>map(this::buildOptionsFromWireMockTestAnnotation)
-        .orElse(Optional.ofNullable(this.options).orElse(DEFAULT_OPTIONS));
+        .map(this::buildOptionsFromWireMockTestAnnotation)
+        .orElse(Optional.ofNullable(this.options).orElse(defaultOptions));
   }
 
   private Options buildOptionsFromWireMockTestAnnotation(WireMockTest annotation) {


### PR DESCRIPTION
## References

Having a JUnit 5 test that uses [`@DisabledInNativeImage`](https://junit.org/junit5/docs/5.9.1/api/org.junit.jupiter.api/org/junit/jupiter/api/condition/DisabledInNativeImage.html) and the `WireMockExtension` produces an exception when running tests in GraalVM native-image.

Fixes https://github.com/wiremock/wiremock/issues/2202

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)