### PR TITLE
Allow empty URI path segments after the first

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/jetty11/Jetty11Utils.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty11/Jetty11Utils.java
@@ -15,6 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.jetty11;
 
+import static org.eclipse.jetty.http.UriCompliance.UNSAFE;
+
 import com.github.tomakehurst.wiremock.common.JettySettings;
 import org.eclipse.jetty.io.NetworkTrafficListener;
 import org.eclipse.jetty.server.*;
@@ -63,6 +65,7 @@ public class Jetty11Utils {
     httpConfig.setSendXPoweredBy(false);
     httpConfig.setSendServerVersion(false);
     httpConfig.addCustomizer(new SecureRequestCustomizer(false));
+    httpConfig.setUriCompliance(UNSAFE);
     return httpConfig;
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/UriComplianceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/UriComplianceTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class UriComplianceTest {
+
+  @RegisterExtension
+  public WireMockExtension wireMockServer =
+      WireMockExtension.newInstance()
+          .options(options().dynamicPort())
+          .configureStaticDsl(true)
+          .build();
+
+  private WireMockTestClient testClient;
+
+  @BeforeEach
+  public void init() {
+    testClient = new WireMockTestClient(wireMockServer.getPort());
+  }
+
+  @Test
+  public void buildsMappingWithEmptySegment() {
+    givenThat(get(urlEqualTo("/my//resource")).willReturn(aResponse().withStatus(200)));
+
+    assertThat(testClient.get("/my//resource").statusCode(), is(200));
+  }
+
+  @Test
+  public void buildsMappingWithAmbiguousSegment() {
+    givenThat(get(urlPathEqualTo("/my/%2e/resource")).willReturn(aResponse().withStatus(200)));
+
+    assertThat(testClient.get("/my/%2e/resource").statusCode(), is(200));
+  }
+
+  @Test
+  public void buildsMappingWithAmbiguousPathSeparator() {
+    givenThat(get(urlPathEqualTo("/foo/b%2fr")).willReturn(aResponse().withStatus(200)));
+
+    assertThat(testClient.get("/foo/b%2fr").statusCode(), is(200));
+  }
+
+  @Test
+  public void buildsMappingWithAmbiguousPathParameter() {
+    givenThat(get(urlPathEqualTo("/foo/..;/bar")).willReturn(aResponse().withStatus(200)));
+
+    assertThat(testClient.get("/foo/..;/bar").statusCode(), is(200));
+  }
+
+  @Test
+  public void buildsMappingWithAmbiguousPathEncoding() {
+    givenThat(get(urlPathEqualTo("/%2557EB-INF")).willReturn(aResponse().withStatus(200)));
+
+    assertThat(testClient.get("/%2557EB-INF").statusCode(), is(200));
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
@@ -70,11 +70,4 @@ public class WireMockClientAcceptanceTest {
     assertThat(
         testClient.get("/my/new/resource").content(), is("{\"address\":\"Puerto Banús, Málaga\"}"));
   }
-
-  @Test
-  public void buildsMappingWithEmptySegment() {
-    givenThat(get(urlEqualTo("/my//resource")).willReturn(aResponse().withStatus(200)));
-
-    assertThat(testClient.get("/my//resource").statusCode(), is(200));
-  }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Thomas Akehurst
+ * Copyright (C) 2011-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,5 +69,12 @@ public class WireMockClientAcceptanceTest {
 
     assertThat(
         testClient.get("/my/new/resource").content(), is("{\"address\":\"Puerto Banús, Málaga\"}"));
+  }
+
+  @Test
+  public void buildsMappingWithEmptySegment() {
+    givenThat(get(urlEqualTo("/my//resource")).willReturn(aResponse().withStatus(200)));
+
+    assertThat(testClient.get("/my//resource").statusCode(), is(200));
   }
 }


### PR DESCRIPTION
[RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3) disallows an empty segment for the _first_ segment of the path, but permits it in any remaining segments.

Jetty 9+ is stricter by default, disallowing _all_ empty segments.

We can revert to the older behaviour, allowing more general mocking, by setting Jetty's `UriCompliance` to `UNSAFE`.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
