### PR TITLE
allow file names in mappings to end in .json5

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -191,6 +192,11 @@ public abstract class AbstractFileSource implements FileSource {
   }
 
   public static Predicate<BinaryFile> byFileExtension(final String extension) {
-    return input -> input.name().endsWith("." + extension);
+    return inputFile -> inputFile.name().endsWith("." + extension);
+  }
+
+  public static Predicate<BinaryFile> byFileExtensions(final Collection<String> extensions) {
+    return inputFile ->
+        extensions.stream().anyMatch(extension -> byFileExtension(extension).test(inputFile));
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/ContentTypes.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/ContentTypes.java
@@ -59,6 +59,8 @@ public class ContentTypes {
   public static final List<String> TEXT_FILE_EXTENSIONS =
       asList("txt", "json", "xml", "html", "htm", "yaml", "csv");
 
+  public static final List<String> JSON_FILE_EXTENSIONS = asList("json", "json5");
+
   public static final List<String> TEXT_MIME_TYPE_PATTERNS =
       asList(
           ".*text.*",

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSource.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.standalone;
 
-import static com.github.tomakehurst.wiremock.common.AbstractFileSource.byFileExtension;
+import static com.github.tomakehurst.wiremock.common.AbstractFileSource.byFileExtensions;
 import static com.github.tomakehurst.wiremock.common.Json.writePrivate;
 
 import com.github.tomakehurst.wiremock.common.*;
@@ -106,7 +106,7 @@ public class JsonFileMappingsSource implements MappingsSource {
 
     List<TextFile> mappingFiles =
         mappingsFileSource.listFilesRecursively().stream()
-            .filter(byFileExtension("json"))
+            .filter(byFileExtensions(ContentTypes.JSON_FILE_EXTENSIONS))
             .collect(Collectors.toList());
     for (TextFile mappingFile : mappingFiles) {
       try {

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/RemoteMappingsLoader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/RemoteMappingsLoader.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.standalone;
 
-import static com.github.tomakehurst.wiremock.common.AbstractFileSource.byFileExtension;
+import static com.github.tomakehurst.wiremock.common.AbstractFileSource.byFileExtensions;
 import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
 import static com.github.tomakehurst.wiremock.core.WireMockApp.MAPPINGS_ROOT;
 import static org.apache.commons.lang3.StringUtils.substringAfterLast;
@@ -50,7 +50,7 @@ public class RemoteMappingsLoader {
   public void load() {
     List<TextFile> mappingFiles =
         mappingsFileSource.listFilesRecursively().stream()
-            .filter(byFileExtension("json"))
+            .filter(byFileExtensions(ContentTypes.JSON_FILE_EXTENSIONS))
             .collect(Collectors.toList());
     for (TextFile mappingFile : mappingFiles) {
       try {

--- a/src/test/java/com/github/tomakehurst/wiremock/MappingsLoaderAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MappingsLoaderAcceptanceTest.java
@@ -78,6 +78,14 @@ public class MappingsLoaderAcceptanceTest {
   }
 
   @Test
+  public void json5MappingsLoadedViaClasspath() {
+    buildWireMock(configuration.usingFilesUnderClasspath("classpath-filesource"));
+    WireMockResponse json5Response = testClient.get("/json5_test");
+    assertThat(json5Response.content(), is("json5 testing"));
+    assertThat(json5Response.statusCode(), is(200));
+  }
+
+  @Test
   public void loadsStubMappingsFromAMixtureOfSingleAndMultiStubFiles() {
     buildWireMock(configuration);
     wireMockServer.resetMappings();

--- a/src/test/resources/classpath-filesource/mappings/subdir/new.json5
+++ b/src/test/resources/classpath-filesource/mappings/subdir/new.json5
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/json5_test"
+  },
+  "response": {
+    // a JSON comment, which is only allowed in JSON5
+    "body": 'json5 testing', // a property in single quotes
+    "status": 200
+  }
+}

--- a/src/test/resources/remoteloader/mappings/one.json5
+++ b/src/test/resources/remoteloader/mappings/one.json5
@@ -1,6 +1,7 @@
 {
   "request": {"url": "/remote-load/1"},
   "response": {
+    // a json5 comment
     "body": "Remote load 1",
     "status": 200
   }


### PR DESCRIPTION
Addresses #2397.
WireMock already supports json5, but files ending in extensions other than `json` are ignored. I've changed this behavior to also load json5 files, both from remote and local sources.

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
