### PR TITLE
feat: add helper to generate fake data using data-faker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,8 @@ dependencies {
 
   api 'com.networknt:json-schema-validator:1.0.87'
 
+  implementation 'net.datafaker:datafaker:2.0.2'
+
   testImplementation "junit:junit:4.13"
   testImplementation("org.junit.jupiter:junit-jupiter:$versions.junitJupiter")
   testImplementation("org.junit.platform:junit-platform-testkit")

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RandomHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RandomHelper.java
@@ -1,0 +1,20 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.github.jknack.handlebars.Options;
+import net.datafaker.Faker;
+
+import java.io.IOException;
+
+public class RandomHelper extends HandlebarsHelper<Object> {
+
+    @Override
+    public Object apply(Object context, Options options) throws IOException {
+        System.out.println(context.toString() + options.toString());
+        Faker faker = new Faker();
+        try {
+            return faker.expression("#{" + context + "}");
+        } catch (RuntimeException e) {
+            return handleError("Unable to evaluate the expression " + context, e);
+        }
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RandomHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RandomHelper.java
@@ -9,7 +9,6 @@ public class RandomHelper extends HandlebarsHelper<Object> {
 
     @Override
     public Object apply(Object context, Options options) throws IOException {
-        System.out.println(context.toString() + options.toString());
         Faker faker = new Faker();
         try {
             return faker.expression("#{" + context + "}");

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
@@ -232,5 +232,14 @@ public enum WireMockHelpers implements Helper<Object> {
     public Object apply(Object context, Options options) throws IOException {
       return helper.apply(context, options);
     }
+  },
+
+  random {
+    private final RandomHelper helper = new RandomHelper();
+
+    @Override
+    public Object apply(Object context, Options options) throws IOException {
+      return helper.apply(context, options);
+    }
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RandomHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RandomHelperTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2021-2022 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class RandomHelperTest extends HandlebarsHelperTestBase {
+
+  RandomHelper helper;
+
+  @BeforeEach
+  public void init() {
+    helper = new RandomHelper();
+  }
+
+  @Test
+  public void rendersAMeaningfulErrorWhenExpressionIsInvalid() {
+    testHelperError(
+            helper,
+            "something really random",
+            "umm",
+            is("[ERROR: Unable to evaluate the expression something really random]"));
+  }
+
+  @Test
+  public void returnsRandomValue() throws Exception {
+    assertThat(renderHelperValue(helper, "Name.first_name"), is(any(String.class)));
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RandomHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RandomHelperTest.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2021-2022 Thomas Akehurst
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
This helper will enable users to add fake, random data to their stub responses.

- Used https://github.com/datafaker-net/datafaker instead of https://github.com/DiUS/java-faker (as mentioned in the issue) as the former is a maintained fork of the latter.
- Used the `expression` method instead of `resolve` (as suggested in the issue) as the `resolve` method is not able to resolve nested references in the yml files. For example, in the [resource file for en-US](https://github.com/datafaker-net/datafaker/blob/main/src/main/resources/en-US.yml), `address.full_address` wasn't resolving because of the `#{street_address}` nested reference, but `address.postcode_by_state.AL` would work fine. `expression` is able to handle all cases.

<!-- Please describe your pull request here. -->

## References

Closes https://github.com/wiremock/wiremock/issues/2412

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, maake sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
