### PR TITLE
Update 2.x dependencies to latest patch releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,12 @@ group = 'com.github.tomakehurst'
 project.ext {
   versions = [
     handlebars     : '4.3.1',
-    jetty          : '9.4.49.v20220914',
+    jetty          : '9.4.52.v20230823',
     guava          : '31.1-jre',
-    jackson        : '2.13.4.20221013',
-    xmlUnit        : '2.9.0',
-    jsonUnit       : '2.36.0',
-    junitJupiter   : '5.9.1'
+    jackson        : '2.13.5',
+    xmlUnit        : '2.9.1',
+    jsonUnit       : '2.36.1',
+    junitJupiter   : '5.9.3'
   ]
 }
 
@@ -58,7 +58,7 @@ dependencies {
   api "com.fasterxml.jackson.core:jackson-core",
       "com.fasterxml.jackson.core:jackson-annotations",
       "com.fasterxml.jackson.core:jackson-databind"
-  api "org.apache.httpcomponents.client5:httpclient5:5.1.3"
+  api "org.apache.httpcomponents.client5:httpclient5:5.1.4"
   api "org.xmlunit:xmlunit-core:$versions.xmlUnit"
   api "org.xmlunit:xmlunit-legacy:$versions.xmlUnit", {
     exclude group: 'junit', module: 'junit'
@@ -94,7 +94,7 @@ dependencies {
   }
   api "commons-io:commons-io:2.11.0"
 
-  testImplementation "junit:junit:4.13"
+  testImplementation "junit:junit:4.13.2"
   testImplementation("org.junit.jupiter:junit-jupiter:$versions.junitJupiter")
   testImplementation("org.junit.platform:junit-platform-testkit")
   testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
@@ -111,13 +111,13 @@ dependencies {
   testImplementation 'org.awaitility:awaitility:4.2.0'
   testImplementation "com.googlecode.jarjar:jarjar:1.3"
   testImplementation "commons-io:commons-io:2.10.0"
-  testImplementation 'org.scala-lang:scala-library:2.13.10'
+  testImplementation 'org.scala-lang:scala-library:2.13.12'
   testImplementation 'com.tngtech.archunit:archunit-junit5:0.23.1'
 
   testImplementation "org.eclipse.jetty:jetty-client"
   testImplementation "org.eclipse.jetty.http2:http2-http-client-transport"
 
-  testImplementation "ch.qos.logback:logback-classic:1.3.0"
+  testImplementation "ch.qos.logback:logback-classic:1.3.11"
 
   testRuntimeOnly files('src/test/resources/classpath file source/classpathfiles.zip', 'src/test/resources/classpath-filesource.jar')
 
@@ -127,10 +127,10 @@ dependencies {
     exclude group: 'org.slf4j', module: 'slf4j-api'
     exclude group: 'io.netty', module: 'netty-all'
   }
-  testImplementation "io.netty:netty-all:4.1.84.Final"
+  testImplementation "io.netty:netty-all:4.1.97.Final"
 
   constraints {
-    implementation "net.minidev:json-smart:2.4.8", {
+    implementation "net.minidev:json-smart:2.4.11", {
       because 'Pinning this above the transitive version from json-path to get CVE fix'
     }
   }


### PR DESCRIPTION
The main motivation is to reduce the number of security dependency scanner findings. This adaptation is very conservative and only updates patch versions. It would also be conceivable to update minor versions of the dependencies. What do you think?

## References

- #2268

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
