### PR TITLE
Add WireMock Java Co-Maintainers as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @wiremock/wiremock-java-co-maintainers


### PR DESCRIPTION
Enables automatic review requests for https://github.com/wiremock/community/issues/42 