### PR TITLE
feat: use expression lambdas over statement lambdas

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ssl/CompositeTrustManager.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ssl/CompositeTrustManager.java
@@ -68,59 +68,41 @@ class CompositeTrustManager extends X509ExtendedTrustManager {
   @Override
   public void checkClientTrusted(final X509Certificate[] chain, final String authType)
       throws CertificateException {
-    checkAllTrustManagers(
-        tm -> {
-          tm.checkClientTrusted(chain, authType);
-        });
+    checkAllTrustManagers(tm -> tm.checkClientTrusted(chain, authType));
   }
 
   @Override
   public void checkServerTrusted(final X509Certificate[] chain, final String authType)
       throws CertificateException {
-    checkAllTrustManagers(
-        tm -> {
-          tm.checkServerTrusted(chain, authType);
-        });
+    checkAllTrustManagers(tm -> tm.checkServerTrusted(chain, authType));
   }
 
   @Override
   public void checkClientTrusted(
       final X509Certificate[] chain, final String authType, final Socket socket)
       throws CertificateException {
-    checkAllTrustManagers(
-        tm -> {
-          tm.checkClientTrusted(chain, authType, socket);
-        });
+    checkAllTrustManagers(tm -> tm.checkClientTrusted(chain, authType, socket));
   }
 
   @Override
   public void checkServerTrusted(
       final X509Certificate[] chain, final String authType, final Socket socket)
       throws CertificateException {
-    checkAllTrustManagers(
-        tm -> {
-          tm.checkServerTrusted(chain, authType, socket);
-        });
+    checkAllTrustManagers(tm -> tm.checkServerTrusted(chain, authType, socket));
   }
 
   @Override
   public void checkClientTrusted(
       final X509Certificate[] chain, final String authType, final SSLEngine engine)
       throws CertificateException {
-    checkAllTrustManagers(
-        tm -> {
-          tm.checkClientTrusted(chain, authType, engine);
-        });
+    checkAllTrustManagers(tm -> tm.checkClientTrusted(chain, authType, engine));
   }
 
   @Override
   public void checkServerTrusted(
       final X509Certificate[] chain, final String authType, final SSLEngine engine)
       throws CertificateException {
-    checkAllTrustManagers(
-        tm -> {
-          tm.checkServerTrusted(chain, authType, engine);
-        });
+    checkAllTrustManagers(tm -> tm.checkServerTrusted(chain, authType, engine));
   }
 
   @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/CustomMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CustomMatchingAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Thomas Akehurst
+ * Copyright (C) 2015-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,12 +115,11 @@ public class CustomMatchingAcceptanceTest {
   public void throwsExecptionIfInlineCustomMatcherUsedWithRemote() {
     assertThrows(
         AdminException.class,
-        () -> {
-          wm.register(
-              get(urlPathMatching("/the/.*/one"))
-                  .andMatching(new MyRequestMatcher())
-                  .willReturn(ok()));
-        });
+        () ->
+            wm.register(
+                get(urlPathMatching("/the/.*/one"))
+                    .andMatching(new MyRequestMatcher())
+                    .willReturn(ok())));
   }
 
   public static class MyRequestMatcher extends RequestMatcherExtension {

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
@@ -344,12 +344,11 @@ public class HttpsBrowserProxyAcceptanceTest {
   public void failsIfCaKeystorePathIsNotAKeystore() throws IOException {
     assertThrows(
         IOException.class,
-        () -> {
-          new WireMockServer(
-              options()
-                  .enableBrowserProxying(true)
-                  .caKeystorePath(Files.createTempFile("notakeystore", "jks").toString()));
-        });
+        () ->
+            new WireMockServer(
+                options()
+                    .enableBrowserProxying(true)
+                    .caKeystorePath(Files.createTempFile("notakeystore", "jks").toString())));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/PortNumberTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/PortNumberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Thomas Akehurst
+ * Copyright (C) 2011-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,18 +77,14 @@ public class PortNumberTest {
   public void unstartedServerThrowsExceptionWhenAttemptingToRetrievePort() {
     assertThrows(
         IllegalStateException.class,
-        () -> {
-          createServer(wireMockConfig().port(Network.findFreePort())).port();
-        });
+        () -> createServer(wireMockConfig().port(Network.findFreePort())).port());
   }
 
   @Test
   public void unstartedServerThrowsExceptionWhenAttemptingToRetrieveHttpsPort() {
     assertThrows(
         IllegalStateException.class,
-        () -> {
-          createServer(wireMockConfig().httpsPort(Network.findFreePort())).httpsPort();
-        });
+        () -> createServer(wireMockConfig().httpsPort(Network.findFreePort())).httpsPort());
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionTransformerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionTransformerAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Thomas Akehurst
+ * Copyright (C) 2014-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,12 +134,11 @@ public class ResponseDefinitionTransformerAcceptanceTest {
   public void preventsMoreThanOneExtensionWithTheSameNameFromBeingAdded() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> {
-          new WireMockServer(
-              wireMockConfig()
-                  .dynamicPort()
-                  .extensions(ExampleTransformer.class, AnotherExampleTransformer.class));
-        });
+        () ->
+            new WireMockServer(
+                wireMockConfig()
+                    .dynamicPort()
+                    .extensions(ExampleTransformer.class, AnotherExampleTransformer.class)));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionTransformerV2AcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionTransformerV2AcceptanceTest.java
@@ -131,15 +131,14 @@ public class ResponseDefinitionTransformerV2AcceptanceTest {
   public void preventsMoreThanOneExtensionWithTheSameNameFromBeingAdded() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> {
-          new WireMockServer(
-                  wireMockConfig()
-                      .dynamicPort()
-                      .extensions(ExampleTransformer.class)
-                      .extensions(
-                          "com.github.tomakehurst.wiremock.ResponseDefinitionTransformerV2AcceptanceTest$AnotherExampleTransformer"))
-              .start();
-        });
+        () ->
+            new WireMockServer(
+                    wireMockConfig()
+                        .dynamicPort()
+                        .extensions(ExampleTransformer.class)
+                        .extensions(
+                            "com.github.tomakehurst.wiremock.ResponseDefinitionTransformerV2AcceptanceTest$AnotherExampleTransformer"))
+                .start());
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
@@ -108,9 +108,7 @@ public class ScenarioAcceptanceTest extends AcceptanceTestBase {
   public void settingScenarioNameToNullCausesException() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> {
-          get(urlEqualTo("/some/resource")).willReturn(aResponse()).inScenario(null);
-        });
+        () -> get(urlEqualTo("/some/resource")).willReturn(aResponse()).inScenario(null));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -1030,18 +1030,14 @@ public class VerificationAcceptanceTest {
     public void verifyThrowsExceptionWhenVerificationAttemptedAndRequestJournalDisabled() {
       assertThrows(
           RequestJournalDisabledException.class,
-          () -> {
-            verify(getRequestedFor(urlEqualTo("/whatever")));
-          });
+          () -> verify(getRequestedFor(urlEqualTo("/whatever"))));
     }
 
     @Test
     public void findAllThrowsExceptionWhenVerificationAttemptedAndRequestJournalDisabled() {
       assertThrows(
           RequestJournalDisabledException.class,
-          () -> {
-            findAll(getRequestedFor(urlEqualTo("/whatever")));
-          });
+          () -> findAll(getRequestedFor(urlEqualTo("/whatever"))));
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockJUnitRuleTest.java
@@ -267,10 +267,7 @@ public class WireMockJUnitRuleTest {
     @Test
     public void requestReceivedByListener() {
       final List<String> urls = new ArrayList<String>();
-      wireMockRule.addMockServiceRequestListener(
-          (request, response) -> {
-            urls.add(request.getUrl());
-          });
+      wireMockRule.addMockServiceRequestListener((request, response) -> urls.add(request.getUrl()));
       wireMockRule.stubFor(
           get(urlEqualTo("/test/listener")).willReturn(aResponse().withBody("Listener")));
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeOffsetTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeOffsetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Thomas Akehurst
+ * Copyright (C) 2018-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,19 +121,11 @@ public class DateTimeOffsetTest {
 
   @Test
   public void throwsExceptionWhenUnparseableStringProvided() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          DateTimeOffset.fromString("101");
-        });
+    assertThrows(IllegalArgumentException.class, () -> DateTimeOffset.fromString("101"));
   }
 
   @Test
   public void throwsExceptionWhenUnparseableUnitProvided() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          DateTimeOffset.fromString("101 squillions");
