### PR TITLE
Do not use deprecated jackson iso8601 class

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/admin/Conversions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/Conversions.java
@@ -15,11 +15,12 @@
  */
 package com.github.tomakehurst.wiremock.admin;
 
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
+
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 public class Conversions {
@@ -30,7 +31,7 @@ public class Conversions {
 
   public static Date toDate(QueryParameter parameter) {
     try {
-      return parameter.isPresent() ? new ISO8601DateFormat().parse(parameter.firstValue()) : null;
+      return parameter.isPresent() ? new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(parameter.firstValue()) : null;
     } catch (ParseException e) {
       throw new InvalidInputException(
           Errors.validation(

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/Conversions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/Conversions.java
@@ -18,8 +18,8 @@ package com.github.tomakehurst.wiremock.admin;
 import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 
 public class Conversions {
@@ -31,9 +31,9 @@ public class Conversions {
   public static Date toDate(QueryParameter parameter) {
     try {
       return parameter.isPresent()
-          ? new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(parameter.firstValue())
+          ? Date.from(ZonedDateTime.parse(parameter.firstValue()).toInstant())
           : null;
-    } catch (ParseException e) {
+    } catch (DateTimeParseException e) {
       throw new InvalidInputException(
           Errors.validation(
               parameter.key(), parameter.firstValue() + " is not a valid ISO8601 date"));

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/Conversions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/Conversions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.github.tomakehurst.wiremock.admin;
 import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
-
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -31,7 +30,9 @@ public class Conversions {
 
   public static Date toDate(QueryParameter parameter) {
     try {
-      return parameter.isPresent() ? new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(parameter.firstValue()) : null;
+      return parameter.isPresent()
+          ? new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(parameter.firstValue())
+          : null;
     } catch (ParseException e) {
       throw new InvalidInputException(
           Errors.validation(

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Dates.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Dates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-
-import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 
 public class Dates {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Dates.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Dates.java
@@ -17,21 +17,23 @@ package com.github.tomakehurst.wiremock.common;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 
 public class Dates {
 
   public static Date parse(String dateString) {
     try {
-      return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(dateString);
-    } catch (ParseException e) {
+      return Date.from(ZonedDateTime.parse(dateString).toInstant());
+    } catch (DateTimeParseException e) {
       return throwUnchecked(e, Date.class);
     }
   }
 
   public static String format(Date date) {
-    return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(date);
+    return DateTimeFormatter.ISO_ZONED_DATE_TIME.format(date.toInstant().atZone(ZoneId.of("Z")));
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Dates.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Dates.java
@@ -15,24 +15,23 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
-
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
-import com.fasterxml.jackson.databind.util.ISO8601Utils;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 
 public class Dates {
 
   public static Date parse(String dateString) {
     try {
-      return new ISO8601DateFormat().parse(dateString);
+      return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(dateString);
     } catch (ParseException e) {
       return throwUnchecked(e, Date.class);
     }
   }
 
   public static String format(Date date) {
-    return ISO8601Utils.format(date);
+    return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(date);
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -260,7 +260,7 @@ public class AdminApiTest extends AcceptanceTestBase {
       testClient.get("/received-request/" + i);
     }
 
-    String midPoint = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'").format(new Date());
+    String midPoint = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(new Date());
 
     for (int i = 6; i <= 9; i++) {
       testClient.get("/received-request/" + i);

--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -15,6 +15,20 @@
  */
 package com.github.tomakehurst.wiremock;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalsMultiLine;
+import static java.util.Arrays.asList;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartEquals;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartMatches;
+import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.common.Json;
@@ -29,15 +43,6 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.toomuchcoding.jsonassert.JsonAssertion;
 import com.toomuchcoding.jsonassert.JsonVerifiable;
-import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
-import org.hamcrest.TypeSafeMatcher;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -46,20 +51,14 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
-import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
-import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalsMultiLine;
-import static java.util.Arrays.asList;
-import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartEquals;
-import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartMatches;
-import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 public class AdminApiTest extends AcceptanceTestBase {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -15,19 +15,6 @@
  */
 package com.github.tomakehurst.wiremock;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
-import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
-import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalsMultiLine;
-import static java.util.Arrays.asList;
-import static net.javacrumbs.jsonunit.JsonMatchers.*;
-import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.common.Json;
@@ -42,13 +29,6 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.toomuchcoding.jsonassert.JsonAssertion;
 import com.toomuchcoding.jsonassert.JsonVerifiable;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -57,6 +37,29 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalsMultiLine;
+import static java.util.Arrays.asList;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartEquals;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonPartMatches;
+import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class AdminApiTest extends AcceptanceTestBase {
 
@@ -258,7 +261,7 @@ public class AdminApiTest extends AcceptanceTestBase {
       testClient.get("/received-request/" + i);
     }
 
-    String midPoint = new ISO8601DateFormat().format(new Date());
+    String midPoint = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'").format(new Date());
 
     for (int i = 6; i <= 9; i++) {
       testClient.get("/received-request/" + i);

--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -46,8 +46,9 @@ import com.toomuchcoding.jsonassert.JsonVerifiable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -260,7 +261,8 @@ public class AdminApiTest extends AcceptanceTestBase {
       testClient.get("/received-request/" + i);
     }
 
-    String midPoint = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(new Date());
+    String midPoint =
+        DateTimeFormatter.ISO_ZONED_DATE_TIME.format(Instant.now().atZone(ZoneId.of("Z")));
 
     for (int i = 6; i <= 9; i++) {
       testClient.get("/received-request/" + i);

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/ConversionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/ConversionsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016-2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.admin;
+
+import com.github.tomakehurst.wiremock.common.InvalidInputException;
+import com.github.tomakehurst.wiremock.http.QueryParameter;
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ConversionsTest {
+
+    @Test
+    void mapsValidFirstParameterValueAsDate() {
+        // given
+        var queryParameter = new QueryParameter("since", List.of("2023-10-07T00:00:00Z"));
+        var expected = new GregorianCalendar(2023, Calendar.OCTOBER, 7).getTime();
+
+        // when
+        var result = Conversions.toDate(queryParameter);
+
+        // then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void throwsExceptionWhenFirstParameterValueIsInvalidDate() {
+        // given
+        var queryParameter = new QueryParameter("since", List.of("invalid"));
+
+        // when + then
+        assertThrows(InvalidInputException.class, () -> Conversions.toDate(queryParameter));
+    }
+
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/ConversionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/ConversionsTest.java
@@ -20,8 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +33,8 @@ public class ConversionsTest {
   void mapsValidFirstParameterValueAsDate() {
     // given
     var queryParameter = new QueryParameter("since", List.of("2023-10-07T00:00:00Z"));
-    var expected = new GregorianCalendar(2023, Calendar.OCTOBER, 7).getTime();
+    var expected =
+        Date.from(LocalDate.of(2023, Month.OCTOBER, 7).atStartOfDay(ZoneId.of("UTC")).toInstant());
 
     // when
     var result = Conversions.toDate(queryParameter);

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/ConversionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/ConversionsTest.java
@@ -15,39 +15,37 @@
  */
 package com.github.tomakehurst.wiremock.admin;
 
-import com.github.tomakehurst.wiremock.common.InvalidInputException;
-import com.github.tomakehurst.wiremock.http.QueryParameter;
-import org.junit.jupiter.api.Test;
-
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-import java.util.List;
-
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.github.tomakehurst.wiremock.common.InvalidInputException;
+import com.github.tomakehurst.wiremock.http.QueryParameter;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
 public class ConversionsTest {
 
-    @Test
-    void mapsValidFirstParameterValueAsDate() {
-        // given
-        var queryParameter = new QueryParameter("since", List.of("2023-10-07T00:00:00Z"));
-        var expected = new GregorianCalendar(2023, Calendar.OCTOBER, 7).getTime();
+  @Test
+  void mapsValidFirstParameterValueAsDate() {
+    // given
+    var queryParameter = new QueryParameter("since", List.of("2023-10-07T00:00:00Z"));
+    var expected = new GregorianCalendar(2023, Calendar.OCTOBER, 7).getTime();
 
-        // when
-        var result = Conversions.toDate(queryParameter);
+    // when
+    var result = Conversions.toDate(queryParameter);
 
-        // then
-        assertThat(result).isEqualTo(expected);
-    }
+    // then
+    assertThat(result).isEqualTo(expected);
+  }
 
-    @Test
-    void throwsExceptionWhenFirstParameterValueIsInvalidDate() {
-        // given
-        var queryParameter = new QueryParameter("since", List.of("invalid"));
+  @Test
+  void throwsExceptionWhenFirstParameterValueIsInvalidDate() {
+    // given
+    var queryParameter = new QueryParameter("since", List.of("invalid"));
 
-        // when + then
-        assertThrows(InvalidInputException.class, () -> Conversions.toDate(queryParameter));
-    }
-
+    // when + then
+    assertThrows(InvalidInputException.class, () -> Conversions.toDate(queryParameter));
+  }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeOffsetTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeOffsetTest.java
@@ -19,15 +19,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import org.junit.jupiter.api.Test;
 
 public class DateTimeOffsetTest {
-
-  static final DateFormat ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
   @Test
   public void parsesSecondsOffset() {
@@ -113,10 +111,12 @@ public class DateTimeOffsetTest {
   @Test
   public void offsetsProvidedDateByConfiguredAmount() throws Exception {
     DateTimeOffset offset = DateTimeOffset.fromString("3 days");
-    Date startingDate = ISO8601.parse("2018-04-16T12:01:01Z");
+    Date startingDate = Date.from(ZonedDateTime.parse("2018-04-16T12:01:01Z").toInstant());
     Date finalDate = offset.shift(startingDate);
 
-    assertThat(ISO8601.format(finalDate), is("2018-04-19T12:01:01Z"));
+    assertThat(
+        DateTimeFormatter.ISO_ZONED_DATE_TIME.format(finalDate.toInstant().atZone(ZoneId.of("Z"))),
+        is("2018-04-19T12:01:01Z"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeOffsetTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeOffsetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Thomas Akehurst
+ * Copyright (C) 2018-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,15 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import org.junit.jupiter.api.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
 import java.util.Date;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 public class DateTimeOffsetTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeOffsetTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeOffsetTest.java
@@ -15,19 +15,20 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
+import org.junit.jupiter.api.Test;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
-import java.text.DateFormat;
-import java.time.ZonedDateTime;
-import java.util.Date;
-import org.junit.jupiter.api.Test;
-
 public class DateTimeOffsetTest {
 
-  static final DateFormat ISO8601 = new ISO8601DateFormat();
+  static final DateFormat ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
   @Test
   public void parsesSecondsOffset() {

--- a/src/test/java/com/github/tomakehurst/wiremock/common/DatesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/DatesTest.java
@@ -1,48 +1,62 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.tomakehurst.wiremock.common;
-
-import org.junit.jupiter.api.Test;
-
-import java.text.ParseException;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.text.ParseException;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import org.junit.jupiter.api.Test;
+
 public class DatesTest {
 
-    @Test
-    void mapsValidInputAsDate() {
-        // given
-        var input = "2023-10-07T00:00:00Z";
-        var expected = new GregorianCalendar(2023, Calendar.OCTOBER, 7).getTime();
+  @Test
+  void mapsValidInputAsDate() {
+    // given
+    var input = "2023-10-07T00:00:00Z";
+    var expected = new GregorianCalendar(2023, Calendar.OCTOBER, 7).getTime();
 
-        // when
-        var result = Dates.parse(input);
+    // when
+    var result = Dates.parse(input);
 
-        // then
-        assertThat(result).isEqualTo(expected);
-    }
+    // then
+    assertThat(result).isEqualTo(expected);
+  }
 
-    @Test
-    void throwsExceptionWhenMappingInvalidInput() {
-        // given
-        var input = "invalid";
+  @Test
+  void throwsExceptionWhenMappingInvalidInput() {
+    // given
+    var input = "invalid";
 
-        // when + then
-        assertThrows(ParseException.class, () -> Dates.parse(input));
-    }
+    // when + then
+    assertThrows(ParseException.class, () -> Dates.parse(input));
+  }
 
-    @Test
-    void parseDateToTextualDate() {
-        // given
-        var input = "2023-10-07T00:00:00Z";
-        var expected = new GregorianCalendar(2023, Calendar.OCTOBER, 7).getTime();
+  @Test
+  void parseDateToTextualDate() {
+    // given
+    var input = "2023-10-07T00:00:00Z";
+    var expected = new GregorianCalendar(2023, Calendar.OCTOBER, 7).getTime();
 
-        // when
-        var result = Dates.parse(input);
+    // when
+    var result = Dates.parse(input);
 
-        // then
-        assertThat(result).isEqualTo(expected);
-    }
+    // then
+    assertThat(result).isEqualTo(expected);
+  }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/common/DatesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/DatesTest.java
@@ -1,0 +1,48 @@
+package com.github.tomakehurst.wiremock.common;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.ParseException;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DatesTest {
+
+    @Test
+    void mapsValidInputAsDate() {
+        // given
+        var input = "2023-10-07T00:00:00Z";
+        var expected = new GregorianCalendar(2023, Calendar.OCTOBER, 7).getTime();
+
+        // when
+        var result = Dates.parse(input);
+
+        // then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void throwsExceptionWhenMappingInvalidInput() {
+        // given
+        var input = "invalid";
+
+        // when + then
+        assertThrows(ParseException.class, () -> Dates.parse(input));
+    }
+
+    @Test
+    void parseDateToTextualDate() {
+        // given
+        var input = "2023-10-07T00:00:00Z";
+        var expected = new GregorianCalendar(2023, Calendar.OCTOBER, 7).getTime();
+
+        // when
+        var result = Dates.parse(input);
+
+        // then
+        assertThat(result).isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/common/DatesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/DatesTest.java
@@ -18,9 +18,11 @@ package com.github.tomakehurst.wiremock.common;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.text.ParseException;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.util.Date;
 import org.junit.jupiter.api.Test;
 
 public class DatesTest {
@@ -29,7 +31,8 @@ public class DatesTest {
   void mapsValidInputAsDate() {
     // given
     var input = "2023-10-07T00:00:00Z";
-    var expected = new GregorianCalendar(2023, Calendar.OCTOBER, 7).getTime();
+    var expected =
+        Date.from(LocalDate.of(2023, Month.OCTOBER, 7).atStartOfDay(ZoneId.of("UTC")).toInstant());
 
     // when
     var result = Dates.parse(input);
@@ -44,14 +47,15 @@ public class DatesTest {
     var input = "invalid";
 
     // when + then
-    assertThrows(ParseException.class, () -> Dates.parse(input));
+    assertThrows(DateTimeParseException.class, () -> Dates.parse(input));
   }
 
   @Test
   void parseDateToTextualDate() {
     // given
     var input = "2023-10-07T00:00:00Z";
-    var expected = new GregorianCalendar(2023, Calendar.OCTOBER, 7).getTime();
+    var expected =
+        Date.from(LocalDate.of(2023, Month.OCTOBER, 7).atStartOfDay(ZoneId.of("UTC")).toInstant());
 
     // when
     var result = Dates.parse(input);

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
@@ -15,6 +15,20 @@
  */
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
+import com.github.jknack.handlebars.Options;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.common.LocalNotifier;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HandlebarsHelperTestBase.transform;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
@@ -22,20 +36,6 @@ import static com.github.tomakehurst.wiremock.testsupport.ExtensionFactoryUtils.
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
-import com.github.jknack.handlebars.Options;
-import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
-import com.github.tomakehurst.wiremock.common.LocalNotifier;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
-import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 public class HandlebarsCurrentDateHelperTest {
 
@@ -111,25 +111,25 @@ public class HandlebarsCurrentDateHelperTest {
   }
 
   @Test
-  public void adjustsISO8601ToSpecfiedTimezone() throws Exception {
+  public void adjustsISO8601ToSpecifiedTimezone() throws Exception {
     Map<String, Object> optionsHash = Map.of("offset", "3 days", "timezone", "Australia/Sydney");
 
-    Date inputDate = new ISO8601DateFormat().parse("2014-10-09T06:06:01Z");
+    Date inputDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'").parse("2023-10-07T00:00:00.00Z");
     Object output = render(inputDate, optionsHash);
 
-    assertThat(output.toString(), is("2014-10-12T17:06:01+11:00"));
+    assertThat(output.toString(), is("2023-10-10T00:00:00+11:00"));
   }
 
   @Test
-  public void adjustsCustomFormatToSpecfiedTimezone() throws Exception {
+  public void adjustsCustomFormatToSpecifiedTimezone() throws Exception {
     Map<String, Object> optionsHash =
         Map.of(
             "offset", "3 days", "timezone", "Australia/Sydney", "format", "yyyy-MM-dd HH:mm:ssZ");
 
-    Date inputDate = new ISO8601DateFormat().parse("2014-10-09T06:06:01Z");
+    Date inputDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'").parse("2023-10-07T00:00:00.00Z");
     Object output = render(inputDate, optionsHash);
 
-    assertThat(output.toString(), is("2014-10-12 17:06:01+1100"));
+    assertThat(output.toString(), is("2023-10-10 00:00:00+1100"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
@@ -15,20 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
-import com.github.jknack.handlebars.Options;
-import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
-import com.github.tomakehurst.wiremock.common.LocalNotifier;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
-import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Map;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HandlebarsHelperTestBase.transform;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
@@ -36,6 +22,19 @@ import static com.github.tomakehurst.wiremock.testsupport.ExtensionFactoryUtils.
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+
+import com.github.jknack.handlebars.Options;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.common.LocalNotifier;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HandlebarsCurrentDateHelperTest {
 
@@ -114,7 +113,8 @@ public class HandlebarsCurrentDateHelperTest {
   public void adjustsISO8601ToSpecifiedTimezone() throws Exception {
     Map<String, Object> optionsHash = Map.of("offset", "3 days", "timezone", "Australia/Sydney");
 
-    Date inputDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'").parse("2023-10-07T00:00:00.00Z");
+    Date inputDate =
+        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'").parse("2023-10-07T00:00:00.00Z");
     Object output = render(inputDate, optionsHash);
 
     assertThat(output.toString(), is("2023-10-10T00:00:00+11:00"));
@@ -126,7 +126,8 @@ public class HandlebarsCurrentDateHelperTest {
         Map.of(
             "offset", "3 days", "timezone", "Australia/Sydney", "format", "yyyy-MM-dd HH:mm:ssZ");
 
-    Date inputDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'").parse("2023-10-07T00:00:00.00Z");
+    Date inputDate =
+        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'").parse("2023-10-07T00:00:00.00Z");
     Object output = render(inputDate, optionsHash);
 
     assertThat(output.toString(), is("2023-10-10 00:00:00+1100"));

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
@@ -15,10 +15,9 @@
  */
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
-import com.github.jknack.handlebars.Options;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.jknack.handlebars.Options;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -27,8 +26,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Map;
 import java.util.TimeZone;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ParseDateHelperTest {
   private ParseDateHelper helper;
@@ -47,7 +46,6 @@ public class ParseDateHelperTest {
 
     DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
     df.setTimeZone(TimeZone.getTimeZone("CEST"));
-
 
     Date expectedDate = df.parse(inputDate);
     assertThat(output).isInstanceOf(Date.class);

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
@@ -19,13 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.jknack.handlebars.Options;
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Map;
-import java.util.TimeZone;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,10 +42,7 @@ public class ParseDateHelperTest {
     String inputDate = "2018-05-01T01:02:03Z";
     Object output = render(inputDate, optionsHash);
 
-    DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-    df.setTimeZone(TimeZone.getTimeZone("CEST"));
-
-    Date expectedDate = df.parse(inputDate);
+    Date expectedDate = Date.from(ZonedDateTime.parse(inputDate).toInstant());
     assertThat(output).isInstanceOf(Date.class);
     assertThat(output).isEqualTo(expectedDate);
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseDateHelperTest.java
@@ -15,24 +15,22 @@
  */
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.github.jknack.handlebars.Options;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ParseDateHelperTest {
-
-  private static final DateFormat df = new ISO8601DateFormat();
-
   private ParseDateHelper helper;
 
   @BeforeEach
@@ -47,9 +45,13 @@ public class ParseDateHelperTest {
     String inputDate = "2018-05-01T01:02:03Z";
     Object output = render(inputDate, optionsHash);
 
+    DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    df.setTimeZone(TimeZone.getTimeZone("CEST"));
+
+
     Date expectedDate = df.parse(inputDate);
-    assertThat(output, instanceOf(Date.class));
-    assertThat(((Date) output), is((expectedDate)));
+    assertThat(output).isInstanceOf(Date.class);
+    assertThat(output).isEqualTo(expectedDate);
   }
 
   @Test
@@ -61,8 +63,8 @@ public class ParseDateHelperTest {
 
     Date expectedDate =
         Date.from(Instant.from(DateTimeFormatter.RFC_1123_DATE_TIME.parse(inputDate)));
-    assertThat(output, instanceOf(Date.class));
-    assertThat(((Date) output), is(expectedDate));
+    assertThat(output).isInstanceOf(Date.class);
+    assertThat(output).isEqualTo(expectedDate);
   }
 
   @Test
@@ -73,8 +75,8 @@ public class ParseDateHelperTest {
     Object output = render(inputDate, optionsHash);
 
     Date expectedDate = Date.from(Instant.parse("2003-02-01T00:00:00Z"));
-    assertThat(output, instanceOf(Date.class));
-    assertThat(((Date) output), is((expectedDate)));
+    assertThat(output).isInstanceOf(Date.class);
+    assertThat(output).isEqualTo(expectedDate);
   }
 
   @Test
@@ -85,8 +87,8 @@ public class ParseDateHelperTest {
     Object output = render(inputDate, optionsHash);
 
     Date expectedDate = Date.from(Instant.parse("2003-02-01T05:06:07Z"));
-    assertThat(output, instanceOf(Date.class));
-    assertThat(((Date) output), is((expectedDate)));
+    assertThat(output).isInstanceOf(Date.class);
+    assertThat(output).isEqualTo(expectedDate);
   }
 
   @Test
@@ -97,8 +99,8 @@ public class ParseDateHelperTest {
     Object output = render(inputDate, optionsHash);
 
     Date expectedDate = Date.from(Instant.parse("2020-01-02T11:21:31Z"));
-    assertThat(output, instanceOf(Date.class));
-    assertThat(((Date) output), is((expectedDate)));
+    assertThat(output).isInstanceOf(Date.class);
+    assertThat(output).isEqualTo(expectedDate);
   }
 
   private Object render(String context, Map<String, Object> optionsHash) throws IOException {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The currently used Jackson ISO8601 class is deprecated

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, maake sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
