### PR TITLE
Bump jetty-bom from 11.0.12 to 11.0.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ group = 'org.wiremock'
 project.ext {
   versions = [
     handlebars     : '4.3.1',
-    jetty          : '11.0.12',
+    jetty          : '11.0.15',
     guava          : '32.1.2-jre',
     jackson        : '2.15.2',
     xmlUnit        : '2.9.1',


### PR DESCRIPTION
This solves the vulnerabilites [CVE-2023-26048](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-26048) and [CVE-2023-26049](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-26049). 

It seems that Dependabot hasn't picked it up patch updates to jetty since last year, so I figured I'd make this PR, to solve the above-mentioned vulnerabilities and hopefully get Dependabot to pick it up again.