### PR TITLE
Add BEFORE_RESPONSE_SENT request phase to the stub-mapping schema

### DIFF
--- a/src/main/resources/swagger/schemas/stub-mapping.yaml
+++ b/src/main/resources/swagger/schemas/stub-mapping.yaml
@@ -47,6 +47,7 @@ properties:
             enum:
               - BEFORE_MATCH
               - AFTER_MATCH
+              - BEFORE_RESPONSE_SENT
               - AFTER_COMPLETE
         parameters:
           type: object


### PR DESCRIPTION
I added the `BEFORE_RESPONSE_SENT` enum value to the stub-mapping schema as a possible serveEventListener request phase.

The related PR that added support for this was merged back in August, so it was missing from the schema.

## References

- https://github.com/wiremock/wiremock/issues/2294
- https://github.com/wiremock/wiremock/pull/2295

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, maake sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
