### PR TITLE
Restore old edit task for 2.x backwards compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,7 @@ allprojects {
     mavenCentral()
   }
 
-  version = '3.0.0-beta-15'
+  version = '3.0.0-beta-16'
 
 
   sourceCompatibility = 11

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
@@ -59,6 +59,11 @@ public class AdminRoutes {
     router.add(POST, "/mappings", new CreateStubMappingTask());
     router.add(DELETE, "/mappings", new ResetStubMappingsTask());
 
+    router.add(
+        POST,
+        "/mappings/edit",
+        new OldEditStubMappingTask()); // Deprecated but kept so that 2.x client will still be
+    // compatible
     router.add(POST, "/mappings/save", new SaveMappingsTask());
     router.add(POST, "/mappings/reset", new ResetToDefaultMappingsTask());
     router.add(GET, "/mappings/{id}", new GetStubMappingTask());

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
@@ -59,11 +59,9 @@ public class AdminRoutes {
     router.add(POST, "/mappings", new CreateStubMappingTask());
     router.add(DELETE, "/mappings", new ResetStubMappingsTask());
 
-    router.add(
-        POST,
-        "/mappings/edit",
-        new OldEditStubMappingTask()); // Deprecated but kept so that 2.x client will still be
-    // compatible
+    // Deprecated but kept so that 2.x client will still be compatible
+    router.add(POST, "/mappings/edit", new OldEditStubMappingTask());
+
     router.add(POST, "/mappings/save", new SaveMappingsTask());
     router.add(POST, "/mappings/reset", new ResetToDefaultMappingsTask());
     router.add(GET, "/mappings/{id}", new GetStubMappingTask());

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/OldEditStubMappingTask.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/OldEditStubMappingTask.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2013-2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.admin.tasks;
+
+import com.github.tomakehurst.wiremock.admin.AdminTask;
+import com.github.tomakehurst.wiremock.common.url.PathParams;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+
+public class OldEditStubMappingTask implements AdminTask {
+
+  @Override
+  public ResponseDefinition execute(Admin admin, ServeEvent serveEvent, PathParams pathParams) {
+    StubMapping stubMapping = StubMapping.buildFrom(serveEvent.getRequest().getBodyAsString());
+    admin.editStubMapping(stubMapping);
+    return ResponseDefinition.noContent();
+  }
+}

--- a/src/main/resources/swagger/wiremock-admin-api.json
+++ b/src/main/resources/swagger/wiremock-admin-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "WireMock",
-    "version": "3.0.0-beta-15"
+    "version": "3.0.0-beta-16"
   },
   "externalDocs": {
     "description": "WireMock user documentation",

--- a/src/main/resources/swagger/wiremock-admin-api.yaml
+++ b/src/main/resources/swagger/wiremock-admin-api.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 
 info:
   title: WireMock
-  version: 3.0.0-beta-15
+  version: 3.0.0-beta-16
 
 externalDocs:
   description: WireMock user documentation

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wiremock-ui-resources",
-  "version": "3.0.0-beta-15",
+  "version": "3.0.0-beta-16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiremock-ui-resources",
-  "version": "3.0.0-beta-15",
+  "version": "3.0.0-beta-16",
   "description": "WireMock UI resources processor",
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
This restores the deprecated edit API so that 2.x WireMock can serve as a client to 3.x, allowing Java 8 users to benefit from 3.x via Testcontainers.