### PR TITLE
Replace Optional.orElse() calls with Optional.orElseGet()

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -75,7 +75,7 @@ public class WireMockServer implements Container, Stubbing, Admin {
     HttpServerFactory httpServerFactory =
         wireMockApp.getExtensions().ofType(HttpServerFactory.class).values().stream()
             .findFirst()
-            .orElse(options.httpServerFactory());
+            .orElseGet(options::httpServerFactory);
 
     httpServer =
         httpServerFactory.buildHttpServer(

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
@@ -126,7 +126,7 @@ public class AdminRoutes {
         .filter(entry -> entry.getKey().matches(method, path))
         .map(Entry::getValue)
         .findFirst()
-        .orElse(new NotFoundAdminTask());
+        .orElseGet(NotFoundAdminTask::new);
   }
 
   public RequestSpec requestSpecForTask(final Class<? extends AdminTask> taskClass) {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
@@ -81,7 +81,7 @@ public abstract class AbstractFileSource implements FileSource {
   }
 
   private void recursivelyAddFilesToList(File root, List<File> fileList) {
-    File[] files = Optional.ofNullable(root.listFiles()).orElse(new File[0]);
+    File[] files = Optional.ofNullable(root.listFiles()).orElseGet(() -> new File[0]);
     for (File file : files) {
       if (file.isDirectory()) {
         recursivelyAddFilesToList(file, fileList);

--- a/src/main/java/com/github/tomakehurst/wiremock/common/ClasspathFileSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/ClasspathFileSource.java
@@ -159,7 +159,7 @@ public class ClasspathFileSource implements FileSource {
   }
 
   private void recursivelyAddFilesToList(File root, List<File> fileList) {
-    File[] files = Optional.ofNullable(root.listFiles()).orElse(new File[0]);
+    File[] files = Optional.ofNullable(root.listFiles()).orElseGet(() -> new File[0]);
     for (File file : files) {
       if (file.isDirectory()) {
         recursivelyAddFilesToList(file, fileList);

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -198,7 +198,7 @@ public class WireMockExtension extends DslWrapper
                     ? AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class)
                     : Optional.empty())
         .map(this::buildOptionsFromWireMockTestAnnotation)
-        .orElse(Optional.ofNullable(this.options).orElse(defaultOptions));
+        .orElseGet(() -> Optional.ofNullable(this.options).orElse(defaultOptions));
   }
 
   private Options buildOptionsFromWireMockTestAnnotation(WireMockTest annotation) {

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
@@ -105,7 +105,7 @@ public class MatchesJsonPathPattern extends PathPattern {
 
       return matchResults.stream()
           .min(Comparator.comparingDouble(MatchResult::getDistance))
-          .orElse(MatchResult.noMatch(subEvents));
+          .orElseGet(() -> MatchResult.noMatch(subEvents));
     } catch (SubExpressionException e) {
       return MatchResult.noMatch(SubEvent.warning(e.getMessage()));
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -264,7 +264,7 @@ public class RequestPattern implements NamedValueMatcher<Request> {
                     return cookie.getValues().stream()
                         .map(cookiePattern::match)
                         .max(Comparator.naturalOrder())
-                        .orElse(MatchResult.noMatch());
+                        .orElseGet(MatchResult::noMatch);
                   })
               .collect(toList()));
     }


### PR DESCRIPTION
Replaced `Optional.orElse()` calls with `Optional.orElseGet()` where it was applicable, so that dynamic values are evaluated lazily, and only when needed.

## References

#2442 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
