### PR TITLE
Resolves #618 - Add ability to name specific wiremock instance

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import org.apache.commons.lang3.StringUtils;
 
 public interface Options {
 
@@ -46,6 +47,10 @@ public interface Options {
   int DEFAULT_TIMEOUT = 300_000;
   int DEFAULT_CONTAINER_THREADS = 25;
   String DEFAULT_BIND_ADDRESS = "0.0.0.0";
+
+  String DEFAULT_SERVER_NAME = StringUtils.EMPTY;
+
+  String getServerName();
 
   int portNumber();
 

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -61,6 +61,8 @@ public class WireMockConfiguration implements Options {
 
   private long asyncResponseTimeout = DEFAULT_TIMEOUT;
   private boolean disableOptimizeXmlFactoriesLoading = false;
+
+  private String serverName = DEFAULT_SERVER_NAME;
   private int portNumber = DEFAULT_PORT;
   private boolean httpDisabled = false;
   private String bindAddress = DEFAULT_BIND_ADDRESS;
@@ -168,6 +170,12 @@ public class WireMockConfiguration implements Options {
 
   public WireMockConfiguration timeout(int timeout) {
     this.asyncResponseTimeout = timeout;
+    return this;
+  }
+
+  public WireMockConfiguration serverName(String serverName) {
+
+    this.serverName = serverName;
     return this;
   }
 
@@ -541,6 +549,12 @@ public class WireMockConfiguration implements Options {
   public WireMockConfiguration withMaxTemplateCacheEntries(Long maxTemplateCacheEntries) {
     this.maxTemplateCacheEntries = maxTemplateCacheEntries;
     return this;
+  }
+
+  @Override
+  public String getServerName() {
+
+    return serverName;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -50,6 +50,12 @@ public class WarConfiguration implements Options {
   }
 
   @Override
+  public String getServerName() {
+
+    return DEFAULT_SERVER_NAME;
+  }
+
+  @Override
   public int portNumber() {
     return 0;
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -64,6 +64,8 @@ public class CommandLineOptions implements Options {
   private static final String PROXY_VIA = "proxy-via";
   private static final String TIMEOUT = "timeout";
   private static final String PORT = "port";
+
+  private static final String SERVER_NAME = "server-name";
   private static final String DISABLE_HTTP = "disable-http";
   private static final String BIND_ADDRESS = "bind-address";
   private static final String HTTPS_PORT = "https-port";
@@ -137,6 +139,7 @@ public class CommandLineOptions implements Options {
 
   public CommandLineOptions(String... args) {
     OptionParser optionParser = new OptionParser();
+    optionParser.accepts(SERVER_NAME, "Name of wiremock server instance").withRequiredArg();
     optionParser
         .accepts(
             PORT,
@@ -505,6 +508,19 @@ public class CommandLineOptions implements Options {
     return optionSet.has(PORT);
   }
 
+  private boolean specifiesServerName() {
+    return optionSet.has(SERVER_NAME);
+  }
+
+  @Override
+  public String getServerName() {
+
+    if (specifiesServerName()) {
+      return (String) optionSet.valueOf(SERVER_NAME);
+    }
+    return DEFAULT_SERVER_NAME;
+  }
+
   @Override
   public int portNumber() {
     if (specifiesPortNumber()) {
@@ -718,7 +734,7 @@ public class CommandLineOptions implements Options {
 
   @Override
   public Notifier notifier() {
-    return new ConsoleNotifier(verboseLoggingEnabled());
+    return new ConsoleNotifier(getServerName(), verboseLoggingEnabled());
   }
 
   @Override


### PR DESCRIPTION
Added ability to name specific wiremock instance.
## References
https://github.com/wiremock/wiremock/issues/618

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org]
