### PR TITLE
[ISSUE-2260] Support for multipart/related without Content-Dispositio…

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileUpload.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileUpload.java
@@ -543,6 +543,7 @@ class FileUpload {
     /** Whether we are currently skipping the preamble. */
     private boolean skipPreamble;
 
+    private int partNumber = 0;
     /** Whether the current item may still be read. */
     private boolean itemValid;
 
@@ -651,6 +652,7 @@ class FileUpload {
         currentItem = null;
       }
       for (; ; ) {
+        partNumber++;
         boolean nextPart;
         if (skipPreamble) {
           nextPart = multi.skipPreamble();
@@ -669,34 +671,36 @@ class FileUpload {
           continue;
         }
         FileItemHeaders headers = getParsedHeaders(multi.readHeaders());
+
         if (currentFieldName == null) {
           // We're parsing the outer multipart
           String fieldName = getFieldName(headers);
-          if (fieldName != null) {
-            String subContentType = headers.getHeader(FileUploadBase.CONTENT_TYPE);
-            if (subContentType != null
-                && subContentType
-                    .toLowerCase(Locale.ENGLISH)
-                    .startsWith(FileUploadBase.MULTIPART_MIXED)) {
-              currentFieldName = fieldName;
-              // Multiple files associated with this field name
-              byte[] subBoundary = getBoundary(subContentType);
-              multi.setBoundary(subBoundary);
-              skipPreamble = true;
-              continue;
-            }
-            String fileName = getFileName(headers);
-            currentItem =
-                new FileItemStreamImpl(
-                    fileName,
-                    fieldName,
-                    headers.getHeader(FileUploadBase.CONTENT_TYPE),
-                    fileName == null,
-                    getContentLength(headers));
-            currentItem.setHeaders(headers);
-            itemValid = true;
-            return true;
+          if (fieldName == null) {
+            fieldName = "part-" + partNumber;
           }
+          String subContentType = headers.getHeader(FileUploadBase.CONTENT_TYPE);
+          if (subContentType != null
+              && subContentType
+                  .toLowerCase(Locale.ENGLISH)
+                  .startsWith(FileUploadBase.MULTIPART_MIXED)) {
+            currentFieldName = fieldName;
+            // Multiple files associated with this field name
+            byte[] subBoundary = getBoundary(subContentType);
+            multi.setBoundary(subBoundary);
+            skipPreamble = true;
+            continue;
+          }
+          String fileName = getFileName(headers);
+          currentItem =
+              new FileItemStreamImpl(
+                  fileName,
+                  fieldName,
+                  headers.getHeader(FileUploadBase.CONTENT_TYPE),
+                  fileName == null,
+                  getContentLength(headers));
+          currentItem.setHeaders(headers);
+          itemValid = true;
+          return true;
         } else {
           String fileName = getFileName(headers);
           if (fileName != null) {

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilder.java
@@ -40,6 +40,11 @@ public class MultipartValuePatternBuilder {
     return this;
   }
 
+  public MultipartValuePatternBuilder withNameOnly(String name) {
+    this.name = name;
+    return this;
+  }
+
   public MultipartValuePatternBuilder withName(String name) {
     this.name = name;
     return withHeader("Content-Disposition", containing("name=\"" + name + "\""));

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.stubbing;
 
 import static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.responseDefinition;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.common.Json.write;
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern;
@@ -98,9 +99,14 @@ public class StubMappingJsonRecorder implements RequestListener {
   private MultipartValuePattern valuePatternForPart(Request.Part part) {
     MultipartValuePatternBuilder builder =
         new MultipartValuePatternBuilder()
-            .withName(part.getName())
-            .matchingType(MultipartValuePattern.MatchingType.ALL);
+            .matchingType(MultipartValuePattern.MatchingType.ANY);
 
+    if (part.getHeader("Content-Disposition").isPresent()
+      && part.getHeader("Content-Disposition").hasValueMatching(containing("name=\"" + part.getName() + "\""))) {
+      builder.withName(part.getName());
+    } else {
+      builder.withNameOnly(part.getName());
+    }
     if (!headersToMatch.isEmpty()) {
       Collection<HttpHeader> all = part.getHeaders().all();
 
@@ -113,12 +119,14 @@ public class StubMappingJsonRecorder implements RequestListener {
 
     HttpHeader contentType = part.getHeader("Content-Type");
 
-    if (!contentType.isPresent() || contentType.firstValue().contains("text")) {
+    if (!contentType.isPresent()) {
       builder.withBody(equalTo(part.getBody().asString()));
     } else if (contentType.firstValue().contains("json")) {
       builder.withBody(equalToJson(part.getBody().asString(), true, true));
     } else if (contentType.firstValue().contains("xml")) {
       builder.withBody(equalToXml(part.getBody().asString()));
+    } else if (contentType.firstValue().contains("text")) {
+      builder.withBody(equalTo(part.getBody().asString()));
     } else {
       builder.withBody(binaryEqualTo(part.getBody().asBytes()));
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
@@ -25,15 +25,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.matching.MultipartValuePattern;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
+import org.apache.hc.client5.http.entity.mime.ByteArrayBody;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.entity.mime.MultipartPartBuilder;
+import org.apache.hc.client5.http.entity.mime.StringBody;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -133,6 +139,66 @@ public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
 
     assertThat(EntityUtils.toString(response.getEntity()), response.getCode(), is(200));
   }
+
+
+  /** @see <a href="https://github.com/tomakehurst/wiremock/issues/2260">#2260</a> */
+  @Test
+  public void acceptsAMultipartRelatedRequestContaining2XmlPartsIfMatchingTypeAny() throws Exception {
+    stubFor(
+        post("/multipart-related")
+            .withMultipartRequestBody(
+                aMultipart()
+                    .withNameOnly("part-1")
+                    .withBody(equalToXml("<root><ref>${xmlunit.ignore}</ref></root>", true))
+                    .matchingType(MultipartValuePattern.MatchingType.ANY)
+            )
+            .withMultipartRequestBody(
+                aMultipart()
+                    .withNameOnly("part-2")
+                    .withBody(equalToXml(
+                        "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
+                            "<a><b>${xmlunit.ignore}</b></a>",
+                        true
+                    ))
+                    .matchingType(MultipartValuePattern.MatchingType.ANY)
+            )
+            .willReturn(ok()));
+
+    ClassicHttpRequest request =
+        ClassicRequestBuilder.post(wireMockServer.baseUrl() + "/multipart-related")
+            .setEntity(
+                MultipartEntityBuilder.create()
+                    .setMimeSubtype("related")
+                    .addParameter(new BasicNameValuePair("type", "text/xml"))
+                    .addPart(
+                        MultipartPartBuilder
+                            .create(new StringBody("<root><ref>cid:xml2</ref></root>", ContentType.TEXT_XML))
+                            .setHeader("Content-ID", "<root-xml>")
+                            .setHeader("Content-Type", "text/xml")
+                            .build()
+                    )
+                    .addPart(
+                        MultipartPartBuilder
+                            .create(new ByteArrayBody(
+                                (
+                                    "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
+                                        "<a><b>1</b></a>"
+                                )
+                                    .getBytes(),
+                                ContentType.TEXT_XML
+                            ))
+                            .setHeader("Content-ID", "<xml2>")
+                            .setHeader("Content-Type", "text/xml")
+                            .build()
+                    )
+                    .build())
+            .build();
+
+    ClassicHttpResponse response = httpClient.execute(request);
+
+    assertThat(EntityUtils.toString(response.getEntity()), response.getCode(), is(200));
+  }
+
 
   // https://github.com/tomakehurst/wiremock/issues/1179
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternTest.java
@@ -64,7 +64,7 @@ public class MultipartValuePatternTest {
   }
 
   @Test
-  public void deserialisesCorrectlyWithSingleJsonBodyMatcer() throws JSONException {
+  public void deserialisesCorrectlyWithSingleJsonBodyMatcher() throws JSONException {
     String expectedJson = "{ \"someKey\": \"someValue\" }";
     String serializedPattern =
         "{                                                \n"
@@ -86,8 +86,7 @@ public class MultipartValuePatternTest {
   }
 
   @Test
-  public void deserialisesCorrectlyWithANYMatchTypeWithMultipleHeaderAndBodyMatchers()
-      throws JSONException {
+  public void deserialisesCorrectlyWithANYMatchTypeWithMultipleHeaderAndBodyMatchers() {
     String expectedJson = "{ \"someKey\": \"someValue\" }";
     String serializedPattern =
         "{\n"

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
@@ -498,6 +498,39 @@ public class RequestPatternTest {
   }
 
   @Test
+  public void doesNotMatchExactlyWhenManyMultipartPatternsSupposeToMatchAllDistinctParts() {
+    RequestPattern requestPattern =
+        newRequestPattern(POST, urlPathEqualTo("/my/url"))
+            .withAllRequestBodyParts(
+                aMultipart()
+                    .withHeader("Content-Type", containing("text/plain"))
+                    .withBody(containing("body value-1"))
+            )
+            .withAllRequestBodyParts(
+                aMultipart()
+                    .withHeader("Content-Type", containing("text/plain"))
+                    .withBody(containing("body value-2"))
+            )
+            .build();
+
+    MatchResult matchResult =
+        requestPattern.match(
+            mockRequest()
+                .method(POST)
+                .url("/my/url")
+                .header("Content-Type", "multipart/form-data; boundary=BOUNDARY")
+                .multipartBody(
+                    "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-1\"; filename=\"\"\r\nContent-Type: text/plain\r\n\r\n"
+                        + "body value-1\r\n"
+                        + "--BOUNDARY\r\nContent-Disposition: form-data; name=\"part-2\"; filename=\"\"\r\nContent-Type: text/plain\r\n\r\n"
+                        + "body value-2\r\n"
+                        + "--BOUNDARY--"));
+
+    assertThat("Distance > 0", matchResult.getDistance(), greaterThan(0.0d));
+    assertFalse(matchResult.isExactMatch(), "isExactMatch");
+  }
+
+  @Test
   public void matchesExactlyWhenAllCookiesMatch() {
     RequestPattern requestPattern =
         newRequestPattern(POST, urlPathEqualTo("/my/url"))


### PR DESCRIPTION
Support for multipart/related without Content-Disposition headers - recording and replaying

<!-- Please describe your pull request here. -->

## References

- https://github.com/wiremock/wiremock/issues/2260

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
