### PR TITLE
Add tests proving we match on request bodies

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -643,6 +643,44 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
   }
 
   @Test
+  public void matchesFormParamForGet() {
+    stubFor(
+        get(urlPathEqualTo("/form"))
+            .withFormParam("key", equalTo("value"))
+            .willReturn(aResponse().withStatus(200)));
+
+    WireMockResponse response =
+        testClient.getWithBody(
+            "/form",
+            "key=value",
+            "application/x-www-form-urlencoded",
+            TestHttpHeader.withHeader("Content-Type", "application/x-www-form-urlencoded"));
+    assertThat(response.statusCode(), is(200));
+
+    response = testClient.get("/form");
+    assertThat(response.statusCode(), is(404));
+  }
+
+  @Test
+  public void matchesFormParamForDelete() {
+    stubFor(
+        delete(urlPathEqualTo("/form"))
+            .withFormParam("key", equalTo("value"))
+            .willReturn(aResponse().withStatus(200)));
+
+    WireMockResponse response =
+        testClient.deleteWithBody(
+            "/form",
+            "key=value",
+            "application/x-www-form-urlencoded",
+            TestHttpHeader.withHeader("Content-Type", "application/x-www-form-urlencoded"));
+    assertThat(response.statusCode(), is(200));
+
+    response = testClient.delete("/form");
+    assertThat(response.statusCode(), is(404));
+  }
+
+  @Test
   public void copesWithEmptyRequestHeaderValueWhenMatchingOnEqualTo() {
     stubFor(
         get(urlPathEqualTo("/empty-header"))


### PR DESCRIPTION
For methods that do not traditionally accept bodies like GET and DELETE

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [X] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