-        });
+    assertThrows(IllegalArgumentException.class, () -> DateTimeOffset.fromString("101 squillions"));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/common/ServletContextFileSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/ServletContextFileSourceTest.java
@@ -63,9 +63,7 @@ public class ServletContextFileSourceTest {
   public void throwsUnsupportedExceptionWhenAttemptingToWrite() {
     assertThrows(
         UnsupportedOperationException.class,
-        () -> {
-          fileSource.writeTextFile("filename", "filecontents");
-        });
+        () -> fileSource.writeTextFile("filename", "filecontents"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
@@ -76,9 +76,7 @@ public class ContentTypeHeaderTest {
   public void throwsExceptionOnAttemptToSetNullHeaderValue() {
     assertThrows(
         NullPointerException.class,
-        () -> {
-          new MockRequestBuilder().withHeader("Content-Type", null).build();
-        });
+        () -> new MockRequestBuilder().withHeader("Content-Type", null).build());
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeaderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Thomas Akehurst
+ * Copyright (C) 2012-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,20 +59,12 @@ public class HttpHeaderTest {
 
   @Test
   public void throwsExceptionWhenAttemptingToAccessFirstValueWhenAbsent() {
-    assertThrows(
-        IllegalStateException.class,
-        () -> {
-          HttpHeader.absent("Something").firstValue();
-        });
+    assertThrows(IllegalStateException.class, () -> HttpHeader.absent("Something").firstValue());
   }
 
   @Test
   public void throwsExceptionWhenAttemptingToAccessValuesWhenAbsent() {
-    assertThrows(
-        IllegalStateException.class,
-        () -> {
-          HttpHeader.absent("Something").values();
-        });
+    assertThrows(IllegalStateException.class, () -> HttpHeader.absent("Something").values());
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CompositeTrustManagerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CompositeTrustManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Thomas Akehurst
+ * Copyright (C) 2020-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,9 +58,7 @@ public class CompositeTrustManagerTest {
     CertificateException thrown =
         assertThrows(
             CertificateException.class,
-            () -> {
-              compositeTrustManager.checkServerTrusted(chain, authType);
-            });
+            () -> compositeTrustManager.checkServerTrusted(chain, authType));
     assertEquals(invalidCertForTrustManager1, thrown);
   }
 
@@ -116,9 +114,7 @@ public class CompositeTrustManagerTest {
     CertificateException thrown =
         assertThrows(
             CertificateException.class,
-            () -> {
-              compositeTrustManager.checkServerTrusted(chain, authType);
-            });
+            () -> compositeTrustManager.checkServerTrusted(chain, authType));
 
     assertEquals(invalidCertForTrustManager2, thrown);
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
@@ -376,16 +376,15 @@ public class MatchesJsonPathPatternTest {
   public void throwsSensibleErrorOnDeserialisationWhenPatternIsBadlyFormedWithMissingExpression() {
     assertThrows(
         JsonException.class,
-        () -> {
-          Json.read(
-              "{                                      \n"
-                  + "    \"matchesJsonPath\": {              \n"
-                  + "        \"express\": \"$..thing\",      \n"
-                  + "        \"equalTo\": \"the value\"      \n"
-                  + "    }                                   \n"
-                  + "}",
-              StringValuePattern.class);
-        });
+        () ->
+            Json.read(
+                "{                                      \n"
+                    + "    \"matchesJsonPath\": {              \n"
+                    + "        \"express\": \"$..thing\",      \n"
+                    + "        \"equalTo\": \"the value\"      \n"
+                    + "    }                                   \n"
+                    + "}",
+                StringValuePattern.class));
   }
 
   @Test
@@ -393,16 +392,15 @@ public class MatchesJsonPathPatternTest {
       throwsSensibleErrorOnDeserialisationWhenPatternIsBadlyFormedWithBadValuePatternName() {
     assertThrows(
         JsonException.class,
-        () -> {
-          Json.read(
-              "{                                      \n"
-                  + "    \"matchesJsonPath\": {              \n"
-                  + "        \"expression\": \"$..thing\",   \n"
-                  + "        \"badOperator\": \"the value\"  \n"
-                  + "    }                                   \n"
-                  + "}",
-              StringValuePattern.class);
-        });
+        () ->
+            Json.read(
+                "{                                      \n"
+                    + "    \"matchesJsonPath\": {              \n"
+                    + "        \"expression\": \"$..thing\",   \n"
+                    + "        \"badOperator\": \"the value\"  \n"
+                    + "    }                                   \n"
+                    + "}",
+                StringValuePattern.class));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotOutputFormatterTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotOutputFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,9 +32,7 @@ public class SnapshotOutputFormatterTest {
   public void fromStringWithInvalidFormat() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> {
-          SnapshotOutputFormatter.fromString("invalid output format");
-        });
+        () -> SnapshotOutputFormatter.fromString("invalid output format"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -163,11 +163,7 @@ public class CommandLineOptionsTest {
 
   @Test
   public void throwsExceptionWhenPortNumberSpecifiedWithoutNumber() {
-    assertThrows(
-        Exception.class,
-        () -> {
-          new CommandLineOptions("--port");
-        });
+    assertThrows(Exception.class, () -> new CommandLineOptions("--port"));
   }
 
   @Test
@@ -193,11 +189,7 @@ public class CommandLineOptionsTest {
 
   @Test
   public void throwsExceptionWhenProxyAllSpecifiedWithoutUrl() {
-    assertThrows(
-        Exception.class,
-        () -> {
-          new CommandLineOptions("--proxy-all");
-        });
+    assertThrows(Exception.class, () -> new CommandLineOptions("--proxy-all"));
   }
 
   @Test
@@ -372,9 +364,7 @@ public class CommandLineOptionsTest {
   public void preventsRecordingWhenRequestJournalDisabled() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> {
-          new CommandLineOptions("--no-request-journal", "--record-mappings");
-        });
+        () -> new CommandLineOptions("--no-request-journal", "--record-mappings"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/ProxySettingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/ProxySettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Thomas Akehurst
+ * Copyright (C) 2013-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,11 +26,7 @@ public class ProxySettingsTest {
 
   @Test
   public void throwsExceptionWhenHostPartNotSpecified() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          ProxySettings.fromString(":8090");
-        });
+    assertThrows(IllegalArgumentException.class, () -> ProxySettings.fromString(":8090"));
   }
 
   @Test

--- a/src/test/java/ignored/Examples.java
+++ b/src/test/java/ignored/Examples.java
@@ -161,20 +161,17 @@ public class Examples extends AcceptanceTestBase {
   public void verifyWithoutHeader() {
     assertThrows(
         VerificationException.class,
-        () -> {
-          verify(putRequestedFor(urlEqualTo("/without/header")).withoutHeader("Content-Type"));
-        });
+        () -> verify(putRequestedFor(urlEqualTo("/without/header")).withoutHeader("Content-Type")));
   }
 
   @Test
   public void verifyWithoutQueryParam() {
     assertThrows(
         VerificationException.class,
-        () -> {
-          verify(
-              getRequestedFor(urlPathEqualTo("without/queryParam"))
-                  .withoutQueryParam("test-param"));
-        });
+        () ->
+            verify(
+                getRequestedFor(urlPathEqualTo("without/queryParam"))
+                    .withoutQueryParam("test-param")));
   }
 
   @Test


### PR DESCRIPTION
Replaces basic statement lambdas with expression ones.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
