### PR TITLE
Refactor: reduce duplication in network rules

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/Dns.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Dns.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.common;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public interface Dns {
+  InetAddress[] getAllByName(String host) throws UnknownHostException;
+
+  InetAddress getByName(String host) throws UnknownHostException;
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -55,18 +55,14 @@ public class NetworkAddressRules {
         && denied.stream().noneMatch(rule -> rule.isIncluded(testValue));
   }
 
-  private boolean isHostProhibited(String host) {
+  public boolean isHostAllowed(String host) {
     try {
       final InetAddress[] resolvedAddresses = dns.getAllByName(host);
-      return !Arrays.stream(resolvedAddresses)
+      return Arrays.stream(resolvedAddresses)
           .allMatch(address -> isAllowed(address.getHostAddress()));
     } catch (UnknownHostException e) {
-      return true;
+      return false;
     }
-  }
-
-  public boolean isHostAllowed(String host) {
-    return !isHostProhibited(host);
   }
 
   public static class Builder {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -55,7 +55,7 @@ public class NetworkAddressRules {
         && denied.stream().noneMatch(rule -> rule.isIncluded(testValue));
   }
 
-  public boolean isHostProhibited(String host) {
+  private boolean isHostProhibited(String host) {
     try {
       final InetAddress[] resolvedAddresses = dns.getAllByName(host);
       return !Arrays.stream(resolvedAddresses)

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -19,6 +19,9 @@ import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL;
 import static java.util.Collections.emptySet;
 
 import com.google.common.collect.ImmutableSet;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Set;
 
 public class NetworkAddressRules {
@@ -40,6 +43,16 @@ public class NetworkAddressRules {
   public boolean isAllowed(String testValue) {
     return allowed.stream().anyMatch(rule -> rule.isIncluded(testValue))
         && denied.stream().noneMatch(rule -> rule.isIncluded(testValue));
+  }
+
+  public boolean isHostProhibited(String host) {
+    try {
+      final InetAddress[] resolvedAddresses = InetAddress.getAllByName(host);
+      return !Arrays.stream(resolvedAddresses)
+          .allMatch(address -> isAllowed(address.getHostAddress()));
+    } catch (UnknownHostException e) {
+      return true;
+    }
   }
 
   public static class Builder {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -65,6 +65,10 @@ public class NetworkAddressRules {
     }
   }
 
+  public boolean isHostAllowed(String host) {
+    return !isHostProhibited(host);
+  }
+
   public static class Builder {
     private final ImmutableSet.Builder<NetworkAddressRange> allowed = ImmutableSet.builder();
     private final ImmutableSet.Builder<NetworkAddressRange> denied = ImmutableSet.builder();

--- a/src/main/java/com/github/tomakehurst/wiremock/common/SystemDns.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/SystemDns.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.common;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class SystemDns implements Dns {
+  public static SystemDns INSTANCE = new SystemDns();
+
+  private SystemDns() {}
+
+  public InetAddress[] getAllByName(String host) throws UnknownHostException {
+    return InetAddress.getAllByName(host);
+  }
+
+  public InetAddress getByName(String host) throws UnknownHostException {
+    return InetAddress.getByName(host);
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -27,11 +27,8 @@ import com.github.tomakehurst.wiremock.store.SettingsStore;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -149,17 +146,7 @@ public class ProxyResponseRenderer implements ResponseRenderer {
 
   private boolean targetAddressProhibited(String proxyUrl) {
     String host = URI.create(proxyUrl).getHost();
-    return isHostProhibited(host);
-  }
-
-  private boolean isHostProhibited(String host) {
-    try {
-      final InetAddress[] resolvedAddresses = InetAddress.getAllByName(host);
-      return !Arrays.stream(resolvedAddresses)
-          .allMatch(address -> targetAddressRules.isAllowed(address.getHostAddress()));
-    } catch (UnknownHostException e) {
-      return true;
-    }
+    return targetAddressRules.isHostProhibited(host);
   }
 
   private Response proxyResponseError(String type, HttpUriRequest request, Exception e) {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -146,7 +146,7 @@ public class ProxyResponseRenderer implements ResponseRenderer {
 
   private boolean targetAddressProhibited(String proxyUrl) {
     String host = URI.create(proxyUrl).getHost();
-    return targetAddressRules.isHostProhibited(host);
+    return !targetAddressRules.isHostAllowed(host);
   }
 
   private Response proxyResponseError(String type, HttpUriRequest request, Exception e) {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -149,6 +149,10 @@ public class ProxyResponseRenderer implements ResponseRenderer {
 
   private boolean targetAddressProhibited(String proxyUrl) {
     String host = URI.create(proxyUrl).getHost();
+    return isHostProhibited(host);
+  }
+
+  private boolean isHostProhibited(String host) {
     try {
       final InetAddress[] resolvedAddresses = InetAddress.getAllByName(host);
       return !Arrays.stream(resolvedAddresses)

--- a/src/test/java/com/github/tomakehurst/wiremock/common/FakeDns.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/FakeDns.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.common;
+
+import com.google.common.net.InetAddresses;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+class FakeDns implements Dns {
+
+  private final ConcurrentMap<String, InetAddress[]> names = new ConcurrentHashMap<>();
+
+  public FakeDns register(String name, InetAddress... addresses) {
+    names.put(name, addresses);
+    return this;
+  }
+
+  @Override
+  public InetAddress[] getAllByName(String host) throws UnknownHostException {
+    if (InetAddresses.isInetAddress(host)) {
+      return InetAddress.getAllByName(host);
+    }
+    InetAddress[] results = names.get(host);
+    if (results == null || results.length == 0) {
+      throw new UnknownHostException(host);
+    }
+    return results;
+  }
+
+  @Override
+  public InetAddress getByName(String host) throws UnknownHostException {
+    return getAllByName(host)[0];
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
@@ -98,18 +98,18 @@ public class NetworkAddressRulesTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"10.1.1.1,true", "10.1.1.2,false"})
-  void isHostProhibitedReturnsExpectedValueForIpv4AddressWithIpv4DenyRule(
+  @CsvSource({"10.1.1.1,false", "10.1.1.2,true"})
+  void isHostAllowedReturnsExpectedValueForIpv4AddressWithIpv4DenyRule(
       String host, boolean expectation) {
     FakeDns dns = new FakeDns();
     NetworkAddressRules rules = NetworkAddressRules.builder(dns).deny("10.1.1.1").build();
 
-    assertThat(rules.isHostProhibited(host), is(expectation));
+    assertThat(rules.isHostAllowed(host), is(expectation));
   }
 
   @ParameterizedTest
-  @CsvSource({"1.example.com,true", "2.example.com,false", "3.example.com,true"})
-  void isHostProhibitedReturnsExpectedValueForHostnameWithIpv4DenyRule(
+  @CsvSource({"1.example.com,false", "2.example.com,true", "3.example.com,false"})
+  void isHostAllowedReturnsExpectedValueForHostnameWithIpv4DenyRule(
       String host, boolean expectation) throws UnknownHostException {
     FakeDns dns =
         new FakeDns()
@@ -118,12 +118,12 @@ public class NetworkAddressRulesTest {
 
     NetworkAddressRules rules = NetworkAddressRules.builder(dns).deny("10.1.1.1").build();
 
-    assertThat(rules.isHostProhibited(host), is(expectation));
+    assertThat(rules.isHostAllowed(host), is(expectation));
   }
 
   @ParameterizedTest
-  @CsvSource({"1.example.com,true", "2.example.com,false", "3.example.com,true"})
-  void isHostProhibitedReturnsExpectedValueForHostnameResolvingToMultipleAddressesWithIpv4DenyRule(
+  @CsvSource({"1.example.com,false", "2.example.com,true", "3.example.com,false"})
+  void isHostAllowedReturnsExpectedValueForHostnameResolvingToMultipleAddressesWithIpv4DenyRule(
       String host, boolean expectation) throws UnknownHostException {
     FakeDns dns =
         new FakeDns()
@@ -138,22 +138,22 @@ public class NetworkAddressRulesTest {
 
     NetworkAddressRules rules = NetworkAddressRules.builder(dns).deny("10.1.1.1").build();
 
-    assertThat(rules.isHostProhibited(host), is(expectation));
+    assertThat(rules.isHostAllowed(host), is(expectation));
   }
 
   @ParameterizedTest
-  @CsvSource({"10.1.1.1,false", "10.1.1.2,true", "3.example.com,true"})
-  void isHostProhibitedReturnsExpectedValueForIpv4AddressWithIpv4AllowRule(
+  @CsvSource({"10.1.1.1,true", "10.1.1.2,false", "3.example.com,false"})
+  void isHostAllowedReturnsExpectedValueForIpv4AddressWithIpv4AllowRule(
       String host, boolean expectation) {
     FakeDns dns = new FakeDns();
     NetworkAddressRules rules = NetworkAddressRules.builder(dns).allow("10.1.1.1").build();
 
-    assertThat(rules.isHostProhibited(host), is(expectation));
+    assertThat(rules.isHostAllowed(host), is(expectation));
   }
 
   @ParameterizedTest
-  @CsvSource({"1.example.com,false", "2.example.com,true", "3.example.com,true"})
-  void isHostProhibitedReturnsExpectedValueForHostnameWithIpv4AllowRule(
+  @CsvSource({"1.example.com,true", "2.example.com,false", "3.example.com,false"})
+  void isHostAllowedReturnsExpectedValueForHostnameWithIpv4AllowRule(
       String host, boolean expectation) throws UnknownHostException {
     FakeDns dns =
         new FakeDns()
@@ -162,12 +162,12 @@ public class NetworkAddressRulesTest {
 
     NetworkAddressRules rules = NetworkAddressRules.builder(dns).allow("10.1.1.1").build();
 
-    assertThat(rules.isHostProhibited(host), is(expectation));
+    assertThat(rules.isHostAllowed(host), is(expectation));
   }
 
   @ParameterizedTest
-  @CsvSource({"1.example.com,true", "2.example.com,true", "3.example.com,true"})
-  void isHostProhibitedReturnsExpectedValueForHostnameResolvingToMultipleAddressesWithIpv4AllowRule(
+  @CsvSource({"1.example.com,false", "2.example.com,false", "3.example.com,false"})
+  void isHostAllowedReturnsExpectedValueForHostnameResolvingToMultipleAddressesWithIpv4AllowRule(
       String host, boolean expectation) throws UnknownHostException {
     FakeDns dns =
         new FakeDns()
@@ -182,6 +182,6 @@ public class NetworkAddressRulesTest {
 
     NetworkAddressRules rules = NetworkAddressRules.builder(dns).allow("10.1.1.1").build();
 
-    assertThat(rules.isHostProhibited(host), is(expectation));
+    assertThat(rules.isHostAllowed(host), is(expectation));
   }
 }

--- a/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -29,9 +29,7 @@ import com.github.tomakehurst.wiremock.extension.responsetemplating.RequestTempl
 import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import java.net.InetAddress;
 import java.net.URI;
-import java.net.UnknownHostException;
 import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -215,17 +213,9 @@ public class Webhooks extends PostServeAction {
     return requestBuilder.build();
   }
 
-  // TODO this is duplicated in com.github.tomakehurst.wiremock.http.ProxyResponseRenderer - should
-  // it be on NetworkAddressRules ?
   private boolean targetAddressProhibited(String url) {
     String host = URI.create(url).getHost();
-    try {
-      final InetAddress[] resolvedAddresses = InetAddress.getAllByName(host);
-      return !Arrays.stream(resolvedAddresses)
-          .allMatch(address -> targetAddressRules.isAllowed(address.getHostAddress()));
-    } catch (UnknownHostException e) {
-      return true;
-    }
+    return targetAddressRules.isHostProhibited(host);
   }
 
   public static WebhookDefinition webhook() {

--- a/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/wiremock-webhooks-extension/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -215,7 +215,7 @@ public class Webhooks extends PostServeAction {
 
   private boolean targetAddressProhibited(String url) {
     String host = URI.create(url).getHost();
-    return targetAddressRules.isHostProhibited(host);
+    return !targetAddressRules.isHostAllowed(host);
   }
 
   public static WebhookDefinition webhook() {


### PR DESCRIPTION
There was previously duplicated code in `ProxyResponseRenderer` and `Webhooks`. This PR extracts that code and pushes it down onto `NetworkAddressRules`, in the process making it testable & adding tests that demonstrate how it works.

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
