### PR TITLE
Fix ParseJsonHelper not storing parsed result in variable (if any) when json is empty

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,13 +57,13 @@ public class ParseJsonHelper extends HandlebarsHelper<Object> {
       // Edge case if JSON object is empty {}
       String jsonAsStringWithoutSpace = jsonAsString.replaceAll("\\s", "");
       if (jsonAsStringWithoutSpace.equals("{}") || jsonAsStringWithoutSpace.equals("")) {
-        return result;
-      }
-
-      if (jsonAsString.startsWith("[") && jsonAsString.endsWith("]")) {
-        result = Json.read(jsonAsString, new TypeReference<List<Object>>() {});
+        result = new HashMap<String, Object>();
       } else {
-        result = Json.read(jsonAsString, new TypeReference<Map<String, Object>>() {});
+        if (jsonAsString.startsWith("[") && jsonAsString.endsWith("]")) {
+          result = Json.read(jsonAsString, new TypeReference<List<Object>>() {});
+        } else {
+          result = Json.read(jsonAsString, new TypeReference<Map<String, Object>>() {});
+        }
       }
     }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
@@ -33,9 +33,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-/**
- * @deprecated this is the legacy recorder and will be removed before 3.x is out of beta
- */
+/** @deprecated this is the legacy recorder and will be removed before 3.x is out of beta */
 @Deprecated
 public class StubMappingJsonRecorder implements RequestListener {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -915,6 +915,33 @@ public class ResponseTemplateTransformerTest {
   }
 
   @Test
+  public void parsesEmptyJsonLiteralToAnEmptyMap() {
+    String result =
+        transform(
+            "{{#parseJson 'parsedObj'}}\n"
+                + "{\n"
+                + "}\n"
+                + "{{/parseJson}}\n"
+                + "{{parsedObj.name}}");
+
+    assertThat(result, equalToCompressingWhiteSpace(""));
+  }
+
+  @Test
+  public void parsesEmptyJsonVariableToAnEmptyMap() {
+    String result =
+        transform(
+            "{{#assign 'json'}}\n"
+                + "{\n"
+                + "}\n"
+                + "{{/assign}}\n"
+                + "{{parseJson json 'parsedObj'}}\n"
+                + "{{parsedObj.name}}\n");
+
+    assertThat(result, equalToCompressingWhiteSpace(""));
+  }
+
+  @Test
   public void conditionalBranchingOnStringMatchesRegexInline() {
     assertThat(transform("{{#if (matches '123' '[0-9]+')}}YES{{/if}}"), is("YES"));
     assertThat(transform("{{#if (matches 'abc' '[0-9]+')}}YES{{/if}}"), is(""));


### PR DESCRIPTION


<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
