### PR TITLE
Fixed Allow/Deny Proxy targets for DomainNameWildCard

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRange.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRange.java
@@ -43,6 +43,10 @@ public abstract class NetworkAddressRange {
     return new DomainNameWildcard(value);
   }
 
+  public boolean isDomainNameWildCard() {
+    return this instanceof DomainNameWildcard;
+  }
+
   public abstract boolean isIncluded(String testValue);
 
   private static class SingleIp extends NetworkAddressRange {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -38,6 +38,11 @@ public class NetworkAddressRules {
     this.denied = denied;
   }
 
+  public boolean isAllowed(String testValue) {
+    return allowed.stream().anyMatch(rule -> rule.isIncluded(testValue))
+            && denied.stream().noneMatch(rule -> rule.isIncluded(testValue));
+  }
+
   public boolean isAllowed(InetAddress address) {
     return allowed.stream().anyMatch(rule -> rule.isIncluded(testValue(rule, address)))
         && denied.stream().noneMatch(rule -> rule.isIncluded(testValue(rule, address)));

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -40,7 +40,7 @@ public class NetworkAddressRules {
 
   public boolean isAllowed(String testValue) {
     return allowed.stream().anyMatch(rule -> rule.isIncluded(testValue))
-            && denied.stream().noneMatch(rule -> rule.isIncluded(testValue));
+        && denied.stream().noneMatch(rule -> rule.isIncluded(testValue));
   }
 
   public boolean isAllowed(InetAddress address) {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -19,6 +19,7 @@ import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL;
 import static java.util.Collections.emptySet;
 
 import com.google.common.collect.ImmutableSet;
+import java.net.InetAddress;
 import java.util.Set;
 
 public class NetworkAddressRules {
@@ -37,9 +38,13 @@ public class NetworkAddressRules {
     this.denied = denied;
   }
 
-  public boolean isAllowed(String testValue) {
-    return allowed.stream().anyMatch(rule -> rule.isIncluded(testValue))
-        && denied.stream().noneMatch(rule -> rule.isIncluded(testValue));
+  public boolean isAllowed(InetAddress address) {
+    return allowed.stream().anyMatch(rule -> rule.isIncluded(testValue(rule, address)))
+        && denied.stream().noneMatch(rule -> rule.isIncluded(testValue(rule, address)));
+  }
+
+  private String testValue(NetworkAddressRange rule, InetAddress address) {
+    return rule.isDomainNameWildCard() ? address.getHostName() : address.getHostAddress();
   }
 
   public static class Builder {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -148,7 +148,7 @@ public class ProxyResponseRenderer implements ResponseRenderer {
     try {
       final InetAddress[] resolvedAddresses = InetAddress.getAllByName(host);
       return !Arrays.stream(resolvedAddresses)
-          .allMatch(address -> targetAddressRules.isAllowed(address.getHostAddress()));
+          .allMatch(targetAddressRules::isAllowed);
     } catch (UnknownHostException e) {
       return true;
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
@@ -18,7 +18,9 @@ package com.github.tomakehurst.wiremock.common;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import java.net.InetAddress;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class NetworkAddressRulesTest {
 
@@ -32,29 +34,47 @@ public class NetworkAddressRulesTest {
             .deny("10.5.5.5")
             .build();
 
-    assertThat(rules.isAllowed("192.168.1.111"), is(true));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("192.168.1.111")), is(true));
 
-    assertThat(rules.isAllowed("10.1.2.1"), is(true));
-    assertThat(rules.isAllowed("10.1.2.3"), is(false));
-    assertThat(rules.isAllowed("10.5.5.5"), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.2.1")), is(true));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.2.3")), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.5.5.5")), is(false));
+  }
+
+  @Test
+  void allowsHostNameIncludedAndNotExcluded() {
+    NetworkAddressRules rules =
+        NetworkAddressRules.builder()
+            .allow("subdomainA.domain.com")
+            .allow("*.subdomainB.domain.com")
+            .deny("subdomainC.domain.com")
+            .deny("*.subdomainD.domain.com")
+            .build();
+
+    assertThat(rules.isAllowed(mockInetAddressForHostName("subdomainA.domain.com")), is(true));
+
+    assertThat(rules.isAllowed(mockInetAddressForHostName("host.subdomainB.domain.com")), is(true));
+    assertThat(rules.isAllowed(mockInetAddressForHostName("subdomainC.domain.com")), is(false));
+    assertThat(
+        rules.isAllowed(mockInetAddressForHostName("host.subdomainD.domain.com")), is(false));
   }
 
   @Test
   void onlyAllowSingleIp() {
     NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
 
-    assertThat(rules.isAllowed("10.1.1.1"), is(true));
-    assertThat(rules.isAllowed("10.1.1.0"), is(false));
-    assertThat(rules.isAllowed("10.1.1.2"), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.1")), is(true));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.0")), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.2")), is(false));
   }
 
   @Test
   void onlyDenySingleIp() {
     NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
 
-    assertThat(rules.isAllowed("10.1.1.1"), is(false));
-    assertThat(rules.isAllowed("10.1.1.0"), is(true));
-    assertThat(rules.isAllowed("10.1.1.2"), is(true));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.1")), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.0")), is(true));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.2")), is(true));
   }
 
   @Test
@@ -62,11 +82,11 @@ public class NetworkAddressRulesTest {
     NetworkAddressRules rules =
         NetworkAddressRules.builder().deny("10.1.1.1").allow("10.1.1.3").build();
 
-    assertThat(rules.isAllowed("10.1.1.0"), is(false));
-    assertThat(rules.isAllowed("10.1.1.1"), is(false));
-    assertThat(rules.isAllowed("10.1.1.2"), is(false));
-    assertThat(rules.isAllowed("10.1.1.3"), is(true));
-    assertThat(rules.isAllowed("10.1.1.4"), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.0")), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.1")), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.2")), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.3")), is(true));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.4")), is(false));
   }
 
   @Test
