### PR TITLE
Remove dependencies on new:ing collections with Guava (refs #2111)

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -15,7 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.client;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.util.Arrays.asList;
 
@@ -25,6 +24,7 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.*;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -42,7 +42,7 @@ public class ResponseDefinitionBuilder {
   protected String proxyUrlPrefixToRemove;
   protected Fault fault;
   protected List<String> responseTransformerNames;
-  protected Map<String, Object> transformerParameters = newHashMap();
+  protected Map<String, Object> transformerParameters = new HashMap<>();
   protected Boolean wasConfigured = true;
 
   public static ResponseDefinitionBuilder like(ResponseDefinition responseDefinition) {

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.github.tomakehurst.wiremock.matching;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
-import static com.google.common.collect.Maps.newLinkedHashMap;
 
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +25,7 @@ import java.util.Map;
 public class MultipartValuePatternBuilder {
 
   private String name = null;
-  private Map<String, MultiValuePattern> headerPatterns = newLinkedHashMap();
+  private Map<String, MultiValuePattern> headerPatterns = new LinkedHashMap<>();
   private List<ContentPattern<?>> bodyPatterns = new LinkedList<>();
   private MultipartValuePattern.MatchingType matchingType = MultipartValuePattern.MatchingType.ANY;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -15,8 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import static com.google.common.collect.Maps.newLinkedHashMap;
-
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Errors;
@@ -25,6 +23,7 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -36,13 +35,13 @@ public class RequestPatternBuilder {
   private Integer port;
   private UrlPattern url = UrlPattern.ANY;
   private RequestMethod method = RequestMethod.ANY;
-  private Map<String, MultiValuePattern> headers = newLinkedHashMap();
-  private Map<String, MultiValuePattern> queryParams = newLinkedHashMap();
+  private Map<String, MultiValuePattern> headers = new LinkedHashMap<>();
+  private Map<String, MultiValuePattern> queryParams = new LinkedHashMap<>();
 
-  private Map<String, MultiValuePattern> formParams = newLinkedHashMap();
-  private Map<String, StringValuePattern> pathParams = newLinkedHashMap();
+  private Map<String, MultiValuePattern> formParams = new LinkedHashMap<>();
+  private Map<String, StringValuePattern> pathParams = new LinkedHashMap<>();
   private List<ContentPattern<?>> bodyPatterns = new ArrayList<>();
-  private Map<String, StringValuePattern> cookies = newLinkedHashMap();
+  private Map<String, StringValuePattern> cookies = new LinkedHashMap<>();
   private BasicCredentials basicCredentials;
   private List<MultipartValuePattern> multiparts = new LinkedList<>();
 

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpecBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpecBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package com.github.tomakehurst.wiremock.recording;
 
-import static com.google.common.collect.Maps.newLinkedHashMap;
 import static java.util.Arrays.asList;
 
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -30,7 +30,7 @@ public class RecordSpecBuilder {
   private String targetBaseUrl;
   private RequestPatternBuilder filterRequestPatternBuilder;
   private List<UUID> filterIds;
-  private Map<String, CaptureHeadersSpec> headers = newLinkedHashMap();
+  private Map<String, CaptureHeadersSpec> headers = new LinkedHashMap<>();
   private RequestBodyPatternFactory requestBodyPatternFactory;
   private long maxTextBodySize = ResponseDefinitionBodyMatcher.DEFAULT_MAX_TEXT_SIZE;
   private long maxBinaryBodySize = ResponseDefinitionBodyMatcher.DEFAULT_MAX_BINARY_SIZE;

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
@@ -15,7 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.client;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -28,6 +27,7 @@ import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
 
@@ -121,7 +121,7 @@ class ResponseDefinitionBuilderTest {
 
     assertThat(
         proxyDefinition.getAdditionalProxyRequestHeaders(),
-        equalTo(new HttpHeaders(newArrayList(new HttpHeader("header", "value")))));
+        equalTo(new HttpHeaders(Arrays.asList(new HttpHeader("header", "value")))));
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
   }
 
@@ -137,7 +137,7 @@ class ResponseDefinitionBuilderTest {
 
     assertThat(
         proxyDefinition.getAdditionalProxyRequestHeaders(),
-        equalTo(new HttpHeaders(newArrayList(new HttpHeader("header", "value")))));
+        equalTo(new HttpHeaders(Arrays.asList(new HttpHeader("header", "value")))));
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
   }
 
@@ -153,7 +153,7 @@ class ResponseDefinitionBuilderTest {
 
     assertThat(
         proxyDefinition.getAdditionalProxyRequestHeaders(),
-        equalTo(new HttpHeaders(newArrayList(new HttpHeader("header", "value")))));
+        equalTo(new HttpHeaders(Arrays.asList(new HttpHeader("header", "value")))));
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
 import static com.github.tomakehurst.wiremock.client.WireMock.absent;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToXml;
-import static com.google.common.collect.Maps.newLinkedHashMap;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.everyItem;
@@ -30,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -70,7 +70,7 @@ public class MultipartValuePatternBuilderTest {
             .withBody(equalToXml("<xml />"))
             .build();
 
-    Map<String, List<MultiValuePattern>> headerPatterns = newLinkedHashMap();
+    Map<String, List<MultiValuePattern>> headerPatterns = new LinkedHashMap<>();
     headerPatterns.put(
         "Content-Disposition", asList(MultiValuePattern.of(containing("name=\"name\""))));
     headerPatterns.put("X-Header", asList(MultiValuePattern.of(containing("something"))));
@@ -97,7 +97,7 @@ public class MultipartValuePatternBuilderTest {
             .withBody(equalToXml("<xml />"))
             .build();
 
-    Map<String, List<MultiValuePattern>> headerPatterns = newLinkedHashMap();
+    Map<String, List<MultiValuePattern>> headerPatterns = new LinkedHashMap<>();
     headerPatterns.put("X-Header", asList(MultiValuePattern.of(containing("something"))));
     headerPatterns.put("X-Other", asList(MultiValuePattern.of(absent())));
     //        assertThat(headerPatterns.entrySet(),
@@ -114,7 +114,7 @@ public class MultipartValuePatternBuilderTest {
             .withHeader("Content-Disposition", containing("filename=\"something\""))
             .build();
 
-    Map<String, List<MultiValuePattern>> headerPatterns = newLinkedHashMap();
+    Map<String, List<MultiValuePattern>> headerPatterns = new LinkedHashMap<>();
     headerPatterns.put(
         "Content-Disposition",
         asList(

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
@@ -17,7 +17,6 @@ package com.github.tomakehurst.wiremock.testsupport;
 
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
-import static com.google.common.collect.Maps.newHashMap;
 import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.http.*;
@@ -30,7 +29,7 @@ public class MockRequestBuilder {
   private RequestMethod method = GET;
   private String clientIp = "x.x.x.x";
   private List<HttpHeader> individualHeaders = new ArrayList<>();
-  private Map<String, Cookie> cookies = newHashMap();
+  private Map<String, Cookie> cookies = new HashMap<>();
   private List<QueryParameter> queryParameters = new ArrayList<>();
 
   private List<FormParameter> formParameters = new ArrayList<>();


### PR DESCRIPTION
A small step removing some imports from Guava.

## References

#2111 

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
