### PR TITLE
Reset system properties at end of test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ dependencies {
   testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
   testImplementation("org.junit.platform:junit-platform-launcher")
   testImplementation("org.junit.jupiter:junit-jupiter-params")
+  testImplementation('org.junit-pioneer:junit-pioneer:2.0.1')
 
   testImplementation "org.hamcrest:hamcrest-core:2.2"
   testImplementation "org.hamcrest:hamcrest-library:2.2"

--- a/src/test/java/com/github/tomakehurst/wiremock/JvmProxyConfigAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/JvmProxyConfigAcceptanceTest.java
@@ -15,9 +15,7 @@
  */
 package com.github.tomakehurst.wiremock;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -33,7 +31,13 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ClearSystemProperty;
 
+@ClearSystemProperty(key = "http.proxyHost")
+@ClearSystemProperty(key = "http.proxyPort")
+@ClearSystemProperty(key = "https.proxyHost")
+@ClearSystemProperty(key = "https.proxyPort")
+@ClearSystemProperty(key = "http.nonProxyHosts")
 public class JvmProxyConfigAcceptanceTest {
 
   WireMockServer wireMockServer;

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.ClearSystemProperty;
 
 public class ResponseTemplatingAcceptanceTest {
 
@@ -365,6 +366,7 @@ public class ResponseTemplatingAcceptanceTest {
     }
 
     @Test
+    @ClearSystemProperty(key = "allowed.thing")
     public void rendersPermittedSystemProperty() {
       System.setProperty("allowed.thing", "123");
 
@@ -377,6 +379,7 @@ public class ResponseTemplatingAcceptanceTest {
     }
 
     @Test
+    @ClearSystemProperty(key = "forbidden.thing")
     public void refusesToRenderForbiddenSystemProperty() {
       System.setProperty("forbidden.thing", "456");
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelperTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ClearSystemProperty;
 
 public class SystemValueHelperTest {
 
@@ -71,6 +72,7 @@ public class SystemValueHelperTest {
   }
 
   @Test
+  @ClearSystemProperty(key = "test.key")
   public void getAllowedPropertyShouldSuccess() throws Exception {
     helper = new SystemValueHelper(new SystemKeyAuthoriser(Set.of("test.*")));
     System.setProperty("test.key", "aaa");
@@ -81,6 +83,7 @@ public class SystemValueHelperTest {
   }
 
   @Test
+  @ClearSystemProperty(key = "test.key")
   public void getForbiddenPropertyShouldReturnError() throws Exception {
     helper = new SystemValueHelper(new SystemKeyAuthoriser(Set.of("JAVA.*")));
     System.setProperty("test.key", "aaa");


### PR DESCRIPTION
Resets system properties at end of tests that set them, preventing them affecting other tests

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [X] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
