### PR TITLE
Implement Get or Head method

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -26,6 +26,8 @@ import com.github.tomakehurst.wiremock.admin.model.SingleStubMappingResult;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
+import com.github.tomakehurst.wiremock.common.Errors;
+import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
@@ -559,6 +561,15 @@ public class WireMock {
 
   public static MappingBuilder head(UrlPattern urlPattern) {
     return new BasicMappingBuilder(RequestMethod.HEAD, urlPattern);
+  }
+
+  public static MappingBuilder getOrHead(String method, UrlPattern urlPattern) {
+    if (RequestMethod.GET.getName().equals(method)) {
+      return new BasicMappingBuilder(RequestMethod.GET, urlPattern);
+    } else if (RequestMethod.HEAD.getName().equals(method)) {
+      return new BasicMappingBuilder(RequestMethod.HEAD, urlPattern);
+    }
+    throw new InvalidInputException(Errors.single(51, method + " is not a valid http method"));
   }
 
   public static MappingBuilder options(UrlPattern urlPattern) {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
@@ -33,7 +33,7 @@ public class RequestMethod implements NamedValueMatcher<RequestMethod> {
   public static final RequestMethod HEAD = new RequestMethod("HEAD");
   public static final RequestMethod TRACE = new RequestMethod("TRACE");
   public static final RequestMethod ANY = new RequestMethod("ANY");
-
+  public static final RequestMethod GET_OR_HEAD = new RequestMethod("GET_OR_HEAD");
   private final String name;
 
   public RequestMethod(String name) {


### PR DESCRIPTION
Implemented `GET_OR_HEAD` method as the requested issue. Feedback is welcome as this is my first contribution here, might need to change a few things.
#2414 


## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, maake sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

