### PR TITLE
Fix for path template match when query param is part of url

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestLine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestLine.java
@@ -58,7 +58,8 @@ public class RequestLine {
     this.pathTemplate = pathTemplate;
   }
 
-  public static RequestLine fromRequest(final Request request, boolean isPathTemplateDefinition, final PathTemplate pathTemplate) {
+  public static RequestLine fromRequest(
+      final Request request, boolean isPathTemplateDefinition, final PathTemplate pathTemplate) {
     URI url = URI.create(request.getUrl());
     Map<String, QueryParameter> rawQuery = Urls.splitQuery(url);
     Map<String, ListOrSingle<String>> adaptedQuery =

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestLine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestLine.java
@@ -58,7 +58,7 @@ public class RequestLine {
     this.pathTemplate = pathTemplate;
   }
 
-  public static RequestLine fromRequest(final Request request, final PathTemplate pathTemplate) {
+  public static RequestLine fromRequest(final Request request, boolean isPathTemplateDefinition, final PathTemplate pathTemplate) {
     URI url = URI.create(request.getUrl());
     Map<String, QueryParameter> rawQuery = Urls.splitQuery(url);
     Map<String, ListOrSingle<String>> adaptedQuery =
@@ -71,7 +71,7 @@ public class RequestLine {
         request.getScheme(),
         request.getHost(),
         request.getPort(),
-        request.getUrl(),
+        isPathTemplateDefinition ? url.getPath() : request.getUrl(),
         request.getClientIp(),
         adaptedQuery,
         pathTemplate);

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -42,11 +42,11 @@ public class RequestTemplateModel {
   }
 
   public static RequestTemplateModel from(final Request request) {
-    return from(request, null);
+    return from(request, false, null);
   }
 
-  public static RequestTemplateModel from(final Request request, final PathTemplate pathTemplate) {
-    RequestLine requestLine = RequestLine.fromRequest(request, pathTemplate);
+  public static RequestTemplateModel from(final Request request, boolean isPathTemplateDefinition, final PathTemplate pathTemplate) {
+    RequestLine requestLine = RequestLine.fromRequest(request, isPathTemplateDefinition, pathTemplate);
     Map<String, ListOrSingle<String>> adaptedHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     adaptedHeaders.putAll(
         Maps.toMap(

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -45,8 +45,10 @@ public class RequestTemplateModel {
     return from(request, false, null);
   }
 
-  public static RequestTemplateModel from(final Request request, boolean isPathTemplateDefinition, final PathTemplate pathTemplate) {
-    RequestLine requestLine = RequestLine.fromRequest(request, isPathTemplateDefinition, pathTemplate);
+  public static RequestTemplateModel from(
+      final Request request, boolean isPathTemplateDefinition, final PathTemplate pathTemplate) {
+    RequestLine requestLine =
+        RequestLine.fromRequest(request, isPathTemplateDefinition, pathTemplate);
     Map<String, ListOrSingle<String>> adaptedHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     adaptedHeaders.putAll(
         Maps.toMap(

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -94,11 +94,13 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer
         ResponseDefinitionBuilder.like(responseDefinition);
 
     final PathTemplate pathTemplate = getCurrentEventPathTemplate();
+    final boolean isPathTemplateDefinition = responseDefinition.getBody() != null
+            && responseDefinition.getBody().contains("request.path");
 
     final ImmutableMap<String, Object> model =
         ImmutableMap.<String, Object>builder()
             .put("parameters", firstNonNull(parameters, Collections.<String, Object>emptyMap()))
-            .put("request", RequestTemplateModel.from(request, pathTemplate))
+            .put("request", RequestTemplateModel.from(request, isPathTemplateDefinition, pathTemplate))
             .putAll(addExtraModelElements(request, responseDefinition, files, parameters))
             .build();
 

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -94,13 +94,16 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer
         ResponseDefinitionBuilder.like(responseDefinition);
 
     final PathTemplate pathTemplate = getCurrentEventPathTemplate();
-    final boolean isPathTemplateDefinition = responseDefinition.getBody() != null
+    final boolean isPathTemplateDefinition =
+        responseDefinition.getBody() != null
             && responseDefinition.getBody().contains("request.path");
 
     final ImmutableMap<String, Object> model =
         ImmutableMap.<String, Object>builder()
             .put("parameters", firstNonNull(parameters, Collections.<String, Object>emptyMap()))
-            .put("request", RequestTemplateModel.from(request, isPathTemplateDefinition, pathTemplate))
+            .put(
+                "request",
+                RequestTemplateModel.from(request, isPathTemplateDefinition, pathTemplate))
             .putAll(addExtraModelElements(request, responseDefinition, files, parameters))
             .build();
 

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
@@ -65,6 +65,20 @@ public class ResponseTemplatingAcceptanceTest {
     }
 
     @Test
+    public void appliedLastPathMatchesDoesNotWork() {
+      wm.stubFor(
+              get(urlPathTemplate("/{template_param}"))
+                      .willReturn(
+                              aResponse()
+                                      .withBody("{ \"key\": \"{{{ request.path.template_param }}}\" }")
+                                      .withTransformers("response-template")));
+
+      String content = client.get("/foo?bar=1").content();
+
+      assertThat(content, is("{ \"key\": \"foo\" }"));
+    }
+
+    @Test
     public void doesNotApplyResponseTemplateWhenNotAddedToStubMapping() {
       wm.stubFor(
           get(urlPathEqualTo("/not-templated"))

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
@@ -67,11 +67,11 @@ public class ResponseTemplatingAcceptanceTest {
     @Test
     public void appliedLastPathMatchesDoesNotWork() {
       wm.stubFor(
-              get(urlPathTemplate("/{template_param}"))
-                      .willReturn(
-                              aResponse()
-                                      .withBody("{ \"key\": \"{{{ request.path.template_param }}}\" }")
-                                      .withTransformers("response-template")));
+          get(urlPathTemplate("/{template_param}"))
+              .willReturn(
+                  aResponse()
+                      .withBody("{ \"key\": \"{{{ request.path.template_param }}}\" }")
+                      .withTransformers("response-template")));
 
       String content = client.get("/foo?bar=1").content();
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
