### PR TITLE
Enabled local response templating by default in standalone

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -92,8 +92,9 @@ public class CommandLineOptions implements Options {
   private static final String ROOT_DIR = "root-dir";
   private static final String CONTAINER_THREADS = "container-threads";
   private static final String GLOBAL_RESPONSE_TEMPLATING = "global-response-templating";
-  public static final String FILENAME_TEMPLATE = "filename-template";
   private static final String LOCAL_RESPONSE_TEMPLATING = "local-response-templating";
+  private static final String DISABLE_RESPONSE_TEMPLATING = "disable-response-templating";
+  public static final String FILENAME_TEMPLATE = "filename-template";
   private static final String ADMIN_API_BASIC_AUTH = "admin-api-basic-auth";
   private static final String ADMIN_API_REQUIRE_HTTPS = "admin-api-require-https";
   private static final String ASYNCHRONOUS_RESPONSE_ENABLED = "async-response-enabled";
@@ -265,6 +266,8 @@ public class CommandLineOptions implements Options {
     optionParser.accepts(FILENAME_TEMPLATE, "Add filename template").withRequiredArg();
     optionParser.accepts(
         LOCAL_RESPONSE_TEMPLATING, "Preprocess selected responses with Handlebars templates");
+    optionParser.accepts(
+        DISABLE_RESPONSE_TEMPLATING, "Disable processing of responses with Handlebars templates");
     optionParser
         .accepts(
             ADMIN_API_BASIC_AUTH,
@@ -926,7 +929,7 @@ public class CommandLineOptions implements Options {
 
   @Override
   public boolean getResponseTemplatingEnabled() {
-    return optionSet.has(GLOBAL_RESPONSE_TEMPLATING) || optionSet.has(LOCAL_RESPONSE_TEMPLATING);
+    return !optionSet.has(DISABLE_RESPONSE_TEMPLATING);
   }
 
   @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -418,10 +418,16 @@ public class CommandLineOptionsTest {
   }
 
   @Test
-  public void enablesLocalResponseTemplating() {
-    CommandLineOptions options = new CommandLineOptions("--local-response-templating");
+  public void enablesLocalResponseTemplatingByDefault() {
+    CommandLineOptions options = new CommandLineOptions();
     assertThat(options.getResponseTemplatingEnabled(), is(true));
     assertThat(options.getResponseTemplatingGlobal(), is(false));
+  }
+
+  @Test
+  public void canDisableTemplating() {
+    CommandLineOptions options = new CommandLineOptions("--disable-response-templating");
+    assertThat(options.getResponseTemplatingEnabled(), is(false));
   }
 
   @Test


### PR DESCRIPTION
This was intended before coming out of beta but got missed in standalone (but done when running programmatically).

There's now no significant performance gain from disabling response templating completely and since this causes a lot of confusion it makes sense to switch it on by default.
