### PR TITLE
Fix custom response templating

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/Extensions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/Extensions.java
@@ -122,13 +122,14 @@ public class Extensions implements WireMockServices {
         new ArrayList<>(ofType(TemplateModelDataProviderExtension.class).values());
 
     if (options.getResponseTemplatingEnabled()) {
-      final ResponseTemplateTransformer responseTemplateTransformer =
-          new ResponseTemplateTransformer(
-              getTemplateEngine(),
-              options.getResponseTemplatingGlobal(),
-              getFiles(),
-              templateModelProviders);
-      loadedExtensions.put(responseTemplateTransformer.getName(), responseTemplateTransformer);
+      loadedExtensions.computeIfAbsent(
+          ResponseTemplateTransformer.NAME,
+          rtt ->
+              new ResponseTemplateTransformer(
+                  getTemplateEngine(),
+                  options.getResponseTemplatingGlobal(),
+                  getFiles(),
+                  templateModelProviders));
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/CustomResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/CustomResponseTemplateTransformerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2011-2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import java.util.Collections;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CustomResponseTemplateTransformerTest {
+
+  private WireMockServer wireMockServer;
+  private WireMockTestClient testClient;
+
+  @BeforeEach
+  public void init() {
+    WireMockConfiguration config = new WireMockConfiguration();
+    config =
+        config
+            .dynamicPort()
+            .extensions(
+                new ResponseTemplateTransformer(
+                    TemplateEngine.defaultTemplateEngine(), true, null, Collections.emptyList()));
+    wireMockServer = new WireMockServer(config);
+    wireMockServer.start();
+    WireMock.configureFor(wireMockServer.port());
+    testClient = new WireMockTestClient(wireMockServer.port());
+  }
+
+  @AfterEach
+  public void stopServer() {
+    wireMockServer.stop();
+  }
+
+  @Test
+  public void makeSureCustomResponseTemplateTransformerTakenIntoAccount() {
+    WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
+
+    wireMock.register(
+        get(urlEqualTo("/my/new/resource"))
+            .willReturn(aResponse().withBody("Path: {{request.path}}")));
+
+    assertThat(testClient.get("/my/new/resource").content(), is("Path: /my/new/resource"));
+  }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References
fixes https://github.com/wiremock/wiremock/issues/2349

when manually creating a `ResponseTemplateTransformer` via `WireMockConfiguration.extentions`. It gets added to the loadedExtensions, but then gets overwritten by the put. 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