@@ -74,11 +94,11 @@ public class NetworkAddressRulesTest {
     NetworkAddressRules rules =
         NetworkAddressRules.builder().allow("10.1.1.1-10.1.1.3").deny("10.1.1.2").build();
 
-    assertThat(rules.isAllowed("10.1.1.0"), is(false));
-    assertThat(rules.isAllowed("10.1.1.1"), is(true));
-    assertThat(rules.isAllowed("10.1.1.2"), is(false));
-    assertThat(rules.isAllowed("10.1.1.3"), is(true));
-    assertThat(rules.isAllowed("10.1.1.4"), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.0")), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.1")), is(true));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.2")), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.3")), is(true));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.4")), is(false));
   }
 
   @Test
@@ -86,10 +106,24 @@ public class NetworkAddressRulesTest {
     NetworkAddressRules rules =
         NetworkAddressRules.builder().deny("10.1.1.1-10.1.1.3").allow("10.1.1.2").build();
 
-    assertThat(rules.isAllowed("10.1.1.0"), is(false));
-    assertThat(rules.isAllowed("10.1.1.1"), is(false));
-    assertThat(rules.isAllowed("10.1.1.2"), is(false));
-    assertThat(rules.isAllowed("10.1.1.3"), is(false));
-    assertThat(rules.isAllowed("10.1.1.4"), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.0")), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.1")), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.2")), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.3")), is(false));
+    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.4")), is(false));
+  }
+
+  private static InetAddress mockInetAddressForHostAddress(String hostAddress) {
+    InetAddress inetAddress = Mockito.mock(InetAddress.class);
+    Mockito.when(inetAddress.getHostAddress()).thenReturn(hostAddress);
+
+    return inetAddress;
+  }
+
+  private static InetAddress mockInetAddressForHostName(String hostName) {
+    InetAddress inetAddress = Mockito.mock(InetAddress.class);
+    Mockito.when(inetAddress.getHostName()).thenReturn(hostName);
+
+    return inetAddress;
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
@@ -34,11 +34,11 @@ public class NetworkAddressRulesTest {
             .deny("10.5.5.5")
             .build();
 
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("192.168.1.111")), is(true));
+    assertThat(rules.isAllowed("192.168.1.111"), is(true));
 
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.2.1")), is(true));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.2.3")), is(false));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.5.5.5")), is(false));
+    assertThat(rules.isAllowed("10.1.2.1"), is(true));
+    assertThat(rules.isAllowed("10.1.2.3"), is(false));
+    assertThat(rules.isAllowed("10.5.5.5"), is(false));
   }
 
   @Test
@@ -63,18 +63,18 @@ public class NetworkAddressRulesTest {
   void onlyAllowSingleIp() {
     NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
 
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.1")), is(true));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.0")), is(false));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.2")), is(false));
+    assertThat(rules.isAllowed("10.1.1.1"), is(true));
+    assertThat(rules.isAllowed("10.1.1.0"), is(false));
+    assertThat(rules.isAllowed("10.1.1.2"), is(false));
   }
 
   @Test
   void onlyDenySingleIp() {
     NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
 
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.1")), is(false));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.0")), is(true));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.2")), is(true));
+    assertThat(rules.isAllowed("10.1.1.1"), is(false));
+    assertThat(rules.isAllowed("10.1.1.0"), is(true));
+    assertThat(rules.isAllowed("10.1.1.2"), is(true));
   }
 
   @Test
