### PR TITLE
add-exports in eclipse configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -508,6 +508,15 @@ tasks.withType(JavaCompile) {
   ])
 }
 
+eclipse.classpath.file {
+  whenMerged {
+    entries.find{ it.path ==~ '.*JRE_CONTAINER.*' }.each {
+      it.entryAttributes['module'] = true
+      it.entryAttributes['add-exports'] = 'java.desktop/com.sun.java.swing.plaf.motif=ALL-UNNAMED'
+    }
+  }
+}
+
 int getMajorVersion() {
   Integer.valueOf(project.version.substring(0, project.version.indexOf('.')))
 }


### PR DESCRIPTION
To avoid compilation error in Eclipse on `import sun.security.x509.*;`.

I found the solution here:
https://stackoverflow.com/a/71749829/2477084

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
