### PR TITLE
Improve error message in AbstractFileSource#assertFilePathIsUnderRoot()

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
@@ -154,7 +154,7 @@ public abstract class AbstractFileSource implements FileSource {
               : new File(rootDirectory, path).getCanonicalPath();
 
       if (!Paths.get(filePath).normalize().startsWith(rootPath)) {
-        throw new NotAuthorisedException("Access to file " + path + " is not permitted");
+        throw new NotAuthorisedException("Access to file " + path + " is not permitted. An absolute path from the filesystem root might be specified");
       }
     } catch (IOException ioe) {
       throw new NotAuthorisedException("File " + path + " cannot be accessed", ioe);

--- a/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
@@ -154,7 +154,10 @@ public abstract class AbstractFileSource implements FileSource {
               : new File(rootDirectory, path).getCanonicalPath();
 
       if (!Paths.get(filePath).normalize().startsWith(rootPath)) {
-        throw new NotAuthorisedException("Access to file " + path + " is not permitted. An absolute path from the filesystem root might be specified");
+        throw new NotAuthorisedException(
+            "Access to file "
+                + path
+                + " is not permitted. An absolute path from the filesystem root might be specified");
       }
     } catch (IOException ioe) {
       throw new NotAuthorisedException("File " + path + " cannot be accessed", ioe);


### PR DESCRIPTION
As reported on Slack, the current error message in the response is confusing and does not contain a reason when a non-absolute path is passed through API

```
<title>Error 500 com.github.tomakehurst.wiremock.security.NotAuthorisedException: Access to file
        ../resources/__files/get-users-200.json is not permitted</title>
getting this error when i am trying to connect to my json file.
```

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected => `SingleRootFileSourceTest#writeThrowsExceptionWhenRootIsNotDir()`
- [ x For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
