### PR TITLE
Added patch Method with URL in WireMock.java

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -648,6 +648,10 @@ public class WireMock {
     return delete(urlEqualTo(url));
   }
 
+  public static MappingBuilder patch(String url) {
+    return patch(urlEqualTo(url));
+  }
+
   public static ResponseDefinitionBuilder created() {
     return aResponse().withStatus(201);
   }


### PR DESCRIPTION
In the original code, there was no 'patch' method available in the WireMock class. I added the 'patch' method, which allows creating a mapping from a url-string for HTTP PATCH requests.

(New PR because the [old ](https://github.com/wiremock/wiremock/pull/2222)one was closed due to accidental deletion of the fork.)

## References

- Already existing code for the other methods (Get, Post, Put etc.)

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)