### PR TITLE
MatchesJsonSchemaPattern will return no match for null input

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPattern.java
@@ -68,6 +68,10 @@ public class MatchesJsonSchemaPattern extends StringValuePattern {
 
   @Override
   public MatchResult match(String json) {
+    if (json == null) {
+      return MatchResult.noMatch();
+    }
+
     JsonNode jsonNode;
     try {
       jsonNode = Json.read(json, JsonNode.class);

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPatternTest.java
@@ -26,6 +26,8 @@ import static org.hamcrest.Matchers.is;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.jayway.jsonpath.JsonPath;
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -49,6 +51,23 @@ public class MatchesJsonSchemaPatternTest {
         pattern.match(file("schema-validation/shop-order.slightly-wrong.json"));
     assertThat(lessBadMatchResult.isExactMatch(), is(false));
     assertThat(lessBadMatchResult.getDistance(), closeTo(0.33, 0.01));
+  }
+
+  private static List<String> invalidContent() {
+    return Arrays.asList(null, "", "not json", "{");
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidContent")
+  void invalidContentGivesNoMatch(String content) {
+    String schema = file("schema-validation/shop-order.schema.json");
+
+    MatchesJsonSchemaPattern pattern = new MatchesJsonSchemaPattern(schema);
+
+    MatchResult veryBadMatchResult = pattern.match(content);
+
+    assertThat(veryBadMatchResult.isExactMatch(), is(false));
+    assertThat(veryBadMatchResult.getDistance(), is(1.0));
   }
 
   @Test


### PR DESCRIPTION
An HTTP request without a body (e.g. GET, DELETE) passes null to the matcher which it used not to handle, causing all requests to the WireMock instance to fail.

This PR fixes that bug.

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
