### PR TITLE
Fixed #2415 Gradle replaces SLF4J-API 1.7.36 with 2.0.7, causing warning in the log

### DIFF
--- a/src/main/resources/META-INF/services/wiremock.org.slf4j.spi.SLF4JServiceProvider
+++ b/src/main/resources/META-INF/services/wiremock.org.slf4j.spi.SLF4JServiceProvider
@@ -1,0 +1,1 @@
+wiremock.org.slf4j.helpers.NOP_FallbackServiceProvider


### PR DESCRIPTION
I tested it locally in a Maven project.
I had the warning before the fix, not after.
I'm not sure how to perform unit testing on it, though...

