### PR TITLE
Favour host allow rules in network address rules

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolver.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolver.java
@@ -40,13 +40,18 @@ public class NetworkAddressRulesAdheringDnsResolver implements DnsResolver {
 
   @Override
   public InetAddress[] resolve(String host) throws UnknownHostException {
-    if (!networkAddressRules.isAllowed(host)) {
-      throw new ProhibitedNetworkAddressException();
+    var hostNameCheckResult = networkAddressRules.isAllowedHostName(host);
+
+    switch (hostNameCheckResult) {
+      case ALLOW:
+        return delegate.resolve(host);
+      case DENY:
+        throw new ProhibitedNetworkAddressException();
     }
 
     final InetAddress[] resolved = delegate.resolve(host);
     if (Stream.of(resolved)
-        .anyMatch(address -> !networkAddressRules.isAllowed(address.getHostAddress()))) {
+        .anyMatch(address -> !networkAddressRules.isAllowedIpAddress(address.getHostAddress()))) {
       throw new ProhibitedNetworkAddressException();
     }
 


### PR DESCRIPTION
If network address rules have conflicting IP deny and Host allow rules, the Host allow rule wins.

This allows blanket banning all private IP addresses, but then selectively allowing access by hostname.

This saves the configurer needing to know what IP address allowed services will resolve to.

Note - while there is no API change, the functionality has changed, that is unchanged configuration may now have different outcomes. I anticipate this will affect few if any existing users, but needs discussion.

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [X] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
