### PR TITLE
Include IntelliJ run configurations in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ To run all of WireMock's tests:
 To build both JARs (thin and standalone), the JARs will be placed under ``build/libs``.:
 
 ```bash
-./gradlew jar shadowJar 
+./gradlew jar shadowJar
 ```
 
 To publish both JARs to your local Maven repository:
@@ -46,6 +46,8 @@ To publish both JARs to your local Maven repository:
 ```bash
 ./gradlew publishToMavenLocal
 ```
+
+If you use IntelliJ, you can also use the corresponding run configurations, **Run Tests**, **Build WireMock** and **Publish to Maven local** respectively.
 
 ## Contributing Code
 
@@ -80,7 +82,8 @@ When running pre-commit checks, if there are any formatting failures the Spotles
 ./gradlew spotlessApply
 ```
 
-There's also an [IntelliJ plugin](https://plugins.jetbrains.com/plugin/8527-google-java-format) for the same purpose.
+If you use IntelliJ, you can also use the run configuration called **Run Spotless**,
+or there's also an [IntelliJ plugin](https://plugins.jetbrains.com/plugin/8527-google-java-format) for the same purpose.
 
 ## Testing
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Since #2273 introduced IntelliJ run configurations for WireMock, as discussed on #2274, they are now mentioned in CONTRIBUTING.md as well for better visibility.

## References

#2273, #2274

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
