### PR TITLE
Second attempt at fixing shaded webhooks plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ allprojects {
     mavenCentral()
   }
 
-  version = '3.0.3'
+  version = '3.0.4'
 
 
   sourceCompatibility = 11

--- a/src/main/resources/swagger/wiremock-admin-api.json
+++ b/src/main/resources/swagger/wiremock-admin-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "WireMock",
-    "version": "3.0.3"
+    "version": "3.0.4"
   },
   "externalDocs": {
     "description": "WireMock user documentation",

--- a/src/main/resources/swagger/wiremock-admin-api.yaml
+++ b/src/main/resources/swagger/wiremock-admin-api.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 
 info:
   title: WireMock
-  version: 3.0.3
+  version: 3.0.4
 
 externalDocs:
   description: WireMock user documentation

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiremock-ui-resources",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "WireMock UI resources processor",
   "engines": {
     "node": ">= 0.10.0"

--- a/wiremock-webhooks-extension/build.gradle
+++ b/wiremock-webhooks-extension/build.gradle
@@ -44,6 +44,8 @@ dependencies {
   testImplementation 'org.awaitility:awaitility:4.2.0'
 }
 
+jar.enabled = false
+
 shadowJar {
   archiveBaseName.set('wiremock-webhooks-extension')
   archiveClassifier.set('')


### PR DESCRIPTION
The attempt at fixing the Gradle build to guarantee that the shaded JAR was published in 3.0.1 seems to have failed.
This PR attempts to fix this by disabling the Gradle JAR task completely.