### PR TITLE
Fix HttpsBrowserProxyAcceptanceTest

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
@@ -140,7 +140,7 @@ public class HttpsBrowserProxyAcceptanceTest {
     ProxyConfiguration proxyConfig = httpClient.getProxyConfiguration();
     HttpProxy httpProxy =
         new HttpProxy(new Origin.Address("localhost", proxy.getHttpsPort()), true);
-    proxyConfig.getProxies().add(httpProxy);
+    proxyConfig.addProxy(httpProxy);
 
     target.stubFor(get(urlEqualTo("/whatever")).willReturn(aResponse().withBody("Got it")));
 


### PR DESCRIPTION
Fix HttpsBrowserProxyAcceptanceTest

Fix \wiremock\src\test\java\com\github\tomakehurst\wiremock\HttpsBrowserProxyAcceptanceTest.java:143: warning: [removal] getProxies() in ProxyConfiguration has been deprecated and marked for removal
    proxyConfig.getProxies().add(httpProxy);

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)