### PR TITLE
Replace Guava Files management with STL (refs #2111)

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
@@ -18,10 +18,10 @@ package com.github.tomakehurst.wiremock.common;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.tomakehurst.wiremock.security.NotAuthorisedException;
-import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -172,7 +172,7 @@ public abstract class AbstractFileSource implements FileSource {
   private void writeTextFileAndTranslateExceptions(String contents, File toFile) {
     try {
       ensureDirectoryExists(toFile);
-      Files.asCharSink(toFile, UTF_8).write(contents);
+      Files.write(toFile.toPath(), contents.getBytes(UTF_8));
     } catch (IOException ioe) {
       throw new RuntimeException(ioe);
     }
@@ -181,7 +181,7 @@ public abstract class AbstractFileSource implements FileSource {
   private void writeBinaryFileAndTranslateExceptions(byte[] contents, File toFile) {
     try {
       ensureDirectoryExists(toFile);
-      Files.write(contents, toFile);
+      Files.write(toFile.toPath(), contents);
     } catch (IOException ioe) {
       throw new RuntimeException(ioe);
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -19,12 +19,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.testsupport.Network.findFreePort;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
 import static com.google.common.collect.Iterables.any;
-import static com.google.common.io.Files.asCharSink;
-import static com.google.common.io.Files.createParentDirs;
-import static com.google.common.io.Files.write;
 import static java.io.File.separator;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.createDirectories;
+import static java.nio.file.Files.write;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -43,6 +42,8 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -514,9 +515,9 @@ public class StandaloneAcceptanceTest {
   private void writeFileToFilesDir(String name, byte[] contents) {
     try {
       String filePath = underFileSourceRoot(underFiles(name));
-      File file = new File(filePath);
-      createParentDirs(file);
-      write(contents, file);
+      Path file = Paths.get(filePath);
+      createDirectories(file.getParent());
+      write(file, contents);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -528,9 +529,9 @@ public class StandaloneAcceptanceTest {
 
   private void writeFile(String absolutePath, String contents) {
     try {
-      File file = new File(absolutePath);
-      createParentDirs(file);
-      asCharSink(file, UTF_8).write(contents);
+      Path file = Paths.get(absolutePath);
+      createDirectories(file.getParent());
+      write(file, contents.getBytes(UTF_8));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSourceTest.java
@@ -32,8 +32,10 @@ import com.github.tomakehurst.wiremock.common.filemaker.FilenameMaker;
 import com.github.tomakehurst.wiremock.stubbing.InMemoryStubMappings;
 import com.github.tomakehurst.wiremock.stubbing.StoreBackedStubMappings;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import com.google.common.io.Files;
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
@@ -56,13 +58,19 @@ public class JsonFileMappingsSourceTest {
 
   private void configureWithMultipleMappingFile() throws Exception {
     stubMappingFile = File.createTempFile("multi", ".json", tempDir);
-    Files.copy(new File(filePath("multi-stub/multi.json")), stubMappingFile);
+    Files.copy(
+        Paths.get(filePath("multi-stub/multi.json")),
+        stubMappingFile.toPath(),
+        StandardCopyOption.REPLACE_EXISTING);
     load();
   }
 
   private void configureWithSingleMappingFile() throws Exception {
     stubMappingFile = File.createTempFile("single", ".json", tempDir);
-    Files.copy(new File(filePath("multi-stub/single.json")), stubMappingFile);
+    Files.copy(
+        Paths.get(filePath("multi-stub/single.json")),
+        stubMappingFile.toPath(),
+        StandardCopyOption.REPLACE_EXISTING);
     load();
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/store/files/BlobStoreFileSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/files/BlobStoreFileSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Thomas Akehurst
+ * Copyright (C) 2022-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.is;
 import com.github.tomakehurst.wiremock.common.TextFile;
 import com.github.tomakehurst.wiremock.store.BlobStore;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -84,7 +84,7 @@ public class BlobStoreFileSourceTest {
     byte[] contents = "{}".getBytes();
     fileSource.writeBinaryFile("folder/file.json", contents);
 
-    byte[] actual = Files.toByteArray(tempDir.resolve("folder/file.json").toFile());
+    byte[] actual = Files.readAllBytes(tempDir.resolve("folder/file.json"));
     assertThat(actual, is(contents));
   }
 
@@ -96,8 +96,7 @@ public class BlobStoreFileSourceTest {
     String contents = "{}";
     fileSource.writeTextFile("folder/text-file.json", contents);
 
-    String actual =
-        new String(Files.toByteArray(tempDir.resolve("folder/text-file.json").toFile()));
+    String actual = new String(Files.readAllBytes(tempDir.resolve("folder/text-file.json")));
     assertThat(actual, is(contents));
   }
 


### PR DESCRIPTION
Removing imports on Guava Files and using Java standard library.

## References

#2111 

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