@@ -82,11 +82,11 @@ public class NetworkAddressRulesTest {
     NetworkAddressRules rules =
         NetworkAddressRules.builder().deny("10.1.1.1").allow("10.1.1.3").build();
 
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.0")), is(false));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.1")), is(false));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.2")), is(false));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.3")), is(true));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.4")), is(false));
+    assertThat(rules.isAllowed("10.1.1.0"), is(false));
+    assertThat(rules.isAllowed("10.1.1.1"), is(false));
+    assertThat(rules.isAllowed("10.1.1.2"), is(false));
+    assertThat(rules.isAllowed("10.1.1.3"), is(true));
+    assertThat(rules.isAllowed("10.1.1.4"), is(false));
   }
 
   @Test
@@ -94,11 +94,11 @@ public class NetworkAddressRulesTest {
     NetworkAddressRules rules =
         NetworkAddressRules.builder().allow("10.1.1.1-10.1.1.3").deny("10.1.1.2").build();
 
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.0")), is(false));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.1")), is(true));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.2")), is(false));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.3")), is(true));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.4")), is(false));
+    assertThat(rules.isAllowed("10.1.1.0"), is(false));
+    assertThat(rules.isAllowed("10.1.1.1"), is(true));
+    assertThat(rules.isAllowed("10.1.1.2"), is(false));
+    assertThat(rules.isAllowed("10.1.1.3"), is(true));
+    assertThat(rules.isAllowed("10.1.1.4"), is(false));
   }
 
   @Test
