### PR TITLE
Replace com.google.common.io.BaseEncoding by java.util.Base64

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/Encoding.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Encoding.java
@@ -29,7 +29,7 @@ public class Encoding {
     if (encoder == null) {
       synchronized (Encoding.class) {
         if (encoder == null) {
-          encoder = new GuavaBase64Encoder();
+          encoder = new JdkBase64Encoder();
         }
       }
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/JdkBase64Encoder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/JdkBase64Encoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Thomas Akehurst
+ * Copyright (C) 2018-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;
 
-public class GuavaBase64Encoder implements Base64Encoder {
+public class JdkBase64Encoder implements Base64Encoder {
 
   @Override
   public String encode(byte[] content) {
@@ -26,15 +26,12 @@ public class GuavaBase64Encoder implements Base64Encoder {
 
   @Override
   public String encode(byte[] content, boolean padding) {
-    BaseEncoding encoder = BaseEncoding.base64();
-    if (!padding) {
-      encoder = encoder.omitPadding();
-    }
-    return encoder.encode(content);
+    var encoder = padding ? Base64.getEncoder() : Base64.getEncoder().withoutPadding();
+    return encoder.encodeToString(content);
   }
 
   @Override
   public byte[] decode(String base64) {
-    return BaseEncoding.base64().decode(base64);
+    return Base64.getDecoder().decode(base64);
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/BinaryEqualToPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/BinaryEqualToPattern.java
@@ -18,8 +18,8 @@ package com.github.tomakehurst.wiremock.matching;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.io.BaseEncoding;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Objects;
 
 public class BinaryEqualToPattern extends ContentPattern<byte[]> {
@@ -30,7 +30,7 @@ public class BinaryEqualToPattern extends ContentPattern<byte[]> {
 
   @JsonCreator
   public BinaryEqualToPattern(@JsonProperty("binaryEqualTo") String expected) {
-    this(BaseEncoding.base64().decode(expected));
+    this(Base64.getDecoder().decode(expected));
   }
 
   @Override
@@ -47,7 +47,7 @@ public class BinaryEqualToPattern extends ContentPattern<byte[]> {
   @Override
   @JsonIgnore
   public String getExpected() {
-    return BaseEncoding.base64().encode(expectedValue);
+    return Base64.getEncoder().encodeToString(expectedValue);
   }
 
   public String getBinaryEqualTo() {

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Thomas Akehurst
+ * Copyright (C) 2012-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,14 +27,14 @@ import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import com.google.common.io.BaseEncoding;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import org.junit.jupiter.api.Test;
 
-public class ResponseDefinitionBuilderTest {
+class ResponseDefinitionBuilderTest {
 
   @Test
-  public void withTransformerParameterShouldNotChangeOriginalTransformerParametersValue() {
+  void withTransformerParameterShouldNotChangeOriginalTransformerParametersValue() {
     ResponseDefinition originalResponseDefinition =
         ResponseDefinitionBuilder.responseDefinition()
             .withTransformerParameter("name", "original")
@@ -53,14 +53,14 @@ public class ResponseDefinitionBuilderTest {
   }
 
   @Test
-  public void likeShouldCreateCompleteResponseDefinitionCopy() throws Exception {
+  void likeShouldCreateCompleteResponseDefinitionCopy() {
     ResponseDefinition originalResponseDefinition =
         ResponseDefinitionBuilder.responseDefinition()
             .withStatus(200)
             .withStatusMessage("OK")
             .withBody("some body")
             .withBase64Body(
-                BaseEncoding.base64().encode("some body".getBytes(StandardCharsets.UTF_8)))
+                Base64.getEncoder().encodeToString("some body".getBytes(StandardCharsets.UTF_8)))
             .withBodyFile("some_body.json")
             .withHeader("some header", "some value")
             .withFixedDelay(100)
@@ -78,7 +78,7 @@ public class ResponseDefinitionBuilderTest {
   }
 
   @Test
-  public void proxyResponseDefinitionWithoutProxyInformationIsNotInResponseDefinition() {
+  void proxyResponseDefinitionWithoutProxyInformationIsNotInResponseDefinition() {
     ResponseDefinition proxyDefinition =
         ResponseDefinitionBuilder.responseDefinition().proxiedFrom("http://my.domain").build();
 
@@ -87,8 +87,7 @@ public class ResponseDefinitionBuilderTest {
   }
 
   @Test
-  public void
-      proxyResponseDefinitionWithoutProxyInformationIsNotInResponseDefinitionWithJsonBody() {
+  void proxyResponseDefinitionWithoutProxyInformationIsNotInResponseDefinitionWithJsonBody() {
     ResponseDefinition proxyDefinition =
         ResponseDefinitionBuilder.responseDefinition()
             .proxiedFrom("http://my.domain")
@@ -100,8 +99,7 @@ public class ResponseDefinitionBuilderTest {
   }
 
   @Test
-  public void
-      proxyResponseDefinitionWithoutProxyInformationIsNotInResponseDefinitionWithBinaryBody() {
+  void proxyResponseDefinitionWithoutProxyInformationIsNotInResponseDefinitionWithBinaryBody() {
     ResponseDefinition proxyDefinition =
         ResponseDefinitionBuilder.responseDefinition()
             .proxiedFrom("http://my.domain")
@@ -113,7 +111,7 @@ public class ResponseDefinitionBuilderTest {
   }
 
   @Test
-  public void proxyResponseDefinitionWithExtraInformationIsInResponseDefinition() {
+  void proxyResponseDefinitionWithExtraInformationIsInResponseDefinition() {
     ResponseDefinition proxyDefinition =
         ResponseDefinitionBuilder.responseDefinition()
             .proxiedFrom("http://my.domain")
@@ -128,7 +126,7 @@ public class ResponseDefinitionBuilderTest {
   }
 
   @Test
-  public void proxyResponseDefinitionWithExtraInformationIsInResponseDefinitionWithJsonBody() {
+  void proxyResponseDefinitionWithExtraInformationIsInResponseDefinitionWithJsonBody() {
     ResponseDefinition proxyDefinition =
         ResponseDefinitionBuilder.responseDefinition()
             .proxiedFrom("http://my.domain")
@@ -144,7 +142,7 @@ public class ResponseDefinitionBuilderTest {
   }
 
   @Test
-  public void proxyResponseDefinitionWithExtraInformationIsInResponseDefinitionWithBinaryBody() {
+  void proxyResponseDefinitionWithExtraInformationIsInResponseDefinitionWithBinaryBody() {
     ResponseDefinition proxyDefinition =
         ResponseDefinitionBuilder.responseDefinition()
             .proxiedFrom("http://my.domain")

--- a/src/test/java/com/github/tomakehurst/wiremock/common/Base64EncoderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/Base64EncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Thomas Akehurst
+ * Copyright (C) 2018-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ public class Base64EncoderTest {
 
   @Test
   public void testGuavaEncoder() {
-    Base64Encoder encoder = new GuavaBase64Encoder();
+    Base64Encoder encoder = new JdkBase64Encoder();
 
     String encoded = encoder.encode(INPUT.getBytes());
     assertThat(encoded, is(OUTPUT));

--- a/src/test/java/com/github/tomakehurst/wiremock/common/Base64EncoderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/Base64EncoderTest.java
@@ -25,8 +25,8 @@ public class Base64EncoderTest {
   public static final String OUTPUT = "MTIzNA==";
 
   @Test
-  public void testGuavaEncoder() {
-    Base64Encoder encoder = new JdkBase64Encoder();
+  void testEncoder() {
+    var encoder = new JdkBase64Encoder();
 
     String encoded = encoder.encode(INPUT.getBytes());
     assertThat(encoded, is(OUTPUT));

--- a/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
@@ -23,13 +23,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.github.tomakehurst.wiremock.common.Json;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;
 import org.junit.jupiter.api.Test;
 
-public class BodyTest {
+class BodyTest {
 
   @Test
-  public void constructsFromBytes() {
+  void constructsFromBytes() {
     Body body =
         Body.fromOneOf(
             "this content".getBytes(), "not this content", new IntNode(1), "lskdjflsjdflks");
@@ -40,7 +40,7 @@ public class BodyTest {
   }
 
   @Test
-  public void constructsFromString() {
+  void constructsFromString() {
     Body body = Body.fromOneOf(null, "this content", new IntNode(1), "lskdjflsjdflks");
 
     assertThat(body.asString(), is("this content"));
@@ -49,7 +49,7 @@ public class BodyTest {
   }
 
   @Test
-  public void constructsFromJson() {
+  void constructsFromJson() {
     Body body = Body.fromOneOf(null, null, new IntNode(1), "lskdjflsjdflks");
 
     assertThat(body.asString(), is("1"));
@@ -58,8 +58,8 @@ public class BodyTest {
   }
 
   @Test
-  public void constructsFromBase64() {
-    byte[] base64Encoded = BaseEncoding.base64().encode("this content".getBytes()).getBytes();
+  void constructsFromBase64() {
+    byte[] base64Encoded = Base64.getEncoder().encodeToString("this content".getBytes()).getBytes();
     String encodedText = stringFromBytes(base64Encoded);
     Body body = Body.fromOneOf(null, null, null, encodedText);
 
@@ -69,7 +69,7 @@ public class BodyTest {
   }
 
   @Test
-  public void bodyAsJson() {
+  void bodyAsJson() {
     final JsonNode jsonContent = Json.node("{\"name\":\"wiremock\",\"isCool\":true}");
     Body body = Body.fromOneOf(null, null, jsonContent, "lskdjflsjdflks");
 
@@ -77,7 +77,7 @@ public class BodyTest {
   }
 
   @Test
-  public void hashCorrectly() {
+  void hashCorrectly() {
     byte[] primes = {2, 3, 5, 7};
     byte[] primes2 = {2, 3, 5, 7};
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/BinaryEqualToPatternPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/BinaryEqualToPatternPatternTest.java
@@ -23,14 +23,14 @@ import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
-import com.google.common.io.BaseEncoding;
+import java.util.Base64;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class BinaryEqualToPatternPatternTest {
+class BinaryEqualToPatternPatternTest {
 
   @Test
-  public void returns1ForNonMatch() {
+  void returns1ForNonMatch() {
     ValueMatcher<byte[]> pattern = WireMock.binaryEqualTo(new byte[] {1, 2, 3});
     byte[] actual = {4, 5, 6};
 
@@ -41,7 +41,7 @@ public class BinaryEqualToPatternPatternTest {
   }
 
   @Test
-  public void returns0WhenExactlyEqual() {
+  void returns0WhenExactlyEqual() {
     ValueMatcher<byte[]> pattern = WireMock.binaryEqualTo(new byte[] {1, 2, 3});
     byte[] actual = {1, 2, 3};
 
@@ -52,7 +52,7 @@ public class BinaryEqualToPatternPatternTest {
   }
 
   @Test
-  public void returnsNonMatchWheActualIsNull() {
+  void returnsNonMatchWheActualIsNull() {
     ValueMatcher<byte[]> pattern = WireMock.binaryEqualTo(new byte[] {1, 2, 3});
     byte[] actual = null;
 
@@ -63,9 +63,9 @@ public class BinaryEqualToPatternPatternTest {
   }
 
   @Test
-  public void serialisesCorrectly() throws Exception {
+  void serialisesCorrectly() throws Exception {
     byte[] expected = {5, 5, 5, 5};
-    String base64Expected = BaseEncoding.base64().encode(expected);
+    String base64Expected = Base64.getEncoder().encodeToString(expected);
     String expectedJson =
         "{                                                   \n"
             + "  \"binaryEqualTo\": \""
@@ -77,8 +77,8 @@ public class BinaryEqualToPatternPatternTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void deserializesCorrectly() {
-    String base64Expected = BaseEncoding.base64().encode(new byte[] {1, 2, 3});
+  void deserializesCorrectly() {
+    String base64Expected = Base64.getEncoder().encodeToString(new byte[] {1, 2, 3});
 
     ContentPattern<byte[]> pattern =
         Json.read(
@@ -94,7 +94,7 @@ public class BinaryEqualToPatternPatternTest {
   }
 
   @Test
-  public void objectsShouldBeEqualOnSameExpectedValue() {
+  void objectsShouldBeEqualOnSameExpectedValue() {
     BinaryEqualToPattern a = new BinaryEqualToPattern(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
     BinaryEqualToPattern b = new BinaryEqualToPattern(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
     BinaryEqualToPattern c = new BinaryEqualToPattern(new byte[] {0, 8, 15});


### PR DESCRIPTION
Replace com.google.common.io.BaseEncoding by java.util.Base64

## References

https://github.com/wiremock/wiremock/issues/2111

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
