### PR TITLE
Update Spotless to 6.17.0 and Google Java Format to 1.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
   id 'idea'
   id 'eclipse'
   id 'project-report'
-  id 'com.diffplug.spotless' version '6.17.0'
+  id 'com.diffplug.spotless' version '6.19.0'
   id 'com.github.johnrengelman.shadow' version '8.1.0'
   id "org.sonarqube" version "4.2.1.3168"
   id 'jacoco'
@@ -144,7 +144,7 @@ allprojects {
   spotless {
     java {
       target 'src/**/*.java'
-      googleJavaFormat('1.7')
+      googleJavaFormat('1.17.0')
       licenseHeaderFile "${rootDir}/gradle/spotless.java.license.txt"
       ratchetFrom 'origin/master'
       trimTrailingWhitespace()


### PR DESCRIPTION
Finalizes #2190 and also bumps Goole Java Format to a version with Java 21 support


<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