@@ -106,18 +106,11 @@ public class NetworkAddressRulesTest {
     NetworkAddressRules rules =
         NetworkAddressRules.builder().deny("10.1.1.1-10.1.1.3").allow("10.1.1.2").build();
 
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.0")), is(false));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.1")), is(false));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.2")), is(false));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.3")), is(false));
-    assertThat(rules.isAllowed(mockInetAddressForHostAddress("10.1.1.4")), is(false));
-  }
-
-  private static InetAddress mockInetAddressForHostAddress(String hostAddress) {
-    InetAddress inetAddress = Mockito.mock(InetAddress.class);
-    Mockito.when(inetAddress.getHostAddress()).thenReturn(hostAddress);
-
-    return inetAddress;
+    assertThat(rules.isAllowed("10.1.1.0"), is(false));
+    assertThat(rules.isAllowed("10.1.1.1"), is(false));
+    assertThat(rules.isAllowed("10.1.1.2"), is(false));
+    assertThat(rules.isAllowed("10.1.1.3"), is(false));
+    assertThat(rules.isAllowed("10.1.1.4"), is(false));
   }
 
   private static InetAddress mockInetAddressForHostName(String hostName) {

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.jknack.handlebars.internal.lang3.StringUtils;
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.github.tomakehurst.wiremock.common.ClasspathFileSource;
 import com.github.tomakehurst.wiremock.common.FileSource;
@@ -46,9 +47,11 @@ import com.github.tomakehurst.wiremock.http.trafficlistener.ConsoleNotifyingWire
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
 import com.github.tomakehurst.wiremock.security.Authenticator;
+import java.net.InetAddress;
 import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class CommandLineOptionsTest {
 
@@ -736,11 +739,11 @@ public class CommandLineOptionsTest {
 
     NetworkAddressRules proxyTargetRules = options.getProxyTargetRules();
 
-    assertThat(proxyTargetRules.isAllowed("192.168.1.1"), is(true));
-    assertThat(proxyTargetRules.isAllowed("10.1.2.3"), is(true));
+    assertThat(proxyTargetRules.isAllowed(mockInetAddressForHostAddress("192.168.1.1")), is(true));
+    assertThat(proxyTargetRules.isAllowed(mockInetAddressForHostAddress("10.1.2.3")), is(true));
 
-    assertThat(proxyTargetRules.isAllowed("10.3.2.1"), is(false));
-    assertThat(proxyTargetRules.isAllowed("localhost"), is(false));
+    assertThat(proxyTargetRules.isAllowed(mockInetAddressForHostAddress("10.3.2.1")), is(false));
+    assertThat(proxyTargetRules.isAllowed(mockInetAddressForHostName("localhost")), is(false));
   }
 
   @Test
@@ -824,5 +827,21 @@ public class CommandLineOptionsTest {
     public String getName() {
       return "RequestMatcherExtension_One";
     }
+  }
+
+  private static InetAddress mockInetAddressForHostAddress(String hostAddress) {
+    InetAddress inetAddress = Mockito.mock(InetAddress.class);
+    Mockito.when(inetAddress.getHostAddress()).thenReturn(hostAddress);
+    Mockito.when(inetAddress.getHostName()).thenReturn(StringUtils.EMPTY);
+
+    return inetAddress;
+  }
+
+  private static InetAddress mockInetAddressForHostName(String hostName) {
+    InetAddress inetAddress = Mockito.mock(InetAddress.class);
+    Mockito.when(inetAddress.getHostName()).thenReturn(hostName);
+    Mockito.when(inetAddress.getHostAddress()).thenReturn(StringUtils.EMPTY);
+
+    return inetAddress;
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.github.jknack.handlebars.internal.lang3.StringUtils;
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.github.tomakehurst.wiremock.common.ClasspathFileSource;
 import com.github.tomakehurst.wiremock.common.FileSource;
@@ -47,11 +46,9 @@ import com.github.tomakehurst.wiremock.http.trafficlistener.ConsoleNotifyingWire
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
 import com.github.tomakehurst.wiremock.security.Authenticator;
-import java.net.InetAddress;
 import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 public class CommandLineOptionsTest {
 
@@ -739,11 +736,11 @@ public class CommandLineOptionsTest {
 
     NetworkAddressRules proxyTargetRules = options.getProxyTargetRules();
 
-    assertThat(proxyTargetRules.isAllowed(mockInetAddressForHostAddress("192.168.1.1")), is(true));
-    assertThat(proxyTargetRules.isAllowed(mockInetAddressForHostAddress("10.1.2.3")), is(true));
+    assertThat(proxyTargetRules.isAllowed("192.168.1.1"), is(true));
+    assertThat(proxyTargetRules.isAllowed("10.1.2.3"), is(true));
 
-    assertThat(proxyTargetRules.isAllowed(mockInetAddressForHostAddress("10.3.2.1")), is(false));
-    assertThat(proxyTargetRules.isAllowed(mockInetAddressForHostName("localhost")), is(false));
+    assertThat(proxyTargetRules.isAllowed("10.3.2.1"), is(false));
+    assertThat(proxyTargetRules.isAllowed("localhost"), is(false));
   }
 
   @Test
@@ -827,21 +824,5 @@ public class CommandLineOptionsTest {
     public String getName() {
       return "RequestMatcherExtension_One";
     }
-  }
-
-  private static InetAddress mockInetAddressForHostAddress(String hostAddress) {
-    InetAddress inetAddress = Mockito.mock(InetAddress.class);
-    Mockito.when(inetAddress.getHostAddress()).thenReturn(hostAddress);
-    Mockito.when(inetAddress.getHostName()).thenReturn(StringUtils.EMPTY);
-
-    return inetAddress;
-  }
-
-  private static InetAddress mockInetAddressForHostName(String hostName) {
-    InetAddress inetAddress = Mockito.mock(InetAddress.class);
-    Mockito.when(inetAddress.getHostName()).thenReturn(hostName);
-    Mockito.when(inetAddress.getHostAddress()).thenReturn(StringUtils.EMPTY);
-
-    return inetAddress;
   }
 }


### PR DESCRIPTION
## Description
[ProxyResponseRenderer:151](https://github.com/numacanedo/wiremock/blob/master/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java#L151) is now calling `targetAddressRules.isAllowed(InetAddress addres)`
```java
  public boolean isAllowed(InetAddress address) {
    return allowed.stream().anyMatch(rule -> rule.isIncluded(testValue(rule, address)))
        && denied.stream().noneMatch(rule -> rule.isIncluded(testValue(rule, address)));
  }
```

By directly providing the inet address, each allowed/denied rule[NetworkAddressRules:41](https://github.com/numacanedo/wiremock/blob/master/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java#L41) can be evaluated to determine if the `address.getHostName()` or `address.getHostAddress()` should be used.
```java
  private String testValue(NetworkAddressRange rule, InetAddress address) {
    return rule.isDomainNameWildCard() ? address.getHostName() : address.getHostAddress();
  }
```

To help this determination [NetworkAddressRange.isDomainNameWildCard()](https://github.com/numacanedo/wiremock/blob/master/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRange.java#L46C1-L48C4) method is added.
```java
  public boolean isDomainNameWildCard() {
    return this instanceof DomainNameWildcard;
  }
```
## Unit tests
Without this change this unit test will fail:
```java
  @Test
  void preventsProxyingToDeniedHostnamesAndProxyAllowedHostNames() {
    init(
        wireMockConfig()
            .limitProxyTargets(
                NetworkAddressRules.builder()
                    .allow("wiremock.org")
                    .allow("*.wiremock.org")
                    .deny("wiremock.io")
                    .build()));

    proxy.register(proxyAllTo("https://wiremock.org"));
    assertThat(testClient.get("/").statusCode(), is(200));

    proxy.register(proxyAllTo("https://www.wiremock.org"));
    assertThat(testClient.get("/").statusCode(), is(301));

    proxy.register(proxyAllTo("http://wiremock.io"));
    assertThat(
        testClient.get("/").content(),
        is("The target proxy address is denied in WireMock's configuration."));
  }
```

## References
[Issue 2248](https://github.com/wiremock/wiremock/issues/2248)

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
