### PR TITLE
Fix FileSource backed blobstore keys bug

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/store/files/FileSourceBlobStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/files/FileSourceBlobStore.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.store.files;
 
 import com.github.tomakehurst.wiremock.common.*;
 import com.github.tomakehurst.wiremock.store.BlobStore;
+import java.io.File;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -47,7 +48,10 @@ public class FileSourceBlobStore implements BlobStore {
 
   @Override
   public Stream<String> getAllKeys() {
-    return fileSource.listFilesRecursively().stream().map(TextFile::getPath);
+    final String rootPath = new File(fileSource.getUri().getSchemeSpecificPart()).getPath();
+    return fileSource.listFilesRecursively().stream()
+        .map(TextFile::getPath)
+        .map(path -> path.substring(rootPath.length() + 1));
   }
 
   @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -19,7 +19,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalsMultiLine;
-import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.matches;
 import static java.util.Arrays.asList;
 import static net.javacrumbs.jsonunit.JsonMatchers.*;
 import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
@@ -43,7 +42,6 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.toomuchcoding.jsonassert.JsonAssertion;
 import com.toomuchcoding.jsonassert.JsonVerifiable;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -916,14 +914,8 @@ public class AdminApiTest extends AcceptanceTestBase {
 
     WireMockResponse response = testClient.get("/__admin/files");
 
-    assertEquals(200, response.statusCode());
-    String pathSeparatorRegex = File.separator;
-    if (File.separator.equals("\\")) {
-      pathSeparatorRegex = "\\\\";
-    }
-    assertThat(
-        new String(response.binaryContent()),
-        matches("\\[ \".*" + pathSeparatorRegex + "bar.txt\", \".*zoo.*txt\" ]"));
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.content(), is("[ \"bar.txt\", \"zoo.txt\" ]"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/store/files/BlobStoreFileSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/files/BlobStoreFileSourceTest.java
@@ -16,8 +16,7 @@
 package com.github.tomakehurst.wiremock.store.files;
 
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.filePath;
-import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.fileNamed;
-import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.hasExactlyIgnoringOrder;
+import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -44,21 +43,21 @@ public class BlobStoreFileSourceTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  void list_all_files() {
+  void list_all_files_returns_paths_relative_to_root_of_file_source() {
     List<TextFile> files = fileSource.listFilesRecursively();
 
     assertThat(
         files,
         hasExactlyIgnoringOrder(
-            fileNamed("one"),
-            fileNamed("two"),
-            fileNamed("three"),
-            fileNamed("four"),
-            fileNamed("five"),
-            fileNamed("six"),
-            fileNamed("seven"),
-            fileNamed("eight"),
-            fileNamed("deepfile.json")));
+            fileWithPath("one"),
+            fileWithPath("two"),
+            fileWithPath("three"),
+            fileWithPath("subdir/four"),
+            fileWithPath("subdir/five"),
+            fileWithPath("anothersubdir/six"),
+            fileWithPath("subdir/subsubdir/seven"),
+            fileWithPath("subdir/subsubdir/eight"),
+            fileWithPath("subdir/deepfile.json")));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMatchers.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMatchers.java
@@ -266,16 +266,18 @@ public class WireMatchers {
   }
 
   public static Matcher<TextFile> fileWithPath(final String path) {
+
+    String normalizedPath = path.replace('/', File.separatorChar);
     return new TypeSafeMatcher<>() {
 
       @Override
       public void describeTo(Description desc) {
-        desc.appendText("a text file with path " + path);
+        desc.appendText("a text file with path " + normalizedPath);
       }
 
       @Override
       public boolean matchesSafely(TextFile textFile) {
-        return textFile.getPath().equals(path);
+        return textFile.getPath().equals(normalizedPath);
       }
     };
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMatchers.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMatchers.java
@@ -265,6 +265,21 @@ public class WireMatchers {
     };
   }
 
+  public static Matcher<TextFile> fileWithPath(final String path) {
+    return new TypeSafeMatcher<>() {
+
+      @Override
+      public void describeTo(Description desc) {
+        desc.appendText("a text file with path " + path);
+      }
+
+      @Override
+      public boolean matchesSafely(TextFile textFile) {
+        return textFile.getPath().equals(path);
+      }
+    };
+  }
+
   public static Matcher<Date> isAfter(final String dateString) {
     return new TypeSafeMatcher<>() {
       @Override


### PR DESCRIPTION
Fixed bug where absolute rather than relative path was being used for FileSource backed blob store keys, such that attempting to retrieve the file by a listed key produced a not found error
