### PR TITLE
Network rules bug

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -19,9 +19,6 @@ import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL;
 import static java.util.Collections.emptySet;
 
 import com.google.common.collect.ImmutableSet;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.Set;
 
 public class NetworkAddressRules {
@@ -36,18 +33,12 @@ public class NetworkAddressRules {
 
   private final Set<NetworkAddressRange> allowed;
   private final Set<NetworkAddressRange> denied;
-  private final Dns dns;
 
   public static NetworkAddressRules ALLOW_ALL = new NetworkAddressRules(Set.of(ALL), emptySet());
 
-  public NetworkAddressRules(Set<NetworkAddressRange> allowed, Set<NetworkAddressRange> denied) {
-    this(allowed, denied, SystemDns.INSTANCE);
-  }
-
-  NetworkAddressRules(Set<NetworkAddressRange> allowed, Set<NetworkAddressRange> denied, Dns dns) {
+  NetworkAddressRules(Set<NetworkAddressRange> allowed, Set<NetworkAddressRange> denied) {
     this.allowed = allowed;
     this.denied = denied;
-    this.dns = dns;
   }
 
   public boolean isAllowed(String testValue) {
@@ -56,13 +47,7 @@ public class NetworkAddressRules {
   }
 
   public boolean isHostAllowed(String host) {
-    try {
-      final InetAddress[] resolvedAddresses = dns.getAllByName(host);
-      return Arrays.stream(resolvedAddresses)
-          .allMatch(address -> isAllowed(address.getHostAddress()));
-    } catch (UnknownHostException e) {
-      return false;
-    }
+    return isAllowed(host);
   }
 
   public static class Builder {
@@ -93,7 +78,7 @@ public class NetworkAddressRules {
       if (allowedRanges.isEmpty()) {
         allowedRanges = Set.of(ALL);
       }
-      return new NetworkAddressRules(allowedRanges, denied.build(), dns);
+      return new NetworkAddressRules(allowedRanges, denied.build());
     }
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
@@ -100,8 +100,12 @@ public class NetworkAddressRulesTest {
   @ParameterizedTest
   @CsvSource({"10.1.1.1,false", "10.1.1.2,true"})
   void isHostAllowedReturnsExpectedValueForIpv4AddressWithIpv4DenyRule(
-      String host, boolean expectation) {
-    FakeDns dns = new FakeDns();
+      String host, boolean expectation) throws UnknownHostException {
+    FakeDns dns =
+        new FakeDns()
+            .register("1.example.com", InetAddress.getByName("10.1.1.1"))
+            .register("2.example.com", InetAddress.getByName("10.1.1.2"));
+    ;
     NetworkAddressRules rules = NetworkAddressRules.builder(dns).deny("10.1.1.1").build();
 
     assertThat(rules.isHostAllowed(host), is(expectation));
@@ -144,8 +148,12 @@ public class NetworkAddressRulesTest {
   @ParameterizedTest
   @CsvSource({"10.1.1.1,true", "10.1.1.2,false", "3.example.com,false"})
   void isHostAllowedReturnsExpectedValueForIpv4AddressWithIpv4AllowRule(
-      String host, boolean expectation) {
-    FakeDns dns = new FakeDns();
+      String host, boolean expectation) throws UnknownHostException {
+    FakeDns dns =
+        new FakeDns()
+            .register("1.example.com", InetAddress.getByName("10.1.1.1"))
+            .register("2.example.com", InetAddress.getByName("10.1.1.2"));
+    ;
     NetworkAddressRules rules = NetworkAddressRules.builder(dns).allow("10.1.1.1").build();
 
     assertThat(rules.isHostAllowed(host), is(expectation));
@@ -181,6 +189,101 @@ public class NetworkAddressRulesTest {
                 InetAddress.getByName("10.1.1.3"));
 
     NetworkAddressRules rules = NetworkAddressRules.builder(dns).allow("10.1.1.1").build();
+
+    assertThat(rules.isHostAllowed(host), is(expectation));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"10.1.1.1,true", "10.1.1.2,true"})
+  void isHostAllowedReturnsExpectedValueForIpv4AddressWithHostnameDenyRule(
+      String host, boolean expectation) throws UnknownHostException {
+    FakeDns dns =
+        new FakeDns()
+            .register("1.example.com", InetAddress.getByName("10.1.1.1"))
+            .register("2.example.com", InetAddress.getByName("10.1.1.2"));
+    NetworkAddressRules rules = NetworkAddressRules.builder(dns).deny("1.example.com").build();
+
+    assertThat(rules.isHostAllowed(host), is(expectation));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1.example.com,false", "2.example.com,true", "3.example.com,false"})
+  void isHostAllowedReturnsExpectedValueForHostnameWithHostnameDenyRule(
+      String host, boolean expectation) throws UnknownHostException {
+    FakeDns dns =
+        new FakeDns()
+            .register("1.example.com", InetAddress.getByName("10.1.1.1"))
+            .register("2.example.com", InetAddress.getByName("10.1.1.2"));
+
+    NetworkAddressRules rules = NetworkAddressRules.builder(dns).deny("1.example.com").build();
+
+    assertThat(rules.isHostAllowed(host), is(expectation));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1.example.com,false", "2.example.com,true", "3.example.com,false"})
+  void isHostAllowedReturnsExpectedValueForHostnameResolvingToMultipleAddressesWithHostnameDenyRule(
+      String host, boolean expectation) throws UnknownHostException {
+    FakeDns dns =
+        new FakeDns()
+            .register(
+                "1.example.com",
+                InetAddress.getByName("10.1.1.0"),
+                InetAddress.getByName("10.1.1.1"))
+            .register(
+                "2.example.com",
+                InetAddress.getByName("10.1.1.2"),
+                InetAddress.getByName("10.1.1.3"));
+
+    NetworkAddressRules rules = NetworkAddressRules.builder(dns).deny("1.example.com").build();
+
+    assertThat(rules.isHostAllowed(host), is(expectation));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"10.1.1.1,false", "10.1.1.2,false", "3.example.com,false"})
+  void isHostAllowedReturnsExpectedValueForIpv4AddressWithHostnameAllowRule(
+      String host, boolean expectation) throws UnknownHostException {
+    FakeDns dns =
+        new FakeDns()
+            .register("1.example.com", InetAddress.getByName("10.1.1.1"))
+            .register("2.example.com", InetAddress.getByName("10.1.1.2"));
+    NetworkAddressRules rules = NetworkAddressRules.builder(dns).allow("1.example.com").build();
+
+    assertThat(rules.isHostAllowed(host), is(expectation));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1.example.com,true", "2.example.com,false", "3.example.com,false"})
+  void isHostAllowedReturnsExpectedValueForHostnameWithHostnameAllowRule(
+      String host, boolean expectation) throws UnknownHostException {
+    FakeDns dns =
+        new FakeDns()
+            .register("1.example.com", InetAddress.getByName("10.1.1.1"))
+            .register("2.example.com", InetAddress.getByName("10.1.1.2"));
+
+    NetworkAddressRules rules = NetworkAddressRules.builder(dns).allow("1.example.com").build();
+
+    assertThat(rules.isHostAllowed(host), is(expectation));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1.example.com,true", "2.example.com,false", "3.example.com,false"})
+  void
+      isHostAllowedReturnsExpectedValueForHostnameResolvingToMultipleAddressesWithHostnameAllowRule(
+          String host, boolean expectation) throws UnknownHostException {
+    FakeDns dns =
+        new FakeDns()
+            .register(
+                "1.example.com",
+                InetAddress.getByName("10.1.1.0"),
+                InetAddress.getByName("10.1.1.1"))
+            .register(
+                "2.example.com",
+                InetAddress.getByName("10.1.1.2"),
+                InetAddress.getByName("10.1.1.3"));
+
+    NetworkAddressRules rules = NetworkAddressRules.builder(dns).allow("1.example.com").build();
 
     assertThat(rules.isHostAllowed(host), is(expectation));
   }


### PR DESCRIPTION
There's a bug with the network rules - rules allowing / denying by host pattern are basically ignored because we resolve the name to IP addresses before applying the rules.

Unfortunately it's hard to fix with the current architecture. In order to get the host rules to apply we need to push the resolution to IP addresses down into the individual `NetworkAddressRange` subtypes, but we then need `NetworkAddressRange` instances in the `allowed` set to behave differently to `NetworkAddressRange` instances in the `denied` set - specifically, a host that resolves to multiple IP addresses should only be included when *all* of the IPs match in an allowed rule but included when *any* of the IPs match in a denied rule.

There's also an issue around what to do if the host cannot be resolved - ideally in an `allowed` range it would not be included but in a `denied` range it would be included.

See the failing tests to understand the issues.

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
