### PR TITLE
fix: avoid crash when printing help in wiremock-standalone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,6 +311,7 @@ shadowJar {
   relocate "org.hamcrest", "wiremock.org.hamcrest"
   relocate "org.slf4j", "wiremock.org.slf4j"
   relocate "joptsimple", "wiremock.joptsimple"
+  exclude 'joptsimple/HelpFormatterMessages.properties'
   relocate "org.yaml", "wiremock.org.yaml"
   relocate "com.ethlo", "wiremock.com.ethlo"
   relocate "com.networknt", "wiremock.com.networknt"

--- a/src/main/resources/wiremock/joptsimple/HelpFormatterMessages.properties
+++ b/src/main/resources/wiremock/joptsimple/HelpFormatterMessages.properties
@@ -1,0 +1,16 @@
+#
+# This is copied from joptsimple.
+# Properties prefixed with "wiremock" to match after relocation into standalone jar
+# Without this, the "--help" command will throw MissingResourceException
+#
+wiremock.joptsimple.BuiltinHelpFormatter.no.options.specified = No options specified
+wiremock.joptsimple.BuiltinHelpFormatter.non.option.arguments.header = Non-option arguments:
+wiremock.joptsimple.BuiltinHelpFormatter.option.header.with.required.indicator = Option (* = required)
+wiremock.joptsimple.BuiltinHelpFormatter.option.divider.with.required.indicator = ---------------------
+wiremock.joptsimple.BuiltinHelpFormatter.option.header = Option
+wiremock.joptsimple.BuiltinHelpFormatter.option.divider = ------
+wiremock.joptsimple.BuiltinHelpFormatter.description.header = Description
+wiremock.joptsimple.BuiltinHelpFormatter.description.divider = -----------
+wiremock.joptsimple.BuiltinHelpFormatter.default.value.header = default:
+wiremock.joptsimple.AlternativeLongOptionSpec.description = Alternative form of long options
+wiremock.joptsimple.AlternativeLongOptionSpec.arg.description = opt=value


### PR DESCRIPTION
Supplying relocated properties to avoid crash when they are read from relocated `joptsimple` when using `wiremock-standalone`.

In Wiremock `3.0.0` and `3.0.1` if you do:

```sh
java -jar wiremock-standalone-3.0.1.jar --help
```

You will get:

```
Exception in thread "main" java.util.MissingResourceException: Can't find resource for bundle java.util.PropertyResourceBundle, key wiremock.joptsimple.BuiltinHelpFormatter.option.header
	at java.base/java.util.ResourceBundle.getObject(ResourceBundle.java:564)
	at java.base/java.util.ResourceBundle.getString(ResourceBundle.java:521)
	at wiremock.joptsimple.internal.Messages.message(Messages.java:42)
	at wiremock.joptsimple.BuiltinHelpFormatter.message(BuiltinHelpFormatter.java:558)
	at wiremock.joptsimple.BuiltinHelpFormatter.addHeaders(BuiltinHelpFormatter.java:316)
	at wiremock.joptsimple.BuiltinHelpFormatter.addRows(BuiltinHelpFormatter.java:203)
	at wiremock.joptsimple.BuiltinHelpFormatter.format(BuiltinHelpFormatter.java:101)
	at wiremock.joptsimple.OptionParser.printHelpOn(OptionParser.java:342)
	at com.github.tomakehurst.wiremock.standalone.CommandLineOptions.captureHelpTextIfRequested(CommandLineOptions.java:450)
	at com.github.tomakehurst.wiremock.standalone.CommandLineOptions.<init>(CommandLineOptions.java:372)
	at com.github.tomakehurst.wiremock.standalone.WireMockServerRunner.run(WireMockServerRunner.java:56)
	at wiremock.Run.main(Run.java:23)
```

I tried adding a test case for this. Since the problem happens after relocation, I was unable to.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
