### PR TITLE
Add parsing for multi-valued query params in non standard format - Resolves #2224 [#hacktoberfest]

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Thomas Akehurst
+ * Copyright (C) 2014-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,38 @@ public class UrlsTest {
     assertThat(params.size(), is(2));
     assertThat(params.get("param1").isSingleValued(), is(false));
     assertThat(params.get("param1").values(), hasItems("1", "2", "3"));
+  }
+
+  @Test
+  public void supportsMultiValuedParametersInArrayFormat() {
+    params = Urls.splitQuery("param1[0]=1&param1[1]=2&param1[2]=3&param1[3]=4");
+    assertThat(params.size(), is(1));
+    assertThat(params.get("param1").isSingleValued(), is(false));
+    assertThat(params.get("param1").values(), hasItems("1", "2", "3", "4"));
+  }
+
+  @Test
+  public void supportsMultiValuedParametersInArrayIndexFormat() {
+    params = Urls.splitQuery("param1=['1','2','3','4']");
+    assertThat(params.size(), is(1));
+    assertThat(params.get("param1").isSingleValued(), is(false));
+    assertThat(params.get("param1").values(), hasItems("1", "2", "3", "4"));
+  }
+
+  @Test
+  public void supportsMultiValuedParametersWithPipeSeparator() {
+    params = Urls.splitQuery("param1=1|2|3|4");
+    assertThat(params.size(), is(1));
+    assertThat(params.get("param1").isSingleValued(), is(false));
+    assertThat(params.get("param1").values(), hasItems("1", "2", "3", "4"));
+  }
+
+  @Test
+  public void supportsMultiValuedParametersWithCommaSeparator() {
+    params = Urls.splitQuery("param1=1,2,3,4");
+    assertThat(params.size(), is(1));
+    assertThat(params.get("param1").isSingleValued(), is(false));
+    assertThat(params.get("param1").values(), hasItems("1", "2", "3", "4"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -739,7 +739,7 @@ public class ResponseTemplateTransformerTest {
     String body =
         transform(
                 mockRequest().url("/stuff?things[1]=one&things[2]=two&things[3]=three"),
-                ok("{{lookup request.query 'things[2]'}}"))
+                ok("{{lookup request.query 'things.[2]'}}"))
             .getBody();
 
     assertThat(body, is("two"));


### PR DESCRIPTION
Description:

This PR adds parsing for query params in non standard format. It will be able to parse following non-standard multi-valued query parameter formats along with standard one.

?id[0]=1&id[1]=2&id[2]=3
?id=1,2,3
?id=1|2|3
?id=[1,2,3]

## References
https://github.com/wiremock/wiremock/issues/2224

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected

#hacktoberfest