### PR TITLE
Adds WiremockNetworkTrafficListeners

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/trafficlistener/ConsoleNotifyingWiremockNetworkTrafficListener.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/trafficlistener/ConsoleNotifyingWiremockNetworkTrafficListener.java
@@ -15,63 +15,41 @@
  */
 package com.github.tomakehurst.wiremock.http.trafficlistener;
 
-import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
-import com.github.tomakehurst.wiremock.common.Notifier;
 import java.net.Socket;
 import java.nio.ByteBuffer;
-import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.StandardCharsets;
 
 public class ConsoleNotifyingWiremockNetworkTrafficListener
     implements WiremockNetworkTrafficListener {
-  private static final ConsoleNotifier DEFAULT_CONSOLE_NOTIFIER = new ConsoleNotifier(true);
-  private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
-  private final Notifier notifier;
-  private final Charset charset;
-  private final CharsetDecoder charsetDecoder;
-
-  ConsoleNotifyingWiremockNetworkTrafficListener(Notifier notifier, Charset charset) {
-    this.notifier = notifier;
-    this.charset = charset;
-    this.charsetDecoder = charset.newDecoder();
-  }
+  private final WiremockNetworkTrafficListener wiremockNetworkTrafficListener;
 
   public ConsoleNotifyingWiremockNetworkTrafficListener(Charset charset) {
-    this(DEFAULT_CONSOLE_NOTIFIER, charset);
+    this.wiremockNetworkTrafficListener =
+        WiremockNetworkTrafficListeners.createConsoleNotifying(charset);
   }
 
   public ConsoleNotifyingWiremockNetworkTrafficListener() {
-    this(DEFAULT_CONSOLE_NOTIFIER, DEFAULT_CHARSET);
+    this.wiremockNetworkTrafficListener = WiremockNetworkTrafficListeners.createConsoleNotifying();
   }
 
   @Override
   public void opened(Socket socket) {
-    notifier.info("Opened " + socket);
+    wiremockNetworkTrafficListener.opened(socket);
   }
 
   @Override
   public void incoming(Socket socket, ByteBuffer bytes) {
-    try {
-      notifier.info("Incoming bytes: " + charsetDecoder.decode(bytes));
-    } catch (CharacterCodingException e) {
-      notifier.error("Incoming bytes omitted. Could not decode with charset: " + charset);
-    }
+    wiremockNetworkTrafficListener.incoming(socket, bytes);
   }
 
   @Override
   public void outgoing(Socket socket, ByteBuffer bytes) {
-    try {
-      notifier.info("Outgoing bytes: " + charsetDecoder.decode(bytes));
-    } catch (CharacterCodingException e) {
-      notifier.error("Outgoing bytes omitted. Could not decode with charset: " + charset);
-    }
+    wiremockNetworkTrafficListener.outgoing(socket, bytes);
   }
 
   @Override
   public void closed(Socket socket) {
-    notifier.info("Closed " + socket);
+    wiremockNetworkTrafficListener.closed(socket);
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/trafficlistener/NotifyingWiremockNetworkTrafficListener.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/trafficlistener/NotifyingWiremockNetworkTrafficListener.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2016-2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http.trafficlistener;
+
+import com.github.tomakehurst.wiremock.common.Notifier;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+
+final class NotifyingWiremockNetworkTrafficListener implements WiremockNetworkTrafficListener {
+
+  private final Notifier notifier;
+  private final Charset charset;
+  private final CharsetDecoder charsetDecoder;
+
+  NotifyingWiremockNetworkTrafficListener(Notifier notifier, Charset charset) {
+    this.notifier = notifier;
+    this.charset = charset;
+    this.charsetDecoder = charset.newDecoder();
+  }
+
+  @Override
+  public void opened(Socket socket) {
+    notifier.info("Opened " + socket);
+  }
+
+  @Override
+  public void incoming(Socket socket, ByteBuffer bytes) {
+    try {
+      notifier.info("Incoming bytes: " + charsetDecoder.decode(bytes));
+    } catch (CharacterCodingException e) {
+      notifier.error("Incoming bytes omitted. Could not decode with charset: " + charset);
+    }
+  }
+
+  @Override
+  public void outgoing(Socket socket, ByteBuffer bytes) {
+    try {
+      notifier.info("Outgoing bytes: " + charsetDecoder.decode(bytes));
+    } catch (CharacterCodingException e) {
+      notifier.error("Outgoing bytes omitted. Could not decode with charset: " + charset);
+    }
+  }
+
+  @Override
+  public void closed(Socket socket) {
+    notifier.info("Closed " + socket);
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/trafficlistener/WiremockNetworkTrafficListeners.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/trafficlistener/WiremockNetworkTrafficListeners.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http.trafficlistener;
+
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.common.Notifier;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public final class WiremockNetworkTrafficListeners {
+  private static final ConsoleNotifier CONSOLE_NOTIFIER = new ConsoleNotifier(true);
+  private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
+  private WiremockNetworkTrafficListeners() {}
+
+  public static WiremockNetworkTrafficListener createNotifying(Notifier notifier, Charset charset) {
+    return new NotifyingWiremockNetworkTrafficListener(notifier, charset);
+  }
+
+  public static WiremockNetworkTrafficListener createConsoleNotifying() {
+    return new NotifyingWiremockNetworkTrafficListener(CONSOLE_NOTIFIER, DEFAULT_CHARSET);
+  }
+
+  public static WiremockNetworkTrafficListener createConsoleNotifying(Charset charset) {
+    return new NotifyingWiremockNetworkTrafficListener(CONSOLE_NOTIFIER, charset);
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/http/trafficlistener/ConsoleNotifyingWiremockNetworkTrafficListenerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/trafficlistener/ConsoleNotifyingWiremockNetworkTrafficListenerTest.java
@@ -17,11 +17,7 @@ package com.github.tomakehurst.wiremock.http.trafficlistener;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
-import com.github.tomakehurst.wiremock.common.Notifier;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.net.Socket;
@@ -31,7 +27,6 @@ import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 public class ConsoleNotifyingWiremockNetworkTrafficListenerTest {
-  private final Notifier mockNotifier = mock(Notifier.class);
 
   @Test
   public void defaultConstructor_notifiesToSystemOutAndUsesUTF8Charset() {
@@ -67,76 +62,6 @@ public class ConsoleNotifyingWiremockNetworkTrafficListenerTest {
     assertThat(out.toString(), containsString("Hello world"));
 
     System.setOut(originalOut);
-  }
-
-  @Test
-  public void opened_withSocket_shouldNotifyAtInfo() {
-    ConsoleNotifyingWiremockNetworkTrafficListener consoleNotifyingWiremockNetworkTrafficListener =
-        new ConsoleNotifyingWiremockNetworkTrafficListener(mockNotifier, StandardCharsets.UTF_8);
-    Socket socket = new Socket();
-
-    consoleNotifyingWiremockNetworkTrafficListener.opened(socket);
-
-    verify(mockNotifier).info(contains("Opened "));
-  }
-
-  @Test
-  public void closed_withSocket_shouldNotifyAtInfo() {
-    ConsoleNotifyingWiremockNetworkTrafficListener consoleNotifyingWiremockNetworkTrafficListener =
-        new ConsoleNotifyingWiremockNetworkTrafficListener(mockNotifier, StandardCharsets.UTF_8);
-    Socket socket = new Socket();
-
-    consoleNotifyingWiremockNetworkTrafficListener.closed(socket);
-
-    verify(mockNotifier).info(contains("Closed "));
-  }
-
-  @Test
-  public void incoming_withBytebufferWithIncompatibleCharset_shouldNotifyBytesOmittedAtInfo() {
-    ConsoleNotifyingWiremockNetworkTrafficListener consoleNotifyingWiremockNetworkTrafficListener =
-        new ConsoleNotifyingWiremockNetworkTrafficListener(mockNotifier, StandardCharsets.UTF_8);
-    Socket socket = new Socket();
-    ByteBuffer byteBuffer = stringToByteBuffer("Hello world", StandardCharsets.UTF_16);
-
-    consoleNotifyingWiremockNetworkTrafficListener.incoming(socket, byteBuffer);
-
-    verify(mockNotifier).error(contains("Incoming bytes omitted."));
-  }
-
-  @Test
-  public void incoming_withBytebufferWithCompatibleCharset_shouldNotifyWithIncomingBytes() {
-    ConsoleNotifyingWiremockNetworkTrafficListener consoleNotifyingWiremockNetworkTrafficListener =
-        new ConsoleNotifyingWiremockNetworkTrafficListener(mockNotifier, StandardCharsets.UTF_8);
-    Socket socket = new Socket();
-    ByteBuffer byteBuffer = stringToByteBuffer("Hello world", StandardCharsets.UTF_8);
-
-    consoleNotifyingWiremockNetworkTrafficListener.incoming(socket, byteBuffer);
-
-    verify(mockNotifier).info(contains("Hello world"));
-  }
-
-  @Test
-  public void outgoing_withBytebufferWithIncompatibleCharset_shouldNotifyBytesOmittedAtInfo() {
-    ConsoleNotifyingWiremockNetworkTrafficListener consoleNotifyingWiremockNetworkTrafficListener =
-        new ConsoleNotifyingWiremockNetworkTrafficListener(mockNotifier, StandardCharsets.UTF_8);
-    Socket socket = new Socket();
-    ByteBuffer byteBuffer = stringToByteBuffer("Hello world", StandardCharsets.UTF_16);
-
-    consoleNotifyingWiremockNetworkTrafficListener.outgoing(socket, byteBuffer);
-
-    verify(mockNotifier).error(contains("Outgoing bytes omitted."));
-  }
-
-  @Test
-  public void outgoing_withBytebufferWithCompatibleCharset_shouldNotifyWithIncomingBytes() {
-    ConsoleNotifyingWiremockNetworkTrafficListener consoleNotifyingWiremockNetworkTrafficListener =
-        new ConsoleNotifyingWiremockNetworkTrafficListener(mockNotifier, StandardCharsets.UTF_8);
-    Socket socket = new Socket();
-    ByteBuffer byteBuffer = stringToByteBuffer("Hello world", StandardCharsets.UTF_8);
-
-    consoleNotifyingWiremockNetworkTrafficListener.outgoing(socket, byteBuffer);
-
-    verify(mockNotifier).info(contains("Hello world"));
   }
 
   public static ByteBuffer stringToByteBuffer(String msg, Charset charset) {

--- a/src/test/java/com/github/tomakehurst/wiremock/http/trafficlistener/NotifyingWiremockNetworkTrafficListenerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/trafficlistener/NotifyingWiremockNetworkTrafficListenerTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http.trafficlistener;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.github.tomakehurst.wiremock.common.Notifier;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+public class NotifyingWiremockNetworkTrafficListenerTest {
+  private final Notifier mockNotifier = mock(Notifier.class);
+
+  @Test
+  public void opened_withSocket_shouldNotifyAtInfo() {
+    NotifyingWiremockNetworkTrafficListener consoleNotifyingWiremockNetworkTrafficListener =
+        new NotifyingWiremockNetworkTrafficListener(mockNotifier, StandardCharsets.UTF_8);
+    Socket socket = new Socket();
+
+    consoleNotifyingWiremockNetworkTrafficListener.opened(socket);
+
+    verify(mockNotifier).info(contains("Opened "));
+  }
+
+  @Test
+  public void closed_withSocket_shouldNotifyAtInfo() {
+    NotifyingWiremockNetworkTrafficListener consoleNotifyingWiremockNetworkTrafficListener =
+        new NotifyingWiremockNetworkTrafficListener(mockNotifier, StandardCharsets.UTF_8);
+    Socket socket = new Socket();
+
+    consoleNotifyingWiremockNetworkTrafficListener.closed(socket);
+
+    verify(mockNotifier).info(contains("Closed "));
+  }
+
+  @Test
+  public void incoming_withBytebufferWithIncompatibleCharset_shouldNotifyBytesOmittedAtInfo() {
+    NotifyingWiremockNetworkTrafficListener consoleNotifyingWiremockNetworkTrafficListener =
+        new NotifyingWiremockNetworkTrafficListener(mockNotifier, StandardCharsets.UTF_8);
+    Socket socket = new Socket();
+    ByteBuffer byteBuffer = stringToByteBuffer("Hello world", StandardCharsets.UTF_16);
+
+    consoleNotifyingWiremockNetworkTrafficListener.incoming(socket, byteBuffer);
+
+    verify(mockNotifier).error(contains("Incoming bytes omitted."));
+  }
+
+  @Test
+  public void incoming_withBytebufferWithCompatibleCharset_shouldNotifyWithIncomingBytes() {
+    NotifyingWiremockNetworkTrafficListener consoleNotifyingWiremockNetworkTrafficListener =
+        new NotifyingWiremockNetworkTrafficListener(mockNotifier, StandardCharsets.UTF_8);
+    Socket socket = new Socket();
+    ByteBuffer byteBuffer = stringToByteBuffer("Hello world", StandardCharsets.UTF_8);
+
+    consoleNotifyingWiremockNetworkTrafficListener.incoming(socket, byteBuffer);
+
+    verify(mockNotifier).info(contains("Hello world"));
+  }
+
+  @Test
+  public void outgoing_withBytebufferWithIncompatibleCharset_shouldNotifyBytesOmittedAtInfo() {
+    NotifyingWiremockNetworkTrafficListener consoleNotifyingWiremockNetworkTrafficListener =
+        new NotifyingWiremockNetworkTrafficListener(mockNotifier, StandardCharsets.UTF_8);
+    Socket socket = new Socket();
+    ByteBuffer byteBuffer = stringToByteBuffer("Hello world", StandardCharsets.UTF_16);
+
+    consoleNotifyingWiremockNetworkTrafficListener.outgoing(socket, byteBuffer);
+
+    verify(mockNotifier).error(contains("Outgoing bytes omitted."));
+  }
+
+  @Test
+  public void outgoing_withBytebufferWithCompatibleCharset_shouldNotifyWithIncomingBytes() {
+    NotifyingWiremockNetworkTrafficListener consoleNotifyingWiremockNetworkTrafficListener =
+        new NotifyingWiremockNetworkTrafficListener(mockNotifier, StandardCharsets.UTF_8);
+    Socket socket = new Socket();
+    ByteBuffer byteBuffer = stringToByteBuffer("Hello world", StandardCharsets.UTF_8);
+
+    consoleNotifyingWiremockNetworkTrafficListener.outgoing(socket, byteBuffer);
+
+    verify(mockNotifier).info(contains("Hello world"));
+  }
+
+  public static ByteBuffer stringToByteBuffer(String msg, Charset charset) {
+    return ByteBuffer.wrap(msg.getBytes(charset));
+  }
+}


### PR DESCRIPTION
Provides factory methods for creating arbitrary notifying traffic listeners.

## References

https://github.com/wiremock/wiremock/pull/2139#discussion_r1265208536

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)