### PR TITLE
ServerEvent: replace Guava predicate and function with STL (refs #2111)

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -16,8 +16,6 @@
 package com.github.tomakehurst.wiremock.core;
 
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
-import static com.github.tomakehurst.wiremock.stubbing.ServeEvent.NOT_MATCHED;
-import static com.github.tomakehurst.wiremock.stubbing.ServeEvent.TO_LOGGED_REQUEST;
 import static com.google.common.collect.Iterables.contains;
 
 import com.github.tomakehurst.wiremock.admin.AdminRoutes;
@@ -397,8 +395,8 @@ public class WireMockApp implements StubServer, Admin {
     try {
       List<LoggedRequest> requests =
           requestJournal.getAllServeEvents().stream()
-              .filter(NOT_MATCHED)
-              .map(TO_LOGGED_REQUEST)
+              .filter(ServeEvent::isNoExactMatch)
+              .map(ServeEvent::getRequest)
               .collect(Collectors.toList());
       return FindRequestsResult.withRequests(requests);
     } catch (RequestJournalDisabledException e) {

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
@@ -31,8 +31,6 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.Response;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.base.Stopwatch;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -226,9 +224,4 @@ public class ServeEvent {
         ? stubMapping.getResponse().getTransformerParameters()
         : Parameters.empty();
   }
-
-  public static final Function<ServeEvent, LoggedRequest> TO_LOGGED_REQUEST =
-      ServeEvent::getRequest;
-
-  public static final Predicate<ServeEvent> NOT_MATCHED = ServeEvent::isNoExactMatch;
 }


### PR DESCRIPTION
These are the last imports of `Predicate` and `Function` from Guava. Perhaps they are left for a reason?

## References

#2111 

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
