### PR TITLE
Allow configuring webhook to forbid target endpoints

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -122,7 +122,7 @@ public class ProxyResponseRenderer implements ResponseRenderer {
       httpRequest.setEntity(buildEntityFrom(originalRequest));
     }
 
-    CloseableHttpClient client = buildClient(serveEvent.getRequest().isBrowserProxyRequest());
+    CloseableHttpClient client = chooseClient(serveEvent.getRequest().isBrowserProxyRequest());
 
     try {
       return client.execute(
@@ -178,7 +178,7 @@ public class ProxyResponseRenderer implements ResponseRenderer {
     return request.getRequestUri();
   }
 
-  private CloseableHttpClient buildClient(boolean browserProxyRequest) {
+  private CloseableHttpClient chooseClient(boolean browserProxyRequest) {
     if (browserProxyRequest) {
       return forwardProxyClient;
     } else {

--- a/wiremock-webhooks-extension/build.gradle
+++ b/wiremock-webhooks-extension/build.gradle
@@ -39,6 +39,7 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter"
   testImplementation "org.hamcrest:hamcrest-core:2.2"
   testImplementation "org.hamcrest:hamcrest-library:2.2"
+  testImplementation 'org.awaitility:awaitility:4.2.0'
 }
 
 shadowJar {

--- a/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -20,6 +20,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.Parameters;
@@ -28,6 +29,9 @@ import com.github.tomakehurst.wiremock.extension.responsetemplating.RequestTempl
 import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
 import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -50,25 +54,37 @@ public class Webhooks extends PostServeAction {
   private final CloseableHttpClient httpClient;
   private final List<WebhookTransformer> transformers;
   private final TemplateEngine templateEngine;
+  private final NetworkAddressRules targetAddressRules;
 
   private Webhooks(
       ScheduledExecutorService scheduler,
       CloseableHttpClient httpClient,
-      List<WebhookTransformer> transformers) {
+      List<WebhookTransformer> transformers,
+      NetworkAddressRules targetAddressRules) {
     this.scheduler = scheduler;
     this.httpClient = httpClient;
     this.transformers = transformers;
 
     this.templateEngine = TemplateEngine.defaultTemplateEngine();
+    this.targetAddressRules = targetAddressRules;
+  }
+
+  private Webhooks(List<WebhookTransformer> transformers, NetworkAddressRules targetAddressRules) {
+    this(
+        Executors.newScheduledThreadPool(10), createHttpClient(), transformers, targetAddressRules);
+  }
+
+  public Webhooks(NetworkAddressRules targetAddressRules) {
+    this(new ArrayList<>(), targetAddressRules);
   }
 
   @JsonCreator
   public Webhooks() {
-    this(Executors.newScheduledThreadPool(10), createHttpClient(), new ArrayList<>());
+    this(NetworkAddressRules.ALLOW_ALL);
   }
 
   public Webhooks(WebhookTransformer... transformers) {
-    this(Executors.newScheduledThreadPool(10), createHttpClient(), Arrays.asList(transformers));
+    this(Arrays.asList(transformers), NetworkAddressRules.ALLOW_ALL);
   }
 
   private static CloseableHttpClient createHttpClient() {
@@ -109,6 +125,10 @@ public class Webhooks extends PostServeAction {
         definition = transformer.transform(serveEvent, definition);
       }
       definition = applyTemplating(definition, serveEvent);
+      if (targetAddressProhibited(definition.getUrl())) {
+        notifier().error("The target webhook address is denied in WireMock's configuration.");
+        return;
+      }
       request = buildRequest(definition);
     } catch (Exception e) {
       notifier().error("Exception thrown while configuring webhook", e);
@@ -193,6 +213,19 @@ public class Webhooks extends PostServeAction {
     }
 
     return requestBuilder.build();
+  }
+
+  // TODO this is duplicated in com.github.tomakehurst.wiremock.http.ProxyResponseRenderer - should
+  // it be on NetworkAddressRules ?
+  private boolean targetAddressProhibited(String url) {
+    String host = URI.create(url).getHost();
+    try {
+      final InetAddress[] resolvedAddresses = InetAddress.getAllByName(host);
+      return !Arrays.stream(resolvedAddresses)
+          .allMatch(address -> targetAddressRules.isAllowed(address.getHostAddress()));
+    } catch (UnknownHostException e) {
+      return true;
+    }
   }
 
   public static WebhookDefinition webhook() {


### PR DESCRIPTION
Allows configuring network address rules to permit / deny webhook usage.

Can be used to prevent Webhooks being used to call endpoints in the same private network as the WireMock instance.

## Submitter checklist

- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
