### PR TITLE
Add a beforeResponseSent serve event listener hook

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/ServeEventListener.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/ServeEventListener.java
@@ -22,6 +22,7 @@ public interface ServeEventListener extends Extension {
   enum RequestPhase {
     BEFORE_MATCH,
     AFTER_MATCH,
+    BEFORE_RESPONSE_SENT,
     AFTER_COMPLETE
   }
 
@@ -33,6 +34,9 @@ public interface ServeEventListener extends Extension {
       case AFTER_MATCH:
         afterMatch(serveEvent, parameters);
         break;
+      case BEFORE_RESPONSE_SENT:
+        beforeResponseSent(serveEvent, parameters);
+        break;
       case AFTER_COMPLETE:
         afterComplete(serveEvent, parameters);
         break;
@@ -42,6 +46,8 @@ public interface ServeEventListener extends Extension {
   default void beforeMatch(ServeEvent serveEvent, Parameters parameters) {}
 
   default void afterMatch(ServeEvent serveEvent, Parameters parameters) {}
+
+  default void beforeResponseSent(ServeEvent serveEvent, Parameters parameters) {}
 
   default void afterComplete(ServeEvent serveEvent, Parameters parameters) {}
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/StubRequestHandler.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/StubRequestHandler.java
@@ -86,6 +86,8 @@ public class StubRequestHandler extends AbstractRequestHandler {
     }
 
     requestJournal.requestReceived(serveEvent);
+
+    triggerListeners(BEFORE_RESPONSE_SENT, serveEvent);
   }
 
   private void appendNonMatchSubEvent(ServeEvent serveEvent) {

--- a/src/test/java/com/github/tomakehurst/wiremock/ServeEventListenerExtensionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ServeEventListenerExtensionTest.java
@@ -27,6 +27,7 @@ import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartEquals;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.admin.Router;
@@ -44,6 +45,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -67,8 +69,8 @@ public class ServeEventListenerExtensionTest {
   }
 
   @Test
-  void eventTriggeredBeforeMatching() throws Exception {
-    final CompletableFuture<Void> completed = new CompletableFuture<>();
+  void eventSynchronouslyTriggeredBeforeMatching() {
+    AtomicBoolean completed = new AtomicBoolean(false);
     initWithOptions(
         options()
             .dynamicPort()
@@ -82,7 +84,7 @@ public class ServeEventListenerExtensionTest {
                     assertThat(serveEvent.getStubMapping(), nullValue());
                     assertThat(serveEvent.getResponse(), nullValue());
 
-                    completed.complete(null);
+                    completed.set(true);
                   }
 
                   @Override
@@ -95,12 +97,12 @@ public class ServeEventListenerExtensionTest {
 
     client.get("/get-this");
 
-    completed.get(2, SECONDS);
+    assertTrue(completed.get());
   }
 
   @Test
-  void eventTriggeredAfterMatching() throws Exception {
-    final CompletableFuture<Void> completed = new CompletableFuture<>();
+  void eventSynchronouslyTriggeredAfterMatching() {
+    AtomicBoolean completed = new AtomicBoolean(false);
     initWithOptions(
         options()
             .dynamicPort()
@@ -114,7 +116,7 @@ public class ServeEventListenerExtensionTest {
                     assertThat(serveEvent.getStubMapping(), notNullValue());
                     assertThat(serveEvent.getResponse(), nullValue());
 
-                    completed.complete(null);
+                    completed.set(true);
                   }
 
                   @Override
@@ -127,11 +129,43 @@ public class ServeEventListenerExtensionTest {
 
     client.get("/get-this");
 
-    completed.get(2, SECONDS);
+    assertTrue(completed.get());
   }
 
   @Test
-  void eventTriggeredAfterCompletion() throws Exception {
+  void eventSynchronouslyTriggeredBeforeResponseSent() {
+    AtomicBoolean completed = new AtomicBoolean(false);
+    initWithOptions(
+        options()
+            .dynamicPort()
+            .extensions(
+                new ServeEventListener() {
+
+                  @Override
+                  public void beforeResponseSent(ServeEvent serveEvent, Parameters parameters) {
+                    assertThat(serveEvent.getRequest().getUrl(), is("/get-this"));
+                    assertThat(serveEvent.getResponseDefinition(), notNullValue());
+                    assertThat(serveEvent.getStubMapping(), notNullValue());
+                    assertThat(serveEvent.getResponse().getStatus(), is(200));
+
+                    completed.set(true);
+                  }
+
+                  @Override
+                  public String getName() {
+                    return "before-resposnse-sent";
+                  }
+                }));
+
+    wm.stubFor(any(anyUrl()).willReturn(ok()));
+
+    client.get("/get-this");
+
+    assertTrue(completed.get());
+  }
+
+  @Test
+  void eventAsynchronouslyTriggeredAfterCompletion() throws Exception {
     final CompletableFuture<Void> completed = new CompletableFuture<>();
     initWithOptions(
         options()


### PR DESCRIPTION
Per #2294 - add a synchronous serve event listener callback triggered just before the rendered response is sent to the client.