### PR TITLE
Favour host allow rules in network address rules

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.common;
 
 import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL;
+import static com.github.tomakehurst.wiremock.common.NetworkAddressRules.NetworkAddressRulesResult.*;
 import static com.github.tomakehurst.wiremock.common.NetworkAddressUtils.isValidInet4Address;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toSet;
@@ -33,6 +34,20 @@ public class NetworkAddressRules {
   private final Set<NetworkAddressRange> allowedHostPatterns;
   private final Set<NetworkAddressRange> deniedIps;
   private final Set<NetworkAddressRange> deniedHostPatterns;
+
+  private final boolean allowedHostRulesExist;
+  private final boolean hostRulesExist;
+
+  private final boolean allowedIpRulesExist;
+  private final boolean deniedIpRulesExist;
+
+  private final boolean allowedRulesExist;
+
+  public enum NetworkAddressRulesResult {
+    ALLOW,
+    NEUTRAL,
+    DENY
+  }
 
   private static final Set<NetworkAddressRange> ALL_SET = Set.of(ALL);
 
@@ -63,11 +78,20 @@ public class NetworkAddressRules {
                 networkAddressRange ->
                     (networkAddressRange instanceof NetworkAddressRange.DomainNameWildcard))
             .collect(toSet());
+
+    allowedHostRulesExist = !allowedHostPatterns.isEmpty();
+    boolean deniedHostRulesExist = !deniedHostPatterns.isEmpty();
+    hostRulesExist = allowedHostRulesExist || deniedHostRulesExist;
+
+    allowedIpRulesExist = !allowedIps.isEmpty();
+    deniedIpRulesExist = !deniedIps.isEmpty();
+
+    allowedRulesExist = allowedHostRulesExist || allowedIpRulesExist;
   }
 
-  private static <T> Set<T> defaultIfEmpty(Set<T> original, Set<T> ifEmpty) {
+  private static Set<NetworkAddressRange> allIfEmpty(Set<NetworkAddressRange> original) {
     if (original.isEmpty()) {
-      return ifEmpty;
+      return ALL_SET;
     } else {
       return original;
     }
@@ -75,13 +99,42 @@ public class NetworkAddressRules {
 
   public boolean isAllowed(String testValue) {
     if (isValidInet4Address(testValue)) {
-      return defaultIfEmpty(allowedIps, ALL_SET).stream()
-              .anyMatch(rule -> rule.isIncluded(testValue))
+      return allIfEmpty(allowedIps).stream().anyMatch(rule -> rule.isIncluded(testValue))
           && deniedIps.stream().noneMatch(rule -> rule.isIncluded(testValue));
     } else {
-      return defaultIfEmpty(allowedHostPatterns, ALL_SET).stream()
-              .anyMatch(rule -> rule.isIncluded(testValue))
+      return hostPatternAllowed(testValue)
           && deniedHostPatterns.stream().noneMatch(rule -> rule.isIncluded(testValue));
+    }
+  }
+
+  public NetworkAddressRulesResult isAllowedHostName(String testValue) {
+    if (!hostRulesExist) {
+      return NEUTRAL;
+    } else if (isValidInet4Address(testValue)) {
+      return NEUTRAL;
+    } else if (hostPatternAllowed(testValue)
+        && deniedHostPatterns.stream().noneMatch(rule -> rule.isIncluded(testValue))) {
+      return ALLOW;
+    } else {
+      return DENY;
+    }
+  }
+
+  private boolean hostPatternAllowed(String testValue) {
+    return allIfEmpty(allowedHostPatterns).stream().anyMatch(rule -> rule.isIncluded(testValue));
+  }
+
+  public boolean isAllowedIpAddress(String testValue) {
+    return ipAllowed(testValue) && deniedIps.stream().noneMatch(rule -> rule.isIncluded(testValue));
+  }
+
+  private boolean ipAllowed(String testValue) {
+    if (!allowedRulesExist) {
+      return true;
+    } else if (allowedHostRulesExist && deniedIpRulesExist && !allowedIpRulesExist) {
+      return true;
+    } else {
+      return allowedIps.stream().anyMatch(rule -> rule.isIncluded(testValue));
     }
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolver.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolver.java
@@ -40,13 +40,18 @@ public class NetworkAddressRulesAdheringDnsResolver implements DnsResolver {
 
   @Override
   public InetAddress[] resolve(String host) throws UnknownHostException {
-    if (!networkAddressRules.isAllowed(host)) {
-      throw new ProhibitedNetworkAddressException();
+    var hostNameCheckResult = networkAddressRules.isAllowedHostName(host);
+
+    switch (hostNameCheckResult) {
+      case ALLOW:
+        return delegate.resolve(host);
+      case DENY:
+        throw new ProhibitedNetworkAddressException();
     }
 
     final InetAddress[] resolved = delegate.resolve(host);
     if (Stream.of(resolved)
-        .anyMatch(address -> !networkAddressRules.isAllowed(address.getHostAddress()))) {
+        .anyMatch(address -> !networkAddressRules.isAllowedIpAddress(address.getHostAddress()))) {
       throw new ProhibitedNetworkAddressException();
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolverTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolverTest.java
@@ -274,10 +274,12 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
       })
   void resolveThrowsExceptionForHostnameWithHostnameAllowRuleAndIpDenyRule(String host)
       throws UnknownHostException {
-    register("1.example.com", "10.1.1.1");
-    register("2.example.com", "10.1.1.2");
+    register("0-0-1-1or2", "0.0.1.1", "0.0.1.2");
+    register("0-0-2-1or2", "0.0.2.1", "0.0.2.2");
+    register("0-0-1-1", "0.0.1.1");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("1.example.com").build();
+    NetworkAddressRules rules =
+        NetworkAddressRules.builder().allow("0-0-1-1or2").deny("0.0.1.0-0.0.1.255").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);

--- a/src/test/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolverTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolverTest.java
@@ -248,12 +248,14 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
       strings = {
         "0-0-1-1or2",
         "0.0.2.1",
+        "example.com",
       })
   void resolveReturnsForHostnameWithHostnameAllowRuleAndIpDenyRule(String host)
       throws UnknownHostException {
     register("0-0-1-1or2", "0.0.1.1", "0.0.1.2");
     register("0-0-2-1or2", "0.0.2.1", "0.0.2.2");
     register("0-0-1-1", "0.0.1.1");
+    register("example.com", "1.0.0.0");
 
     NetworkAddressRules rules =
         NetworkAddressRules.builder().allow("0-0-1-1or2").deny("0.0.1.0-0.0.1.255").build();
@@ -277,6 +279,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("0-0-1-1or2", "0.0.1.1", "0.0.1.2");
     register("0-0-2-1or2", "0.0.2.1", "0.0.2.2");
     register("0-0-1-1", "0.0.1.1");
+    register("example.com", "1.0.0.0");
 
     NetworkAddressRules rules =
         NetworkAddressRules.builder().allow("0-0-1-1or2").deny("0.0.1.0-0.0.1.255").build();


### PR DESCRIPTION
If network address rules have conflicting IP deny and Host allow rules, the Host allow rule wins.

This allows blanket banning all private IP addresses, but then selectively allowing access by hostname.

This saves the configurer needing to know what IP address allowed services will resolve to.

Note - while there is no API change, the functionality has changed, that is unchanged configuration may now have different outcomes. I anticipate this will affect few if any existing users, but needs discussion.

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [X] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
