### PR TITLE
Include more info when webhook refusal logged

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
@@ -38,6 +38,7 @@ import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.CompositeNotifier;
 import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
@@ -374,17 +375,18 @@ public class WebhooksAcceptanceViaServeEventTest {
 
   @Test
   public void doesNotFireAWebhookWhenRequestedForDeniedTarget() throws Exception {
-    rule.stubFor(
-        post(urlPathEqualTo("/webhook"))
-            .willReturn(aResponse().withStatus(200))
-            .withServeEventListener(
-                "webhook",
-                webhook()
-                    .withMethod(POST)
-                    .withUrl("http://169.254.2.34/foo")
-                    .withHeader("Content-Type", "application/json")
-                    .withHeader("X-Multi", "one", "two")
-                    .withBody("{ \"result\": \"SUCCESS\" }")));
+    StubMapping stub =
+        rule.stubFor(
+            post(urlPathEqualTo("/webhook"))
+                .willReturn(aResponse().withStatus(200))
+                .withServeEventListener(
+                    "webhook",
+                    webhook()
+                        .withMethod(POST)
+                        .withUrl("http://169.254.2.34/foo")
+                        .withHeader("Content-Type", "application/json")
+                        .withHeader("X-Multi", "one", "two")
+                        .withBody("{ \"result\": \"SUCCESS\" }")));
 
     client.post("/webhook", new StringEntity("", TEXT_PLAIN));
 
@@ -398,7 +400,10 @@ public class WebhooksAcceptanceViaServeEventTest {
         await().until(() -> testNotifier.getErrorMessages(), hasSize(greaterThanOrEqualTo(1)));
     assertThat(
         errorMessages.get(0),
-        is("The target webhook address is denied in WireMock's configuration."));
+        is(
+            "The target webhook address http://169.254.2.34/foo specified by stub "
+                + stub.getId()
+                + " is denied in WireMock's configuration."));
   }
 
   private void waitForRequestToTargetServer() throws Exception {


### PR DESCRIPTION
Otherwise, there's no context to trace it back to a stub

<!-- Please describe your pull request here. -->

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
