### PR TITLE
Fix flood json string can not be null or empty from mapping matcher

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
@@ -81,7 +81,6 @@ public class MatchesJsonPathPattern extends PathPattern {
               "Warning: JSON path expression '%s' failed to match document '%s' because %s",
               expectedValue, value, error);
 
-      notifier().info(message);
       return MatchResult.noMatch(SubEvent.warning(message));
     }
   }
@@ -108,7 +107,6 @@ public class MatchesJsonPathPattern extends PathPattern {
           .min(Comparator.comparingDouble(MatchResult::getDistance))
           .orElse(MatchResult.noMatch(subEvents));
     } catch (SubExpressionException e) {
-      notifier().info(e.getMessage());
       return MatchResult.noMatch(SubEvent.warning(e.getMessage()));
     }
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
@@ -100,16 +100,14 @@ public class MatchesJsonPathPatternTest {
   }
 
   @Test
-  public void providesSensibleNotificationWhenJsonMatchFailsDueToInvalidJson() {
-    Notifier notifier = setMockNotifier();
-
+  public void providesEventMessageWhenJsonMatchFailsDueToInvalidJson() {
     StringValuePattern pattern = WireMock.matchingJsonPath("$.something");
     MatchResult match = pattern.match("Not a JSON document");
 
     assertFalse(match.isExactMatch(), "Expected the match to fail");
-    checkWarningMessageAndEvent(
-        notifier,
+    checkMessage(
         match,
+        WARNING,
         "Warning: JSON path expression '$.something' failed to match document 'Not a JSON document' because of error 'Expected to find an object with property ['something'] in path $ but found 'java.lang.String'. This is not a json object according to the JsonProvider: 'com.jayway.jsonpath.spi.json.JsonSmartJsonProvider'.'");
   }
 
@@ -120,16 +118,14 @@ public class MatchesJsonPathPatternTest {
   }
 
   @Test
-  public void providesSensibleNotificationWhenJsonMatchFailsDueToMissingAttributeJson() {
-    Notifier notifier = setMockNotifier();
-
+  public void providesEventMessageWhenJsonMatchFailsDueToMissingAttributeJson() {
     StringValuePattern pattern = WireMock.matchingJsonPath("$.something");
     MatchResult matchResult = pattern.match("{ \"nothing\": 1 }");
 
     assertFalse(matchResult.isExactMatch(), "Expected the match to fail");
-    checkWarningMessageAndEvent(
-        notifier,
+    checkMessage(
         matchResult,
+        WARNING,
         "Warning: JSON path expression '$.something' failed to match document '{ \"nothing\": 1 }' because of error 'No results for path: $['something']'");
   }
 


### PR DESCRIPTION
When using body patterns and matchesJsonPath with either `$.` or `$[?.` there are several occasions that wiremock throws a warning with the error:
`Warning: JSON path expression {Expression} failed to match document 'null' because of error 'json string can not be null or empty'`
This floods the entire wiremock logs leaving verbose pretty useless.

## References
https://github.com/wiremock/wiremock/issues/1817

## Submitter checklist

- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [X] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)