### PR TITLE
Added a startup option to enable/disable extension scanning

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -57,7 +57,9 @@ public interface Options {
 
   int containerThreads();
 
-  /** @deprecated use {@link BrowserProxySettings#enabled()} */
+  /**
+   * @deprecated use {@link BrowserProxySettings#enabled()}
+   */
   @Deprecated
   boolean browserProxyingEnabled();
 
@@ -94,6 +96,8 @@ public interface Options {
   ThreadPoolFactory threadPoolFactory();
 
   ExtensionDeclarations getDeclaredExtensions();
+
+  boolean isExtensionScanningEnabled();
 
   WiremockNetworkTrafficListener networkTrafficListener();
 

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -109,6 +109,7 @@ public class WireMockConfiguration implements Options {
   private Long jettyIdleTimeout;
 
   private ExtensionDeclarations extensions = new ExtensionDeclarations();
+  private boolean extensionScanningEnabled = false;
   private WiremockNetworkTrafficListener networkTrafficListener =
       new DoNothingWiremockNetworkTrafficListener();
 
@@ -411,6 +412,11 @@ public class WireMockConfiguration implements Options {
     return this;
   }
 
+  public WireMockConfiguration extensionScanningEnabled(boolean enabled) {
+    this.extensionScanningEnabled = enabled;
+    return this;
+  }
+
   public WireMockConfiguration httpServerFactory(HttpServerFactory serverFactory) {
     httpServerFactory = serverFactory;
     return this;
@@ -667,6 +673,11 @@ public class WireMockConfiguration implements Options {
   @Override
   public ExtensionDeclarations getDeclaredExtensions() {
     return extensions;
+  }
+
+  @Override
+  public boolean isExtensionScanningEnabled() {
+    return extensionScanningEnabled;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/Extensions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/Extensions.java
@@ -80,12 +80,17 @@ public class Extensions implements WireMockServices {
 
     loadedExtensions.putAll(extensionDeclarations.getInstances());
 
-    loadedExtensions.putAll(
-        loadExtensionsAsServices().collect(toMap(Extension::getName, Function.identity())));
+    if (options.isExtensionScanningEnabled()) {
+      loadedExtensions.putAll(
+          loadExtensionsAsServices().collect(toMap(Extension::getName, Function.identity())));
+    }
 
     final Stream<ExtensionFactory> allFactories =
-        Stream.concat(
-            extensionDeclarations.getFactories().stream(), loadExtensionFactoriesAsServices());
+        options.isExtensionScanningEnabled()
+            ? Stream.concat(
+                extensionDeclarations.getFactories().stream(), loadExtensionFactoriesAsServices())
+            : extensionDeclarations.getFactories().stream();
+
     loadedExtensions.putAll(
         allFactories
             .map(factory -> factory.create(Extensions.this))

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -165,6 +165,11 @@ public class WarConfiguration implements Options {
   }
 
   @Override
+  public boolean isExtensionScanningEnabled() {
+    return true;
+  }
+
+  @Override
   public WiremockNetworkTrafficListener networkTrafficListener() {
     return new DoNothingWiremockNetworkTrafficListener();
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -80,6 +80,7 @@ public class CommandLineOptions implements Options {
   private static final String DISABLE_BANNER = "disable-banner";
   private static final String DISABLE_REQUEST_JOURNAL = "no-request-journal";
   private static final String EXTENSIONS = "extensions";
+  private static final String DISABLE_EXTENSION_SCANNING = "disable-extensions-scanning";
   private static final String MAX_ENTRIES_REQUEST_JOURNAL = "max-request-journal-entries";
   private static final String JETTY_ACCEPTOR_THREAD_COUNT = "jetty-acceptor-threads";
   private static final String PRINT_ALL_NETWORK_TRAFFIC = "print-all-network-traffic";
@@ -230,6 +231,9 @@ public class CommandLineOptions implements Options {
             EXTENSIONS,
             "Matching and/or response transformer extension class names, comma separated.")
         .withRequiredArg();
+    optionParser.accepts(
+        DISABLE_EXTENSION_SCANNING,
+        "Prevent extensions from being scanned and loaded from the classpath");
     optionParser
         .accepts(
             MAX_ENTRIES_REQUEST_JOURNAL,
@@ -635,6 +639,11 @@ public class CommandLineOptions implements Options {
   @Override
   public ExtensionDeclarations getDeclaredExtensions() {
     return extensions;
+  }
+
+  @Override
+  public boolean isExtensionScanningEnabled() {
+    return !optionSet.has(DISABLE_EXTENSION_SCANNING);
   }
 
   @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -403,6 +403,18 @@ public class CommandLineOptionsTest {
   }
 
   @Test
+  void extensionScanningIsEnabledByDefault() {
+    CommandLineOptions options = new CommandLineOptions();
+    assertThat(options.isExtensionScanningEnabled(), is(true));
+  }
+
+  @Test
+  void canDisableExtensionScanning() {
+    CommandLineOptions options = new CommandLineOptions("--disable-extensions-scanning");
+    assertThat(options.isExtensionScanningEnabled(), is(false));
+  }
+
+  @Test
   public void returnsAConsoleNotifyingListenerWhenOptionPresent() {
     CommandLineOptions options = new CommandLineOptions("--print-all-network-traffic");
     assertThat(


### PR DESCRIPTION
When working with the WireMock server programmatically it's usually preferable not to scan the classpath for extensions and thus load all extensions into all instances.

However, we nearly always want to scan when running standalone (this is the main use case).

This change adds a startup option to toggle this behaviour with the sensible defaults.