### PR TITLE
Fix json string schema rejecting numbers

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPattern.java
@@ -80,7 +80,7 @@ public class MatchesJsonSchemaPattern extends StringValuePattern {
       jsonNode = new TextNode(json);
     }
 
-    final Set<ValidationMessage> validationMessages = schema.validate(jsonNode);
+    final Set<ValidationMessage> validationMessages = validate(jsonNode, json);
     if (validationMessages.isEmpty()) {
       return MatchResult.exactMatch();
     }
@@ -100,5 +100,14 @@ public class MatchesJsonSchemaPattern extends StringValuePattern {
         return (double) validationMessages.size() / schemaPropertyCount;
       }
     };
+  }
+
+  private Set<ValidationMessage> validate(JsonNode jsonNode, String originalJson) {
+    final Set<ValidationMessage> validationMessages = schema.validate(jsonNode);
+    if (validationMessages.isEmpty() || jsonNode.isTextual() || jsonNode.isContainerNode()) {
+      return validationMessages;
+    } else {
+      return schema.validate(new TextNode(originalJson));
+    }
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPatternTest.java
@@ -155,7 +155,13 @@ public class MatchesJsonSchemaPatternTest {
   }
 
   private static Stream<Arguments> validStrings() {
-    return Stream.of(Arguments.of("\"12\""), Arguments.of("\"123\""), Arguments.of("\"1234\""));
+    return Stream.of(
+        Arguments.of("\"12\""),
+        Arguments.of("\"123\""),
+        Arguments.of("\"1234\""),
+        Arguments.of("12"),
+        Arguments.of("123"),
+        Arguments.of("1234"));
   }
 
   @ParameterizedTest
@@ -173,9 +179,8 @@ public class MatchesJsonSchemaPatternTest {
         Arguments.of("\"\""),
         Arguments.of("\"1\""),
         Arguments.of("\"12345\""),
-        Arguments.of("12"),
-        Arguments.of("123"),
-        Arguments.of("1234"));
+        Arguments.of("1"),
+        Arguments.of("12345"));
   }
 
   @ParameterizedTest
@@ -272,7 +277,7 @@ public class MatchesJsonSchemaPatternTest {
   }
 
   @Test
-  void corercesNumericActualValueToJsonString() {
+  void coercesNumericActualValueToJsonString() {
     String schema = file("schema-validation/stringy.schema.json");
 
     MatchesJsonSchemaPattern pattern =
@@ -281,7 +286,9 @@ public class MatchesJsonSchemaPatternTest {
     assertThat(pattern.match("abcd").isExactMatch(), is(true));
     assertThat(pattern.match("abcde").isExactMatch(), is(true));
     assertThat(pattern.match("abcdef").isExactMatch(), is(false));
-    assertThat(pattern.match("0").isExactMatch(), is(false));
+    assertThat(pattern.match("1").isExactMatch(), is(true));
+    assertThat(pattern.match("12345").isExactMatch(), is(true));
+    assertThat(pattern.match("123456").isExactMatch(), is(false));
   }
 
   private static Stream<Arguments> recursiveSchemaNonMatchingExamples() {

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
@@ -579,7 +579,15 @@ public class RequestPatternTest {
   }
 
   private static Stream<Arguments> validStrings() {
-    return Stream.of(Arguments.of("\"12\""), Arguments.of("\"123\""), Arguments.of("\"1234\""));
+    return Stream.of(
+        Arguments.of("ab"),
+        Arguments.of("\"ab\""),
+        Arguments.of("\"12\""),
+        Arguments.of("\"123\""),
+        Arguments.of("\"1234\""),
+        Arguments.of("12"),
+        Arguments.of("123"),
+        Arguments.of("1234"));
   }
 
   @ParameterizedTest
@@ -604,9 +612,8 @@ public class RequestPatternTest {
         Arguments.of("\"\""),
         Arguments.of("\"1\""),
         Arguments.of("\"12345\""),
-        Arguments.of("12"),
-        Arguments.of("123"),
-        Arguments.of("1234"));
+        Arguments.of("1"),
+        Arguments.of("12345"));
   }
 
   static final String ALL_BODY_PATTERNS_EXAMPLE =


### PR DESCRIPTION
When a path param, header value, query string etc. matcher is
`matchesJsonSchema`, and the schema requires the value to be of type
string, then at present it will be rejected if it has value `123` or
`true` or `false` because it will be considered a number or a boolean.

As these are also possible strings, try validating them as text as well.

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
