### PR TITLE
Print loaded extensions at startup

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -49,6 +49,7 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.stubbing.StubMappingJsonRecorder;
 import com.github.tomakehurst.wiremock.verification.*;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public class WireMockServer implements Container, Stubbing, Admin {
@@ -545,5 +546,9 @@ public class WireMockServer implements Container, Stubbing, Admin {
         throw VerificationException.forUnmatchedNearMisses(nearMisses);
       }
     }
+  }
+
+  public Set<String> getLoadedExtensionNames() {
+    return wireMockApp.getLoadedExtensionNames();
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -567,4 +567,8 @@ public class WireMockApp implements StubServer, Admin {
       }
     }
   }
+
+  public Set<String> getLoadedExtensionNames() {
+    return extensions.getAllExtensionNames();
+  }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/Extensions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/Extensions.java
@@ -177,6 +177,10 @@ public class Extensions implements WireMockServices {
     return loadedExtensions.size();
   }
 
+  public Set<String> getAllExtensionNames() {
+    return loadedExtensions.keySet();
+  }
+
   @SuppressWarnings("unchecked")
   private static Class<? extends Extension> loadClass(String className) {
     try {

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -31,6 +31,7 @@ import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import java.io.PrintStream;
+import java.util.Set;
 
 public class WireMockServerRunner {
 
@@ -96,6 +97,12 @@ public class WireMockServerRunner {
         out.println("The WireMock server is started .....");
       }
       out.println(options);
+
+      final Set<String> loadedExtensionNames = wireMockServer.getLoadedExtensionNames();
+      if (!loadedExtensionNames.isEmpty()) {
+        out.println("extensions:                   " + String.join(",", loadedExtensionNames));
+      }
+
     } catch (FatalStartupException e) {
       System.err.println(e.getMessage());
       System.exit(1);


### PR DESCRIPTION
Prints all loaded extensions in the startup info when running standalone