### PR TITLE
Stop returning 500s for unmatched path patterns

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
@@ -357,12 +357,7 @@ public class Diff {
         if (PathPattern.class.isAssignableFrom(pattern.getClass())) {
           PathPattern pathPattern = (PathPattern) pattern;
           if (!pathPattern.isSimple()) {
-            ListOrSingle<String> expressionResult =
-                pathPattern.getExpressionResult(body.asString());
-            String expressionResultString =
-                expressionResult != null && !expressionResult.isEmpty()
-                    ? expressionResult.toString()
-                    : null;
+            String expressionResultString = getExpressionResultString(body, pathPattern);
             String printedExpectedValue =
                 pathPattern.getExpected()
                     + " ["
@@ -395,6 +390,17 @@ public class Diff {
                   "Body", nonStringPattern, formattedBody.getBytes(), pattern.getExpected()));
         }
       }
+    }
+  }
+
+  private static String getExpressionResultString(Body body, PathPattern pathPattern) {
+    try {
+      ListOrSingle<String> expressionResult = pathPattern.getExpressionResult(body.asString());
+      return expressionResult != null && !expressionResult.isEmpty()
+          ? expressionResult.toString()
+          : null;
+    } catch (Exception e) {
+      return e.getMessage();
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/diff/DiffTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/diff/DiffTest.java
@@ -524,4 +524,24 @@ public class DiffTest {
             junitStyleDiffMessage(
                 "https\n" + "ANY\n" + "/thing\n", "http\n" + "ANY\n" + "/thing\n")));
   }
+
+  @Test
+  public void handleExceptionGettingExpressionResult() {
+    Diff diff =
+        new Diff(
+            newRequestPattern(ANY, urlEqualTo("/thing"))
+                .withRequestBody(matchingJsonPath("$.accountNum", equalTo("1234")))
+                .build(),
+            mockRequest().url("/thing").body(""));
+
+    assertThat(
+        diff.toString(),
+        is(
+            junitStyleDiffMessage(
+                "ANY\n" + "/thing\n" + "\n" + "$.accountNum [equalTo] 1234",
+                "ANY\n"
+                    + "/thing\n"
+                    + "\n"
+                    + "Warning: JSON path expression '$.accountNum' failed to match document '' because of error 'json string can not be null or empty'")));
+  }
 }


### PR DESCRIPTION
The Diff rendering did not handle the `SubExpressionException` thrown in
e.g. `MatchesJsonPathPattern`. This makes it catch that exception and
output it in the diff.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [X] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
