### PR TITLE
Respect StopAction in V1 Filter

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/FilterProcessor.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/FilterProcessor.java
@@ -34,7 +34,11 @@ public class FilterProcessor {
   public RequestFilterAction processFilters(Request request, ServeEvent serveEvent) {
     RequestFilterAction requestFilterAction =
         processV1Filters(request, v1RequestFilters, RequestFilterAction.continueWith(request));
-    return processV2Filters(request, serveEvent, v2RequestFilters, requestFilterAction);
+    if (requestFilterAction instanceof ContinueAction) {
+      return processV2Filters(request, serveEvent, v2RequestFilters, requestFilterAction);
+    } else {
+      return requestFilterAction;
+    }
   }
 
   private RequestFilterAction processV1Filters(


### PR DESCRIPTION
We should only continue to V2 filters if the V1 filters return a ContinueAction.

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [X] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
