### PR TITLE
Substitutable HTTP client

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/DefaultNetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/DefaultNetworkAddressRules.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2022-2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.common;
+
+import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL;
+import static com.github.tomakehurst.wiremock.common.NetworkAddressUtils.isValidInet4Address;
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class DefaultNetworkAddressRules implements NetworkAddressRules {
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private final Set<NetworkAddressRange> allowed;
+  private final Set<NetworkAddressRange> allowedHostPatterns;
+  private final Set<NetworkAddressRange> denied;
+  private final Set<NetworkAddressRange> deniedHostPatterns;
+
+  public static final NetworkAddressRules ALLOW_ALL =
+      new DefaultNetworkAddressRules(Set.of(ALL), emptySet());
+
+  public DefaultNetworkAddressRules(
+      Set<NetworkAddressRange> allowed, Set<NetworkAddressRange> denied) {
+    this.allowed =
+        defaultIfEmpty(
+            allowed.stream()
+                .filter(
+                    networkAddressRange ->
+                        !(networkAddressRange instanceof NetworkAddressRange.DomainNameWildcard))
+                .collect(toSet()),
+            Set.of(ALL));
+    this.allowedHostPatterns =
+        defaultIfEmpty(
+            allowed.stream()
+                .filter(
+                    networkAddressRange ->
+                        (networkAddressRange instanceof NetworkAddressRange.DomainNameWildcard))
+                .collect(toSet()),
+            Set.of(ALL));
+    this.denied =
+        denied.stream()
+            .filter(
+                networkAddressRange ->
+                    !(networkAddressRange instanceof NetworkAddressRange.DomainNameWildcard))
+            .collect(toSet());
+    this.deniedHostPatterns =
+        denied.stream()
+            .filter(
+                networkAddressRange ->
+                    (networkAddressRange instanceof NetworkAddressRange.DomainNameWildcard))
+            .map(
+                networkAddressRange -> (NetworkAddressRange.DomainNameWildcard) networkAddressRange)
+            .collect(toSet());
+  }
+
+  private static <T> Set<T> defaultIfEmpty(Set<T> original, Set<T> ifEmpty) {
+    if (original.isEmpty()) {
+      return ifEmpty;
+    } else {
+      return original;
+    }
+  }
+
+  @Override
+  public boolean isAllowed(String testValue) {
+    if (isValidInet4Address(testValue)) {
+      return allowed.stream().anyMatch(rule -> rule.isIncluded(testValue))
+          && denied.stream().noneMatch(rule -> rule.isIncluded(testValue));
+    } else {
+      return allowedHostPatterns.stream().anyMatch(rule -> rule.isIncluded(testValue))
+          && deniedHostPatterns.stream().noneMatch(rule -> rule.isIncluded(testValue));
+    }
+  }
+
+  public static class Builder {
+    private final Set<NetworkAddressRange> allowed = new HashSet<>();
+    private final Set<NetworkAddressRange> denied = new HashSet<>();
+
+    public Builder allow(String expression) {
+      allowed.add(NetworkAddressRange.of(expression));
+      return this;
+    }
+
+    public Builder deny(String expression) {
+      denied.add(NetworkAddressRange.of(expression));
+      return this;
+    }
+
+    public NetworkAddressRules build() {
+      Set<NetworkAddressRange> allowedRanges = allowed;
+      if (allowedRanges.isEmpty()) {
+        allowedRanges = Set.of(ALL);
+      }
+      return new DefaultNetworkAddressRules(Set.copyOf(allowedRanges), Set.copyOf(denied));
+    }
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Lazy.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Lazy.java
@@ -13,22 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.tomakehurst.wiremock.http.client;
+package com.github.tomakehurst.wiremock.common;
 
-import com.github.tomakehurst.wiremock.core.Options;
-import com.github.tomakehurst.wiremock.extension.Extension;
-import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
-public interface HttpClientFactory extends Extension {
+public class Lazy<T> {
 
-  @Override
-  default String getName() {
-    return "http-client-factory";
+  public static <T> Lazy<T> lazy(Supplier<T> supplier) {
+    return new Lazy<>(supplier);
   }
 
-  HttpClient buildHttpClient(
-      Options options,
-      boolean trustAllCertificates,
-      List<String> trustedHosts,
-      boolean useSystemProperties);
+  private final Supplier<T> supplier;
+  private final AtomicReference<T> ref = new AtomicReference<>();
+
+  private Lazy(Supplier<T> supplier) {
+    this.supplier = supplier;
+  }
+
+  public T get() {
+    return ref.updateAndGet(existing -> existing == null ? supplier.get() : existing);
+  }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Thomas Akehurst
+ * Copyright (C) 2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,99 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL;
-import static com.github.tomakehurst.wiremock.common.NetworkAddressUtils.isValidInet4Address;
-import static java.util.Collections.emptySet;
-import static java.util.stream.Collectors.toSet;
-
-import java.util.HashSet;
-import java.util.Set;
-
-public class NetworkAddressRules {
-
-  public static Builder builder() {
-    return new Builder();
-  }
-
-  private final Set<NetworkAddressRange> allowed;
-  private final Set<NetworkAddressRange> allowedHostPatterns;
-  private final Set<NetworkAddressRange> denied;
-  private final Set<NetworkAddressRange> deniedHostPatterns;
-
-  public static final NetworkAddressRules ALLOW_ALL =
-      new NetworkAddressRules(Set.of(ALL), emptySet());
-
-  public NetworkAddressRules(Set<NetworkAddressRange> allowed, Set<NetworkAddressRange> denied) {
-    this.allowed =
-        defaultIfEmpty(
-            allowed.stream()
-                .filter(
-                    networkAddressRange ->
-                        !(networkAddressRange instanceof NetworkAddressRange.DomainNameWildcard))
-                .collect(toSet()),
-            Set.of(ALL));
-    this.allowedHostPatterns =
-        defaultIfEmpty(
-            allowed.stream()
-                .filter(
-                    networkAddressRange ->
-                        (networkAddressRange instanceof NetworkAddressRange.DomainNameWildcard))
-                .collect(toSet()),
-            Set.of(ALL));
-    this.denied =
-        denied.stream()
-            .filter(
-                networkAddressRange ->
-                    !(networkAddressRange instanceof NetworkAddressRange.DomainNameWildcard))
-            .collect(toSet());
-    this.deniedHostPatterns =
-        denied.stream()
-            .filter(
-                networkAddressRange ->
-                    (networkAddressRange instanceof NetworkAddressRange.DomainNameWildcard))
-            .map(
-                networkAddressRange -> (NetworkAddressRange.DomainNameWildcard) networkAddressRange)
-            .collect(toSet());
-  }
-
-  private static <T> Set<T> defaultIfEmpty(Set<T> original, Set<T> ifEmpty) {
-    if (original.isEmpty()) {
-      return ifEmpty;
-    } else {
-      return original;
-    }
-  }
-
-  public boolean isAllowed(String testValue) {
-    if (isValidInet4Address(testValue)) {
-      return allowed.stream().anyMatch(rule -> rule.isIncluded(testValue))
-          && denied.stream().noneMatch(rule -> rule.isIncluded(testValue));
-    } else {
-      return allowedHostPatterns.stream().anyMatch(rule -> rule.isIncluded(testValue))
-          && deniedHostPatterns.stream().noneMatch(rule -> rule.isIncluded(testValue));
-    }
-  }
-
-  public static class Builder {
-    private final Set<NetworkAddressRange> allowed = new HashSet<>();
-    private final Set<NetworkAddressRange> denied = new HashSet<>();
-
-    public Builder allow(String expression) {
-      allowed.add(NetworkAddressRange.of(expression));
-      return this;
-    }
-
-    public Builder deny(String expression) {
-      denied.add(NetworkAddressRange.of(expression));
-      return this;
-    }
-
-    public NetworkAddressRules build() {
-      Set<NetworkAddressRange> allowedRanges = allowed;
-      if (allowedRanges.isEmpty()) {
-        allowedRanges = Set.of(ALL);
-      }
-      return new NetworkAddressRules(Set.copyOf(allowedRanges), Set.copyOf(denied));
-    }
-  }
+public interface NetworkAddressRules {
+  boolean isAllowed(String testValue);
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Urls.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Urls.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.util.*;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 
 public class Urls {
 
@@ -74,6 +75,14 @@ public class Urls {
     return url.contains("?") ? url.substring(0, url.indexOf("?")) : url;
   }
 
+  public static String getPathAndQuery(String url) {
+    return isAbsolute(url) ? url.substring(StringUtils.ordinalIndexOf(url, "/", 3)) : url;
+  }
+
+  private static boolean isAbsolute(String url) {
+    return url.matches("^https?:\\/\\/.*");
+  }
+
   public static List<String> getPathSegments(String path) {
     return List.of(path.split("/"));
   }
@@ -101,6 +110,7 @@ public class Urls {
   }
 
   // Workaround for a Jetty bug that appends "null" onto the end of the URL
+
   private static String clean(String url) {
     return url.matches(".*:[0-9]+null$") ? url.substring(0, url.length() - 4) : url;
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.extension.Extensions;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.HttpServerFactory;
 import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
+import com.github.tomakehurst.wiremock.http.client.HttpClientFactory;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.security.Authenticator;
 import com.github.tomakehurst.wiremock.standalone.MappingsLoader;
@@ -92,6 +93,8 @@ public interface Options {
   String proxyHostHeader();
 
   HttpServerFactory httpServerFactory();
+
+  HttpClientFactory httpClientFactory();
 
   ThreadPoolFactory threadPoolFactory();
 

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -134,6 +134,10 @@ public interface Options {
 
   int proxyTimeout();
 
+  default int getMaxHttpClientConnections() {
+    return 1000;
+  }
+
   boolean getResponseTemplatingEnabled();
 
   boolean getResponseTemplatingGlobal();

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -196,27 +196,15 @@ public class WireMockApp implements StubServer, Admin {
             .orElse(options.httpClientFactory());
 
     final HttpClient reverseProxyClient =
-        httpClientFactory.buildHttpClient(
-            1000,
-            options.proxyTimeout(),
-            options.proxyVia(),
-            options.httpsSettings().trustStore(),
-            true,
-            Collections.emptyList(),
-            true,
-            options.getProxyTargetRules());
+        httpClientFactory.buildHttpClient(options, true, Collections.emptyList(), true);
     final HttpClient forwardProxyClient =
         httpClientFactory.buildHttpClient(
-            1000,
-            options.proxyTimeout(),
-            options.proxyVia(),
-            options.httpsSettings().trustStore(),
+            options,
             browserProxySettings.trustAllProxyTargets(),
             browserProxySettings.trustAllProxyTargets()
                 ? Collections.emptyList()
                 : browserProxySettings.trustedProxyTargets(),
-            false,
-            options.getProxyTargetRules());
+            false);
 
     return new StubRequestHandler(
         this,

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -36,6 +36,8 @@ import com.github.tomakehurst.wiremock.global.GlobalSettings;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.HttpServerFactory;
 import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
+import com.github.tomakehurst.wiremock.http.client.ApacheHttpClientFactory;
+import com.github.tomakehurst.wiremock.http.client.HttpClientFactory;
 import com.github.tomakehurst.wiremock.http.trafficlistener.DoNothingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.jetty.JettyHttpServerFactory;
@@ -99,6 +101,7 @@ public class WireMockConfiguration implements Options {
   private boolean preserveHostHeader;
   private String proxyHostHeader;
   private HttpServerFactory httpServerFactory = new JettyHttpServerFactory();
+  private HttpClientFactory httpClientFactory = new ApacheHttpClientFactory();
   private ThreadPoolFactory threadPoolFactory = new QueuedThreadPoolFactory();
   private Integer jettyAcceptors;
   private Integer jettyAcceptQueueSize;
@@ -131,7 +134,7 @@ public class WireMockConfiguration implements Options {
 
   private Limit responseBodySizeLimit = UNLIMITED;
 
-  private NetworkAddressRules proxyTargetRules = NetworkAddressRules.ALLOW_ALL;
+  private NetworkAddressRules proxyTargetRules = DefaultNetworkAddressRules.ALLOW_ALL;
 
   private int proxyTimeout = DEFAULT_TIMEOUT;
 
@@ -418,7 +421,12 @@ public class WireMockConfiguration implements Options {
   }
 
   public WireMockConfiguration httpServerFactory(HttpServerFactory serverFactory) {
-    httpServerFactory = serverFactory;
+    this.httpServerFactory = serverFactory;
+    return this;
+  }
+
+  public WireMockConfiguration httpClientFactory(HttpClientFactory httpClientFactory) {
+    this.httpClientFactory = httpClientFactory;
     return this;
   }
 
@@ -653,6 +661,11 @@ public class WireMockConfiguration implements Options {
   @Override
   public HttpServerFactory httpServerFactory() {
     return httpServerFactory;
+  }
+
+  @Override
+  public HttpClientFactory httpClientFactory() {
+    return httpClientFactory;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/WireMockServices.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/WireMockServices.java
@@ -19,6 +19,8 @@ import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
+import com.github.tomakehurst.wiremock.http.client.HttpClient;
+import com.github.tomakehurst.wiremock.http.client.HttpClientFactory;
 import com.github.tomakehurst.wiremock.store.Stores;
 
 public interface WireMockServices {
@@ -34,4 +36,8 @@ public interface WireMockServices {
   Extensions getExtensions();
 
   TemplateEngine getTemplateEngine();
+
+  HttpClientFactory getHttpClientFactory();
+
+  HttpClient getDefaultHttpClient();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
@@ -23,6 +23,7 @@ import static com.github.tomakehurst.wiremock.http.RequestMethod.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
+import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.ProxySettings;
 import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
@@ -63,7 +64,7 @@ public class HttpClientFactory {
       int timeoutMilliseconds,
       ProxySettings proxySettings,
       KeyStoreSettings trustStoreSettings,
-      boolean trustSelfSignedCertificates,
+      boolean trustAllCertificates,
       final List<String> trustedHosts,
       boolean useSystemProperties,
       NetworkAddressRules networkAddressRules) {
@@ -114,7 +115,7 @@ public class HttpClientFactory {
     }
 
     final SSLContext sslContext =
-        buildSslContext(trustStoreSettings, trustSelfSignedCertificates, trustedHosts);
+        buildSslContext(trustStoreSettings, trustAllCertificates, trustedHosts);
     LayeredConnectionSocketFactory sslSocketFactory = buildSslConnectionSocketFactory(sslContext);
     PoolingHttpClientConnectionManager connectionManager =
         PoolingHttpClientConnectionManagerBuilder.create()
@@ -152,12 +153,11 @@ public class HttpClientFactory {
 
   private static SSLContext buildSslContext(
       KeyStoreSettings trustStoreSettings,
-      boolean trustSelfSignedCertificates,
+      boolean trustAllCertificates,
       List<String> trustedHosts) {
     if (trustStoreSettings != NO_STORE) {
-      return buildSSLContextWithTrustStore(
-          trustStoreSettings, trustSelfSignedCertificates, trustedHosts);
-    } else if (trustSelfSignedCertificates) {
+      return buildSSLContextWithTrustStore(trustStoreSettings, trustAllCertificates, trustedHosts);
+    } else if (trustAllCertificates) {
       return buildAllowAnythingSSLContext();
     } else {
       try {
@@ -241,7 +241,7 @@ public class HttpClientFactory {
         NO_PROXY,
         NO_STORE,
         true,
-        NetworkAddressRules.ALLOW_ALL);
+        DefaultNetworkAddressRules.ALLOW_ALL);
   }
 
   public static CloseableHttpClient createClient(int timeoutMilliseconds) {
@@ -255,7 +255,7 @@ public class HttpClientFactory {
         proxySettings,
         NO_STORE,
         true,
-        NetworkAddressRules.ALLOW_ALL);
+        DefaultNetworkAddressRules.ALLOW_ALL);
   }
 
   public static CloseableHttpClient createClient() {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
@@ -16,14 +16,16 @@
 package com.github.tomakehurst.wiremock.http;
 
 import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
+import static java.util.Objects.requireNonNull;
 
 import com.github.tomakehurst.wiremock.common.Strings;
 import com.github.tomakehurst.wiremock.common.Urls;
+import java.net.URI;
 import java.util.*;
 
 public class ImmutableRequest implements Request {
 
-  private final String absouteUrl;
+  private final String absoluteUrl;
   private final Map<String, QueryParameter> queryParams;
   private final RequestMethod method;
   private final String protocol;
@@ -43,24 +45,24 @@ public class ImmutableRequest implements Request {
   }
 
   protected ImmutableRequest(
-      String absouteUrl,
+      String absoluteUrl,
       RequestMethod method,
       String protocol,
-      String scheme,
-      String host,
-      int port,
       String clientIp,
       HttpHeaders headers,
       byte[] body,
       boolean multipart,
       boolean browserProxyRequest) {
-    this.absouteUrl = absouteUrl;
-    this.queryParams = Urls.splitQueryFromUrl(absouteUrl);
-    this.method = method;
+    this.absoluteUrl = requireNonNull(absoluteUrl);
+    this.queryParams = Urls.splitQueryFromUrl(absoluteUrl);
+    this.method = requireNonNull(method);
     this.protocol = protocol;
-    this.scheme = scheme;
-    this.host = host;
-    this.port = port;
+
+    final URI uri = URI.create(absoluteUrl);
+    this.scheme = uri.getScheme();
+    this.host = uri.getHost();
+    this.port = uri.getPort();
+
     this.clientIp = clientIp;
     this.headers = headers;
     this.body = body;
@@ -71,12 +73,12 @@ public class ImmutableRequest implements Request {
 
   @Override
   public String getUrl() {
-    return Urls.getPathAndQuery(absouteUrl);
+    return Urls.getPathAndQuery(absoluteUrl);
   }
 
   @Override
   public String getAbsoluteUrl() {
-    return absouteUrl;
+    return absoluteUrl;
   }
 
   @Override
@@ -204,9 +206,6 @@ public class ImmutableRequest implements Request {
     private String absouteUrl;
     private RequestMethod requestMethod;
     private String protocol;
-    private String scheme;
-    private String host;
-    private int port;
     private String clientIp;
     private List<HttpHeader> headers = new ArrayList<>();
     private byte[] body;
@@ -225,21 +224,6 @@ public class ImmutableRequest implements Request {
 
     public Builder withProtocol(String protocol) {
       this.protocol = protocol;
-      return this;
-    }
-
-    public Builder withScheme(String scheme) {
-      this.scheme = scheme;
-      return this;
-    }
-
-    public Builder withHost(String host) {
-      this.host = host;
-      return this;
-    }
-
-    public Builder withPort(int port) {
-      this.port = port;
       return this;
     }
 
@@ -283,9 +267,6 @@ public class ImmutableRequest implements Request {
           absouteUrl,
           requestMethod,
           protocol,
-          scheme,
-          host,
-          port,
           clientIp,
           new HttpHeaders(headers),
           body,

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http;
+
+import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
+
+import com.github.tomakehurst.wiremock.common.Strings;
+import com.github.tomakehurst.wiremock.common.Urls;
+import java.util.*;
+
+public class ImmutableRequest implements Request {
+
+  private final String absouteUrl;
+  private final Map<String, QueryParameter> queryParams;
+  private final RequestMethod method;
+  private final String protocol;
+  private final String scheme;
+  private final String host;
+  private final int port;
+  private final String clientIp;
+  private final HttpHeaders headers;
+  private final byte[] body;
+  private final boolean multipart;
+
+  private final Map<String, Part> parts;
+  private final boolean browserProxyRequest;
+
+  public static Builder create() {
+    return new Builder();
+  }
+
+  protected ImmutableRequest(
+      String absouteUrl,
+      RequestMethod method,
+      String protocol,
+      String scheme,
+      String host,
+      int port,
+      String clientIp,
+      HttpHeaders headers,
+      byte[] body,
+      boolean multipart,
+      boolean browserProxyRequest) {
+    this.absouteUrl = absouteUrl;
+    this.queryParams = Urls.splitQueryFromUrl(absouteUrl);
+    this.method = method;
+    this.protocol = protocol;
+    this.scheme = scheme;
+    this.host = host;
+    this.port = port;
+    this.clientIp = clientIp;
+    this.headers = headers;
+    this.body = body;
+    this.multipart = multipart;
+    this.parts = Collections.emptyMap();
+    this.browserProxyRequest = browserProxyRequest;
+  }
+
+  @Override
+  public String getUrl() {
+    return Urls.getPathAndQuery(absouteUrl);
+  }
+
+  @Override
+  public String getAbsoluteUrl() {
+    return absouteUrl;
+  }
+
+  @Override
+  public RequestMethod getMethod() {
+    return method;
+  }
+
+  @Override
+  public String getScheme() {
+    return scheme;
+  }
+
+  @Override
+  public String getHost() {
+    return host;
+  }
+
+  @Override
+  public int getPort() {
+    return port;
+  }
+
+  @Override
+  public String getClientIp() {
+    return clientIp;
+  }
+
+  @Override
+  public String getHeader(String key) {
+    final HttpHeader header = header(key);
+    return header.isPresent() ? header.firstValue() : null;
+  }
+
+  @Override
+  public HttpHeader header(String key) {
+    return headers.getHeader(key);
+  }
+
+  @Override
+  public ContentTypeHeader contentTypeHeader() {
+    return headers.getContentTypeHeader();
+  }
+
+  @Override
+  public HttpHeaders getHeaders() {
+    return headers;
+  }
+
+  @Override
+  public boolean containsHeader(String key) {
+    return headers.getHeader(key).isPresent();
+  }
+
+  @Override
+  public Set<String> getAllHeaderKeys() {
+    return headers.keys();
+  }
+
+  @Override
+  public QueryParameter queryParameter(String key) {
+    return queryParams.get(key);
+  }
+
+  @Override
+  public FormParameter formParameter(String key) {
+    return null;
+  }
+
+  @Override
+  public Map<String, FormParameter> formParameters() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public Map<String, Cookie> getCookies() {
+    return null;
+  }
+
+  @Override
+  public byte[] getBody() {
+    return body;
+  }
+
+  @Override
+  public String getBodyAsString() {
+    return Strings.stringFromBytes(body);
+  }
+
+  @Override
+  public String getBodyAsBase64() {
+    return encodeBase64(getBody());
+  }
+
+  @Override
+  public boolean isMultipart() {
+    return multipart;
+  }
+
+  @Override
+  public Collection<Part> getParts() {
+    return parts.values();
+  }
+
+  @Override
+  public Part getPart(String name) {
+    return parts.get(name);
+  }
+
+  @Override
+  public boolean isBrowserProxyRequest() {
+    return browserProxyRequest;
+  }
+
+  @Override
+  public Optional<Request> getOriginalRequest() {
+    return Optional.empty();
+  }
+
+  @Override
+  public String getProtocol() {
+    return protocol;
+  }
+
+  public static class Builder {
+    private String absouteUrl;
+    private RequestMethod requestMethod;
+    private String protocol;
+    private String scheme;
+    private String host;
+    private int port;
+    private String clientIp;
+    private List<HttpHeader> headers = new ArrayList<>();
+    private byte[] body;
+    private boolean multipart;
+    private boolean browserProxyRequest;
+
+    public Builder withAbsoluteUrl(String absouteUrl) {
+      this.absouteUrl = absouteUrl;
+      return this;
+    }
+
+    public Builder withMethod(RequestMethod requestMethod) {
+      this.requestMethod = requestMethod;
+      return this;
+    }
+
+    public Builder withProtocol(String protocol) {
+      this.protocol = protocol;
+      return this;
+    }
+
+    public Builder withScheme(String scheme) {
+      this.scheme = scheme;
+      return this;
+    }
+
+    public Builder withHost(String host) {
+      this.host = host;
+      return this;
+    }
+
+    public Builder withPort(int port) {
+      this.port = port;
+      return this;
+    }
+
+    public Builder withClientIp(String clientIp) {
+      this.clientIp = clientIp;
+      return this;
+    }
+
+    public Builder withHeaders(HttpHeaders headers) {
+      this.headers = new ArrayList<>(headers.all());
+      return this;
+    }
+
+    public Builder withHeader(String key, String value) {
+      this.headers.add(new HttpHeader(key, Collections.singletonList(value)));
+      return this;
+    }
+
+    public Builder withHeader(String key, Collection<String> values) {
+      this.headers.add(new HttpHeader(key, values));
+      return this;
+    }
+
+    public Builder withBody(byte[] body) {
+      this.body = body;
+      return this;
+    }
+
+    public Builder withMultipart(boolean multipart) {
+      this.multipart = multipart;
+      return this;
+    }
+
+    public Builder withBrowserProxyRequest(boolean browserProxyRequest) {
+      this.browserProxyRequest = browserProxyRequest;
+      return this;
+    }
+
+    public ImmutableRequest build() {
+      return new ImmutableRequest(
+          absouteUrl,
+          requestMethod,
+          protocol,
+          scheme,
+          host,
+          port,
+          clientIp,
+          new HttpHeaders(headers),
+          body,
+          multipart,
+          browserProxyRequest);
+    }
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -78,19 +78,17 @@ public class ProxyResponseRenderer implements ResponseRenderer {
     HttpClient client = chooseClient(serveEvent.getRequest().isBrowserProxyRequest());
 
     try {
-      return client.execute(
-          request,
-          httpResponse ->
-              Response.Builder.like(httpResponse)
-                  .fromProxy(true)
-                  .headers(headersFrom(httpResponse, responseDefinition))
-                  .configureDelay(
-                      settings.getFixedDelay(),
-                      settings.getDelayDistribution(),
-                      responseDefinition.getFixedDelayMilliseconds(),
-                      responseDefinition.getDelayDistribution())
-                  .chunkedDribbleDelay(responseDefinition.getChunkedDribbleDelay())
-                  .build());
+      final Response httpResponse = client.execute(request);
+      return Response.Builder.like(httpResponse)
+          .fromProxy(true)
+          .headers(headersFrom(httpResponse, responseDefinition))
+          .configureDelay(
+              settings.getFixedDelay(),
+              settings.getDelayDistribution(),
+              responseDefinition.getFixedDelayMilliseconds(),
+              responseDefinition.getDelayDistribution())
+          .chunkedDribbleDelay(responseDefinition.getChunkedDribbleDelay())
+          .build();
     } catch (ProhibitedNetworkAddressException e) {
       return response()
           .status(HTTP_INTERNAL_ERROR)

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -15,124 +15,75 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import static com.github.tomakehurst.wiremock.common.HttpClientUtils.getEntityAsByteArray;
 import static com.github.tomakehurst.wiremock.http.Response.response;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 
-import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.ProhibitedNetworkAddressException;
-import com.github.tomakehurst.wiremock.common.ProxySettings;
-import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
+import com.github.tomakehurst.wiremock.http.client.HttpClient;
 import com.github.tomakehurst.wiremock.store.SettingsStore;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import javax.net.ssl.SSLException;
-import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
-import org.apache.hc.client5.http.entity.GzipCompressingEntity;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.core5.http.*;
-import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
-import org.apache.hc.core5.http.io.entity.InputStreamEntity;
 
 public class ProxyResponseRenderer implements ResponseRenderer {
 
-  private static final String TRANSFER_ENCODING = "transfer-encoding";
-  private static final String CONTENT_ENCODING = "content-encoding";
-  private static final String CONTENT_LENGTH = "content-length";
-  private static final String HOST_HEADER = "host";
-  public static final List<String> FORBIDDEN_RESPONSE_HEADERS =
-      List.of(TRANSFER_ENCODING, "connection");
-  public static final List<String> FORBIDDEN_REQUEST_HEADERS =
-      List.of(CONTENT_LENGTH, TRANSFER_ENCODING, "connection");
-
-  private final CloseableHttpClient reverseProxyClient;
-  private final CloseableHttpClient forwardProxyClient;
+  private final HttpClient reverseProxyClient;
+  private final HttpClient forwardProxyClient;
   private final boolean preserveHostHeader;
   private final String hostHeaderValue;
   private final SettingsStore settingsStore;
   private final boolean stubCorsEnabled;
 
-  private final NetworkAddressRules targetAddressRules;
-
   public ProxyResponseRenderer(
-      ProxySettings proxySettings,
-      KeyStoreSettings trustStoreSettings,
       boolean preserveHostHeader,
       String hostHeaderValue,
       SettingsStore settingsStore,
-      boolean trustAllProxyTargets,
-      List<String> trustedProxyTargets,
       boolean stubCorsEnabled,
-      NetworkAddressRules targetAddressRules,
-      int proxyTimeout) {
-    this.settingsStore = settingsStore;
-    reverseProxyClient =
-        HttpClientFactory.createClient(
-            1000,
-            proxyTimeout,
-            proxySettings,
-            trustStoreSettings,
-            true,
-            Collections.emptyList(),
-            true,
-            targetAddressRules);
-    forwardProxyClient =
-        HttpClientFactory.createClient(
-            1000,
-            proxyTimeout,
-            proxySettings,
-            trustStoreSettings,
-            trustAllProxyTargets,
-            trustAllProxyTargets ? Collections.emptyList() : trustedProxyTargets,
-            false,
-            targetAddressRules);
+      HttpClient reverseProxyClient,
+      HttpClient forwardProxyClient) {
 
+    this.settingsStore = settingsStore;
     this.preserveHostHeader = preserveHostHeader;
     this.hostHeaderValue = hostHeaderValue;
     this.stubCorsEnabled = stubCorsEnabled;
-    this.targetAddressRules = targetAddressRules;
+
+    this.forwardProxyClient = forwardProxyClient;
+    this.reverseProxyClient = reverseProxyClient;
   }
 
   @Override
   public Response render(ServeEvent serveEvent) {
     ResponseDefinition responseDefinition = serveEvent.getResponseDefinition();
-    //    if (targetAddressProhibited(responseDefinition.getProxyUrl())) {
-    //      return response()
-    //          .status(500)
-    //          .headers(new HttpHeaders(new HttpHeader("Content-Type", "text/plain")))
-    //          .body("The target proxy address is denied in WireMock's configuration.")
-    //          .build();
-    //    }
 
-    HttpUriRequest httpRequest = getHttpRequestFor(responseDefinition);
-    addRequestHeaders(httpRequest, responseDefinition);
+    final ImmutableRequest.Builder requestBuilder =
+        ImmutableRequest.create()
+            .withAbsoluteUrl(responseDefinition.getProxyUrl())
+            .withMethod(responseDefinition.getOriginalRequest().getMethod());
+    addRequestHeaders(requestBuilder, responseDefinition);
 
     GlobalSettings settings = settingsStore.get();
 
     Request originalRequest = responseDefinition.getOriginalRequest();
     if ((originalRequest.getBody() != null && originalRequest.getBody().length > 0)
-        || originalRequest.containsHeader(CONTENT_LENGTH)) {
-      httpRequest.setEntity(buildEntityFrom(originalRequest));
+        || originalRequest.containsHeader(HttpClient.CONTENT_LENGTH)) {
+      requestBuilder.withBody(originalRequest.getBody());
     }
 
-    CloseableHttpClient client = chooseClient(serveEvent.getRequest().isBrowserProxyRequest());
+    Request request = requestBuilder.build();
+
+    HttpClient client = chooseClient(serveEvent.getRequest().isBrowserProxyRequest());
 
     try {
       return client.execute(
-          httpRequest,
+          request,
           httpResponse ->
-              response()
-                  .status(httpResponse.getCode())
-                  .headers(headersFrom(httpResponse, responseDefinition))
-                  .body(getEntityAsByteArray(httpResponse))
+              Response.Builder.like(httpResponse)
                   .fromProxy(true)
+                  .headers(headersFrom(httpResponse, responseDefinition))
                   .configureDelay(
                       settings.getFixedDelay(),
                       settings.getDelayDistribution(),
@@ -147,33 +98,25 @@ public class ProxyResponseRenderer implements ResponseRenderer {
           .body("The target proxy address is denied in WireMock's configuration.")
           .build();
     } catch (SSLException e) {
-      return proxyResponseError("SSL", httpRequest, e);
+      return proxyResponseError("SSL", request, e);
     } catch (IOException e) {
-      return proxyResponseError("Network", httpRequest, e);
+      return proxyResponseError("Network", request, e);
     }
   }
 
-  private Response proxyResponseError(String type, HttpUriRequest request, Exception e) {
+  private Response proxyResponseError(String type, Request request, Exception e) {
     return response()
         .status(HTTP_INTERNAL_ERROR)
         .body(
-            (type
-                    + " failure trying to make a proxied request from WireMock to "
-                    + extractUri(request))
+            type
+                + " failure trying to make a proxied request from WireMock to "
+                + request.getAbsoluteUrl()
                 + "\r\n"
                 + e.getMessage())
         .build();
   }
 
-  private static String extractUri(HttpUriRequest request) {
-    try {
-      return request.getUri().toString();
-    } catch (URISyntaxException ignored) {
-    }
-    return request.getRequestUri();
-  }
-
-  private CloseableHttpClient chooseClient(boolean browserProxyRequest) {
+  private HttpClient chooseClient(boolean browserProxyRequest) {
     if (browserProxyRequest) {
       return forwardProxyClient;
     } else {
@@ -181,12 +124,11 @@ public class ProxyResponseRenderer implements ResponseRenderer {
     }
   }
 
-  private HttpHeaders headersFrom(
-      HttpResponse httpResponse, ResponseDefinition responseDefinition) {
+  private HttpHeaders headersFrom(Response response, ResponseDefinition responseDefinition) {
     List<HttpHeader> httpHeaders = new LinkedList<>();
-    for (Header header : httpResponse.getHeaders()) {
-      if (responseHeaderShouldBeTransferred(header.getName())) {
-        httpHeaders.add(new HttpHeader(header.getName(), header.getValue()));
+    for (HttpHeader header : response.getHeaders().all()) {
+      if (responseHeaderShouldBeTransferred(header.getKey())) {
+        httpHeaders.add(header);
       }
     }
 
@@ -197,77 +139,33 @@ public class ProxyResponseRenderer implements ResponseRenderer {
     return new HttpHeaders(httpHeaders);
   }
 
-  public static HttpUriRequest getHttpRequestFor(ResponseDefinition response) {
-    final RequestMethod method = response.getOriginalRequest().getMethod();
-    final String url = response.getProxyUrl();
-    return HttpClientFactory.getHttpRequestFor(method, url);
-  }
-
-  private void addRequestHeaders(HttpRequest httpRequest, ResponseDefinition response) {
+  private void addRequestHeaders(
+      ImmutableRequest.Builder requestBuilder, ResponseDefinition response) {
     Request originalRequest = response.getOriginalRequest();
     for (String key : originalRequest.getAllHeaderKeys()) {
-      if (requestHeaderShouldBeTransferred(key)) {
-        if (!HOST_HEADER.equalsIgnoreCase(key) || preserveHostHeader) {
-          List<String> values = originalRequest.header(key).values();
-          for (String value : values) {
-            httpRequest.addHeader(key, value);
-          }
-        } else {
-          if (hostHeaderValue != null) {
-            httpRequest.addHeader(key, hostHeaderValue);
-          } else if (response.getProxyBaseUrl() != null) {
-            httpRequest.addHeader(key, URI.create(response.getProxyBaseUrl()).getAuthority());
-          }
+      if (!HttpClient.HOST_HEADER.equalsIgnoreCase(key) || preserveHostHeader) {
+        List<String> values = originalRequest.header(key).values();
+        requestBuilder.withHeader(key, values);
+      } else {
+        if (hostHeaderValue != null) {
+          requestBuilder.withHeader(key, hostHeaderValue);
+        } else if (response.getProxyBaseUrl() != null) {
+          requestBuilder.withHeader(key, URI.create(response.getProxyBaseUrl()).getAuthority());
         }
       }
     }
 
     if (response.getAdditionalProxyRequestHeaders() != null) {
       for (String key : response.getAdditionalProxyRequestHeaders().keys()) {
-        httpRequest.setHeader(
+        requestBuilder.withHeader(
             key, response.getAdditionalProxyRequestHeaders().getHeader(key).firstValue());
       }
     }
   }
 
-  private static boolean requestHeaderShouldBeTransferred(String key) {
-    return !FORBIDDEN_REQUEST_HEADERS.contains(key.toLowerCase());
-  }
-
-  private boolean responseHeaderShouldBeTransferred(String key) {
+  public boolean responseHeaderShouldBeTransferred(String key) {
     final String lowerCaseKey = key.toLowerCase();
-    return !FORBIDDEN_RESPONSE_HEADERS.contains(lowerCaseKey)
+    return !HttpClient.FORBIDDEN_RESPONSE_HEADERS.contains(lowerCaseKey)
         && (!stubCorsEnabled || !lowerCaseKey.startsWith("access-control"));
-  }
-
-  private static HttpEntity buildEntityFrom(Request originalRequest) {
-    ContentTypeHeader contentTypeHeader = originalRequest.contentTypeHeader().or("text/plain");
-    ContentType contentType =
-        ContentType.create(
-            contentTypeHeader.mimeTypePart(), contentTypeHeader.encodingPart().orElse("utf-8"));
-
-    if (originalRequest.containsHeader(TRANSFER_ENCODING)
-        && originalRequest.header(TRANSFER_ENCODING).firstValue().equals("chunked")) {
-      return applyGzipWrapperIfRequired(
-          originalRequest,
-          new InputStreamEntity(
-              new ByteArrayInputStream(originalRequest.getBody()), -1, contentType));
-    }
-
-    return applyGzipWrapperIfRequired(
-        originalRequest,
-        new ByteArrayEntity(
-            originalRequest.getBody(),
-            originalRequest.contentTypeHeader().isPresent() ? contentType : null));
-  }
-
-  private static HttpEntity applyGzipWrapperIfRequired(
-      Request originalRequest, HttpEntity content) {
-    if (originalRequest.containsHeader(CONTENT_ENCODING)
-        && originalRequest.header(CONTENT_ENCODING).firstValue().contains("gzip")) {
-      return new GzipCompressingEntity(content);
-    }
-
-    return content;
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheBackedHttpClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheBackedHttpClient.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http.client;
+
+import static com.github.tomakehurst.wiremock.common.ContentTypes.CONTENT_ENCODING;
+import static com.github.tomakehurst.wiremock.common.ContentTypes.TRANSFER_ENCODING;
+import static com.github.tomakehurst.wiremock.http.Response.response;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.Response;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import org.apache.hc.client5.http.entity.GzipCompressingEntity;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.core5.http.*;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.InputStreamEntity;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
+import org.apache.hc.core5.http.message.BasicHeader;
+
+public class ApacheBackedHttpClient implements HttpClient {
+
+  private final CloseableHttpClient apacheHttpClient;
+
+  public ApacheBackedHttpClient(CloseableHttpClient apacheHttpClient) {
+    this.apacheHttpClient = apacheHttpClient;
+  }
+
+  @Override
+  public <T> T execute(Request request, Function<Response, T> responseHandler) throws IOException {
+    ClassicHttpRequest apacheRequest = createApacheRequest(request);
+    return apacheHttpClient.execute(
+        apacheRequest,
+        apacheResponse -> responseHandler.apply(toWireMockHttpResponse(apacheResponse)));
+  }
+
+  private static ClassicHttpRequest createApacheRequest(Request request) {
+    ContentType contentType =
+        request.contentTypeHeader().isPresent()
+            ? ContentType.parse(request.contentTypeHeader().firstValue())
+            : ContentType.APPLICATION_OCTET_STREAM.withCharset(UTF_8);
+
+    final ClassicRequestBuilder requestBuilder =
+        ClassicRequestBuilder.create(request.getMethod().getName())
+            .setUri(request.getAbsoluteUrl())
+            .setHeaders(
+                request.getHeaders().all().stream()
+                    .filter(
+                        header -> !FORBIDDEN_REQUEST_HEADERS.contains(header.key().toLowerCase()))
+                    .flatMap(
+                        header ->
+                            header.values().stream()
+                                .map(headerValue -> new BasicHeader(header.key(), headerValue)))
+                    .toArray(Header[]::new));
+
+    if (request.getBody() != null) {
+      HttpEntity entity =
+          request.containsHeader(TRANSFER_ENCODING)
+                  && request.header(TRANSFER_ENCODING).firstValue().equals("chunked")
+              ? new InputStreamEntity(new ByteArrayInputStream(request.getBody()), -1, contentType)
+              : new ByteArrayEntity(
+                  request.getBody(), request.contentTypeHeader().isPresent() ? contentType : null);
+
+      requestBuilder.setEntity(applyGzipWrapperIfRequired(request, entity));
+    }
+
+    ClassicHttpRequest apacheRequest = requestBuilder.build();
+    return apacheRequest;
+  }
+
+  private static HttpEntity applyGzipWrapperIfRequired(
+      Request originalRequest, HttpEntity content) {
+    if (originalRequest.containsHeader(CONTENT_ENCODING)
+        && originalRequest.header(CONTENT_ENCODING).firstValue().contains("gzip")) {
+      return new GzipCompressingEntity(content);
+    }
+
+    return content;
+  }
+
+  private static Response toWireMockHttpResponse(ClassicHttpResponse apacheResponse)
+      throws IOException {
+    final List<HttpHeader> headers =
+        Arrays.stream(apacheResponse.getHeaders())
+            .collect(groupingBy(NameValuePair::getName))
+            .entrySet()
+            .stream()
+            .map(
+                entry ->
+                    new HttpHeader(
+                        entry.getKey(),
+                        entry.getValue().stream()
+                            .map(Header::getValue)
+                            .collect(toUnmodifiableList())))
+            .collect(toUnmodifiableList());
+
+    final Response.Builder responseBuilder =
+        response()
+            .status(apacheResponse.getCode())
+            .headers(new HttpHeaders(headers))
+            .protocol(apacheResponse.getVersion().toString());
+
+    final HttpEntity entity = apacheResponse.getEntity();
+    if (entity != null) {
+      responseBuilder.body(EntityUtils.toByteArray(entity));
+    }
+
+    if (apacheResponse.getReasonPhrase() != null) {
+      responseBuilder.statusMessage(apacheResponse.getReasonPhrase());
+    }
+
+    return responseBuilder.build();
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheBackedHttpClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheBackedHttpClient.java
@@ -15,8 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.http.client;
 
-import static com.github.tomakehurst.wiremock.common.ContentTypes.CONTENT_ENCODING;
-import static com.github.tomakehurst.wiremock.common.ContentTypes.TRANSFER_ENCODING;
 import static com.github.tomakehurst.wiremock.http.Response.response;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.groupingBy;
@@ -30,7 +28,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Function;
 import org.apache.hc.client5.http.entity.GzipCompressingEntity;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.*;
@@ -49,11 +46,9 @@ public class ApacheBackedHttpClient implements HttpClient {
   }
 
   @Override
-  public <T> T execute(Request request, Function<Response, T> responseHandler) throws IOException {
+  public Response execute(Request request) throws IOException {
     ClassicHttpRequest apacheRequest = createApacheRequest(request);
-    return apacheHttpClient.execute(
-        apacheRequest,
-        apacheResponse -> responseHandler.apply(toWireMockHttpResponse(apacheResponse)));
+    return apacheHttpClient.execute(apacheRequest, ApacheBackedHttpClient::toWireMockHttpResponse);
   }
 
   private static ClassicHttpRequest createApacheRequest(Request request) {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http.client;
+
+import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.ProxySettings;
+import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
+import java.util.List;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+
+public class ApacheHttpClientFactory implements HttpClientFactory {
+
+  @Override
+  public HttpClient buildHttpClient(
+      int maxConnections,
+      int proxyTimeoutMillis,
+      ProxySettings proxyVia,
+      KeyStoreSettings trustStoreSettings,
+      boolean trustAllCertificates,
+      List<String> trustedHosts,
+      boolean useSystemProperties,
+      NetworkAddressRules networkAddressRules) {
+
+    final CloseableHttpClient apacheClient =
+        com.github.tomakehurst.wiremock.http.HttpClientFactory.createClient(
+            maxConnections,
+            proxyTimeoutMillis,
+            proxyVia,
+            trustStoreSettings,
+            trustAllCertificates,
+            trustedHosts,
+            useSystemProperties,
+            networkAddressRules);
+
+    return new ApacheBackedHttpClient(apacheClient);
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
@@ -15,9 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.http.client;
 
-import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
-import com.github.tomakehurst.wiremock.common.ProxySettings;
-import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
+import com.github.tomakehurst.wiremock.core.Options;
 import java.util.List;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 
@@ -25,25 +23,20 @@ public class ApacheHttpClientFactory implements HttpClientFactory {
 
   @Override
   public HttpClient buildHttpClient(
-      int maxConnections,
-      int proxyTimeoutMillis,
-      ProxySettings proxyVia,
-      KeyStoreSettings trustStoreSettings,
+      Options options,
       boolean trustAllCertificates,
       List<String> trustedHosts,
-      boolean useSystemProperties,
-      NetworkAddressRules networkAddressRules) {
-
+      boolean useSystemProperties) {
     final CloseableHttpClient apacheClient =
         com.github.tomakehurst.wiremock.http.HttpClientFactory.createClient(
-            maxConnections,
-            proxyTimeoutMillis,
-            proxyVia,
-            trustStoreSettings,
+            options.getMaxHttpClientConnections(),
+            options.proxyTimeout(),
+            options.proxyVia(),
+            options.httpsSettings().trustStore(),
             trustAllCertificates,
             trustedHosts,
             useSystemProperties,
-            networkAddressRules);
+            options.getProxyTargetRules());
 
     return new ApacheBackedHttpClient(apacheClient);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/HttpClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/HttpClient.java
@@ -19,7 +19,6 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.Response;
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Function;
 
 public interface HttpClient {
 
@@ -32,5 +31,5 @@ public interface HttpClient {
       List.of(TRANSFER_ENCODING, CONTENT_LENGTH, "connection", USER_AGENT);
   String HOST_HEADER = "host";
 
-  <T> T execute(Request request, Function<Response, T> responseHandler) throws IOException;
+  Response execute(Request request) throws IOException;
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/HttpClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/HttpClient.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http.client;
+
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.Response;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+
+public interface HttpClient {
+
+  String USER_AGENT = "user-agent";
+  String TRANSFER_ENCODING = "transfer-encoding";
+  List<String> FORBIDDEN_RESPONSE_HEADERS = List.of(TRANSFER_ENCODING, "connection");
+  String CONTENT_ENCODING = "content-encoding";
+  String CONTENT_LENGTH = "content-length";
+  List<String> FORBIDDEN_REQUEST_HEADERS =
+      List.of(TRANSFER_ENCODING, CONTENT_LENGTH, "connection", USER_AGENT);
+  String HOST_HEADER = "host";
+
+  <T> T execute(Request request, Function<Response, T> responseHandler) throws IOException;
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/HttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/HttpClientFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http.client;
+
+import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.ProxySettings;
+import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
+import com.github.tomakehurst.wiremock.extension.Extension;
+import java.util.List;
+
+public interface HttpClientFactory extends Extension {
+
+  @Override
+  default String getName() {
+    return "http-client-factory";
+  }
+
+  HttpClient buildHttpClient(
+      int maxConnections,
+      int proxyTimeoutMillis,
+      ProxySettings proxyVia,
+      KeyStoreSettings trustStoreSettings,
+      boolean trustAllCertificates,
+      List<String> trustedHosts,
+      boolean useSystemProperties,
+      NetworkAddressRules networkAddressRules);
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -26,6 +26,8 @@ import com.github.tomakehurst.wiremock.extension.ExtensionDeclarations;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.HttpServerFactory;
 import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
+import com.github.tomakehurst.wiremock.http.client.ApacheHttpClientFactory;
+import com.github.tomakehurst.wiremock.http.client.HttpClientFactory;
 import com.github.tomakehurst.wiremock.http.trafficlistener.DoNothingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.security.Authenticator;
@@ -155,6 +157,11 @@ public class WarConfiguration implements Options {
   }
 
   @Override
+  public HttpClientFactory httpClientFactory() {
+    return new ApacheHttpClientFactory();
+  }
+
+  @Override
   public ThreadPoolFactory threadPoolFactory() {
     return null;
   }
@@ -231,7 +238,7 @@ public class WarConfiguration implements Options {
 
   @Override
   public NetworkAddressRules getProxyTargetRules() {
-    return NetworkAddressRules.ALLOW_ALL;
+    return DefaultNetworkAddressRules.ALLOW_ALL;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -35,6 +35,8 @@ import com.github.tomakehurst.wiremock.global.GlobalSettings;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.HttpServerFactory;
 import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
+import com.github.tomakehurst.wiremock.http.client.ApacheHttpClientFactory;
+import com.github.tomakehurst.wiremock.http.client.HttpClientFactory;
 import com.github.tomakehurst.wiremock.http.trafficlistener.ConsoleNotifyingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.http.trafficlistener.DoNothingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
@@ -497,6 +499,11 @@ public class CommandLineOptions implements Options {
   }
 
   @Override
+  public HttpClientFactory httpClientFactory() {
+    return new ApacheHttpClientFactory();
+  }
+
+  @Override
   public ThreadPoolFactory threadPoolFactory() {
     return new QueuedThreadPoolFactory();
   }
@@ -897,7 +904,7 @@ public class CommandLineOptions implements Options {
 
   @Override
   public NetworkAddressRules getProxyTargetRules() {
-    NetworkAddressRules.Builder builder = NetworkAddressRules.builder();
+    DefaultNetworkAddressRules.Builder builder = DefaultNetworkAddressRules.builder();
     if (optionSet.has(ALLOW_PROXY_TARGETS)) {
       Arrays.stream(((String) optionSet.valueOf(ALLOW_PROXY_TARGETS)).split(","))
           .forEach(builder::allow);

--- a/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -21,6 +21,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.common.ProhibitedNetworkAddressException;
@@ -78,12 +79,12 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
 
   @JsonCreator
   public Webhooks() {
-    this(NetworkAddressRules.ALLOW_ALL);
+    this(DefaultNetworkAddressRules.ALLOW_ALL);
   }
 
   @SuppressWarnings("unused") // public API
   public Webhooks(WebhookTransformer... transformers) {
-    this(Arrays.asList(transformers), NetworkAddressRules.ALLOW_ALL);
+    this(Arrays.asList(transformers), DefaultNetworkAddressRules.ALLOW_ALL);
   }
 
   private static CloseableHttpClient createHttpClient(NetworkAddressRules targetAddressRules) {

--- a/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -15,97 +15,47 @@
  */
 package org.wiremock.webhooks;
 
+import static com.github.tomakehurst.wiremock.common.Lazy.lazy;
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
-import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
-import com.github.tomakehurst.wiremock.common.Notifier;
-import com.github.tomakehurst.wiremock.common.ProhibitedNetworkAddressException;
+import com.github.tomakehurst.wiremock.common.*;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.extension.ServeEventListener;
+import com.github.tomakehurst.wiremock.extension.WireMockServices;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.RequestTemplateModel;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
-import com.github.tomakehurst.wiremock.http.HttpHeader;
-import com.github.tomakehurst.wiremock.http.NetworkAddressRulesAdheringDnsResolver;
+import com.github.tomakehurst.wiremock.http.*;
+import com.github.tomakehurst.wiremock.http.client.HttpClient;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import java.util.*;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
-import org.apache.hc.core5.http.ClassicHttpRequest;
-import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.io.SocketConfig;
-import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
-import org.apache.hc.core5.util.TimeValue;
-import org.apache.hc.core5.util.Timeout;
 
 @SuppressWarnings("deprecation") // maintaining PostServeAction for backwards compatibility
 public class Webhooks extends PostServeAction implements ServeEventListener {
 
   private final ScheduledExecutorService scheduler;
-  private final CloseableHttpClient httpClient;
+  private final Lazy<HttpClient> lazyHttpClient;
   private final List<WebhookTransformer> transformers;
   private final TemplateEngine templateEngine;
 
-  private Webhooks(
+  public Webhooks(
+      WireMockServices wireMockServices,
       ScheduledExecutorService scheduler,
-      CloseableHttpClient httpClient,
       List<WebhookTransformer> transformers) {
-    this.scheduler = scheduler;
-    this.httpClient = httpClient;
-    this.transformers = transformers;
 
+    this.scheduler = scheduler;
+    this.lazyHttpClient = lazy(wireMockServices::getDefaultHttpClient);
+    this.transformers = transformers;
     this.templateEngine = TemplateEngine.defaultTemplateEngine();
   }
 
-  public Webhooks(List<WebhookTransformer> transformers, NetworkAddressRules targetAddressRules) {
-    this(Executors.newScheduledThreadPool(10), createHttpClient(targetAddressRules), transformers);
-  }
-
-  public Webhooks(NetworkAddressRules targetAddressRules) {
-    this(new ArrayList<>(), targetAddressRules);
-  }
-
-  @JsonCreator
-  public Webhooks() {
-    this(DefaultNetworkAddressRules.ALLOW_ALL);
-  }
-
-  @SuppressWarnings("unused") // public API
-  public Webhooks(WebhookTransformer... transformers) {
-    this(Arrays.asList(transformers), DefaultNetworkAddressRules.ALLOW_ALL);
-  }
-
-  private static CloseableHttpClient createHttpClient(NetworkAddressRules targetAddressRules) {
-    return HttpClientBuilder.create()
-        .disableAuthCaching()
-        .disableAutomaticRetries()
-        .disableCookieManagement()
-        .disableRedirectHandling()
-        .disableContentCompression()
-        .setConnectionManager(
-            PoolingHttpClientConnectionManagerBuilder.create()
-                .setDnsResolver(new NetworkAddressRulesAdheringDnsResolver(targetAddressRules))
-                .setDefaultSocketConfig(
-                    SocketConfig.custom().setSoTimeout(Timeout.ofMilliseconds(30000)).build())
-                .setMaxConnPerRoute(1000)
-                .setMaxConnTotal(1000)
-                .setValidateAfterInactivity(TimeValue.ofSeconds(5)) // TODO Verify duration
-                .build())
-        .setConnectionReuseStrategy((request, response, context) -> false)
-        .setKeepAliveStrategy((response, context) -> TimeValue.ZERO_MILLISECONDS)
-        .build();
+  private HttpClient getHttpClient() {
+    return lazyHttpClient.get();
   }
 
   @Override
@@ -128,7 +78,7 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
     final Notifier notifier = notifier();
 
     WebhookDefinition definition;
-    ClassicHttpRequest request;
+    Request request;
     try {
       definition = WebhookDefinition.from(parameters);
       for (WebhookTransformer transformer : transformers) {
@@ -144,14 +94,15 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
     final WebhookDefinition finalDefinition = definition;
     scheduler.schedule(
         () -> {
-          try (CloseableHttpResponse response = httpClient.execute(request)) {
+          try {
+            Response response = getHttpClient().execute(request);
             notifier.info(
                 String.format(
                     "Webhook %s request to %s returned status %s\n\n%s",
                     finalDefinition.getMethod(),
                     finalDefinition.getUrl(),
-                    response.getCode(),
-                    EntityUtils.toString(response.getEntity())));
+                    response.getStatus(),
+                    response.getBodyAsString()));
           } catch (ProhibitedNetworkAddressException e) {
             notifier.error(
                 String.format(
@@ -211,19 +162,15 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
     return templateEngine.getUncachedTemplate(value).apply(context);
   }
 
-  private static ClassicHttpRequest buildRequest(WebhookDefinition definition) {
-    final ClassicRequestBuilder requestBuilder =
-        ClassicRequestBuilder.create(definition.getMethod()).setUri(definition.getUrl());
-
-    for (HttpHeader header : definition.getHeaders().all()) {
-      for (String value : header.values()) {
-        requestBuilder.addHeader(header.key(), value);
-      }
-    }
+  private static Request buildRequest(WebhookDefinition definition) {
+    final ImmutableRequest.Builder requestBuilder =
+        ImmutableRequest.create()
+            .withMethod(definition.getRequestMethod())
+            .withAbsoluteUrl(definition.getUrl())
+            .withHeaders(definition.getHeaders());
 
     if (definition.getRequestMethod().hasEntity() && definition.hasBody()) {
-      requestBuilder.setEntity(
-          new ByteArrayEntity(definition.getBinaryBody(), ContentType.DEFAULT_BINARY));
+      requestBuilder.withBody(definition.getBinaryBody());
     }
 
     return requestBuilder.build();

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpClientSubstitutionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpClientSubstitutionTest.java
@@ -19,9 +19,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
-import com.github.tomakehurst.wiremock.common.ProxySettings;
-import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
+import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.Response;
@@ -71,15 +69,10 @@ public class HttpClientSubstitutionTest {
 
     @Override
     public HttpClient buildHttpClient(
-        int maxConnections,
-        int proxyTimeoutMillis,
-        ProxySettings proxyVia,
-        KeyStoreSettings trustStoreSettings,
+        Options options,
         boolean trustAllCertificates,
         List<String> trustedHosts,
-        boolean useSystemProperties,
-        NetworkAddressRules networkAddressRules) {
-
+        boolean useSystemProperties) {
       return new HttpClient() {
         @Override
         public Response execute(Request request) {

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpClientSubstitutionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpClientSubstitutionTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.ProxySettings;
+import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.Response;
+import com.github.tomakehurst.wiremock.http.client.HttpClient;
+import com.github.tomakehurst.wiremock.http.client.HttpClientFactory;
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class HttpClientSubstitutionTest {
+
+  WireMockServer wm;
+  WireMockTestClient client;
+
+  void startWireMockServer(WireMockConfiguration options) {
+    wm = new WireMockServer(options);
+    wm.start();
+
+    client = new WireMockTestClient(wm.port());
+
+    // Doesn't matter what the proxy URL is - we're faking the client
+    wm.stubFor(WireMock.proxyAllTo("http://localhost:1234"));
+  }
+
+  @AfterEach
+  void cleanup() {
+    wm.stop();
+  }
+
+  @Test
+  void viaOptions() {
+    startWireMockServer(
+        wireMockConfig().dynamicPort().httpClientFactory(new FakeHttpClientFactory()));
+
+    assertThat(client.get("/whatever").statusCode()).isEqualTo(418);
+  }
+
+  @Test
+  void viaExtension() {
+    startWireMockServer(wireMockConfig().dynamicPort().extensions(new FakeHttpClientFactory()));
+
+    assertThat(client.get("/whatever").statusCode()).isEqualTo(418);
+  }
+
+  public static class FakeHttpClientFactory implements HttpClientFactory {
+
+    @Override
+    public HttpClient buildHttpClient(
+        int maxConnections,
+        int proxyTimeoutMillis,
+        ProxySettings proxyVia,
+        KeyStoreSettings trustStoreSettings,
+        boolean trustAllCertificates,
+        List<String> trustedHosts,
+        boolean useSystemProperties,
+        NetworkAddressRules networkAddressRules) {
+
+      return new HttpClient() {
+        @Override
+        public Response execute(Request request) {
+          return Response.response().status(418).body("Teapot").build();
+        }
+      };
+    }
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.ProxySettings;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -636,7 +636,7 @@ public class ProxyAcceptanceTest {
     init(
         wireMockConfig()
             .limitProxyTargets(
-                NetworkAddressRules.builder()
+                DefaultNetworkAddressRules.builder()
                     .deny("10.1.2.3")
                     .deny("192.168.10.1-192.168.11.254")
                     .build()));
@@ -655,7 +655,8 @@ public class ProxyAcceptanceTest {
   void preventsProxyingToExcludedHostnames() {
     init(
         wireMockConfig()
-            .limitProxyTargets(NetworkAddressRules.builder().deny("*.wiremock.org").build()));
+            .limitProxyTargets(
+                DefaultNetworkAddressRules.builder().deny("*.wiremock.org").build()));
 
     proxy.register(proxyAllTo("http://noway.wiremock.org"));
     assertThat(
@@ -667,7 +668,7 @@ public class ProxyAcceptanceTest {
   void preventsProxyingToNonIncludedHostnames() {
     init(
         wireMockConfig()
-            .limitProxyTargets(NetworkAddressRules.builder().allow("wiremock.org").build()));
+            .limitProxyTargets(DefaultNetworkAddressRules.builder().allow("wiremock.org").build()));
 
     proxy.register(proxyAllTo("http://wiremock.io"));
     assertThat(
@@ -679,7 +680,7 @@ public class ProxyAcceptanceTest {
   void preventsProxyingToIpResolvedFromHostname() {
     init(
         wireMockConfig()
-            .limitProxyTargets(NetworkAddressRules.builder().deny("127.0.0.1").build()));
+            .limitProxyTargets(DefaultNetworkAddressRules.builder().deny("127.0.0.1").build()));
 
     proxy.register(proxyAllTo("http://localhost"));
     assertThat(

--- a/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
@@ -16,6 +16,8 @@
 package com.github.tomakehurst.wiremock;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.common.ContentTypes.CONTENT_ENCODING;
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.getLast;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
@@ -309,9 +311,9 @@ public class ProxyAcceptanceTest {
 
     testClient.postWithChunkedBody("/chunked", "TEST".getBytes());
 
-    target.verifyThat(
-        postRequestedFor(urlEqualTo("/chunked"))
-            .withHeader("Transfer-Encoding", equalTo("chunked")));
+    List<LoggedRequest> loggedRequests = target.find(postRequestedFor(urlEqualTo("/chunked")));
+    assertThat(loggedRequests.size(), is(1));
+    assertThat(loggedRequests.get(0).header("Transfer-Encoding").firstValue(), is("chunked"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
@@ -32,7 +32,7 @@ import static org.wiremock.webhooks.Webhooks.webhook;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
-import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
@@ -92,7 +92,9 @@ public class WebhooksAcceptanceViaPostServeActionTest {
                   .dynamicPort()
                   .notifier(notifier)
                   .limitProxyTargets(
-                      NetworkAddressRules.builder().deny("169.254.0.0-169.254.255.255").build()))
+                      DefaultNetworkAddressRules.builder()
+                          .deny("169.254.0.0-169.254.255.255")
+                          .build()))
           .configureStaticDsl(true)
           .build();
 

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
@@ -32,7 +32,7 @@ import static org.wiremock.webhooks.Webhooks.webhook;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
-import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
@@ -92,7 +92,9 @@ public class WebhooksAcceptanceViaServeEventTest {
                   .dynamicPort()
                   .notifier(notifier)
                   .limitProxyTargets(
-                      NetworkAddressRules.builder().deny("169.254.0.0-169.254.255.255").build()))
+                      DefaultNetworkAddressRules.builder()
+                          .deny("169.254.0.0-169.254.255.255")
+                          .build()))
           .configureStaticDsl(true)
           .build();
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/LazyTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/LazyTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.common;
+
+import static com.github.tomakehurst.wiremock.common.Lazy.lazy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+public class LazyTest {
+
+  @Test
+  void initialisesFromSupplierOnlyOnce() {
+    AtomicInteger count = new AtomicInteger(0);
+
+    Lazy<String> lazy =
+        lazy(
+            () -> {
+              count.incrementAndGet();
+              return "Lazily";
+            });
+
+    lazy.get();
+    lazy.get();
+
+    assertThat(lazy.get()).isEqualTo("Lazily");
+    assertThat(count.get()).isEqualTo(1);
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Thomas Akehurst
+ * Copyright (C) 2022-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ public class NetworkAddressRulesTest {
   @Test
   void allowsAddressIncludedAndNotExcluded() {
     NetworkAddressRules rules =
-        NetworkAddressRules.builder()
+        DefaultNetworkAddressRules.builder()
             .allow("10.1.1.1-10.2.1.1")
             .allow("192.168.1.1-192.168.2.1")
             .deny("10.1.2.3")
@@ -41,7 +41,7 @@ public class NetworkAddressRulesTest {
 
   @Test
   void onlyAllowSingleIp() {
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
 
     assertThat(rules.isAllowed("10.1.1.1"), is(true));
     assertThat(rules.isAllowed("10.1.1.0"), is(false));
@@ -50,7 +50,7 @@ public class NetworkAddressRulesTest {
 
   @Test
   void onlyDenySingleIp() {
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
 
     assertThat(rules.isAllowed("10.1.1.1"), is(false));
     assertThat(rules.isAllowed("10.1.1.0"), is(true));
@@ -60,7 +60,7 @@ public class NetworkAddressRulesTest {
   @Test
   void allowAndDenySingleIps() {
     NetworkAddressRules rules =
-        NetworkAddressRules.builder().deny("10.1.1.1").allow("10.1.1.3").build();
+        DefaultNetworkAddressRules.builder().deny("10.1.1.1").allow("10.1.1.3").build();
 
     assertThat(rules.isAllowed("10.1.1.0"), is(false));
     assertThat(rules.isAllowed("10.1.1.1"), is(false));
@@ -72,7 +72,7 @@ public class NetworkAddressRulesTest {
   @Test
   void allowRangeAndDenySingleIp() {
     NetworkAddressRules rules =
-        NetworkAddressRules.builder().allow("10.1.1.1-10.1.1.3").deny("10.1.1.2").build();
+        DefaultNetworkAddressRules.builder().allow("10.1.1.1-10.1.1.3").deny("10.1.1.2").build();
 
     assertThat(rules.isAllowed("10.1.1.0"), is(false));
     assertThat(rules.isAllowed("10.1.1.1"), is(true));
@@ -84,7 +84,7 @@ public class NetworkAddressRulesTest {
   @Test
   void denyRangeAndAllowSingleIp() {
     NetworkAddressRules rules =
-        NetworkAddressRules.builder().deny("10.1.1.1-10.1.1.3").allow("10.1.1.2").build();
+        DefaultNetworkAddressRules.builder().deny("10.1.1.1-10.1.1.3").allow("10.1.1.2").build();
 
     assertThat(rules.isAllowed("10.1.1.0"), is(false));
     assertThat(rules.isAllowed("10.1.1.1"), is(false));

--- a/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Thomas Akehurst
+ * Copyright (C) 2014-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,5 +143,24 @@ public class UrlsTest {
   @Test
   public void getsThePathFromAUrlWithJustAQuery() {
     assertThat(Urls.getPath("?q=a"), is(""));
+  }
+
+  @Test
+  void getsThePathAndQueryFromAbsoluteHttpUrl() {
+    assertThat(
+        Urls.getPathAndQuery("http://example.com/things?q=boo&limit=5"),
+        is("/things?q=boo&limit=5"));
+  }
+
+  @Test
+  void getsThePathAndQueryFromAbsoluteHttpsUrl() {
+    assertThat(
+        Urls.getPathAndQuery("https://example.com/things?q=boo&limit=5"),
+        is("/things?q=boo&limit=5"));
+  }
+
+  @Test
+  void getsThePathAndQueryFromRelativeUrl() {
+    assertThat(Urls.getPathAndQuery("/things?q=boo&limit=5"), is("/things?q=boo&limit=5"));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
@@ -22,7 +22,7 @@ import static com.github.tomakehurst.wiremock.crypto.X509CertificateVersion.V3;
 import static java.util.Collections.emptyList;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
 import com.github.tomakehurst.wiremock.crypto.CertificateSpecification;
 import com.github.tomakehurst.wiremock.crypto.InMemoryKeyStore;
@@ -94,7 +94,7 @@ public abstract class HttpClientFactoryCertificateVerificationTest {
             /* trustSelfSignedCertificates= */ false,
             trustedHosts,
             false,
-            NetworkAddressRules.ALLOW_ALL);
+            DefaultNetworkAddressRules.ALLOW_ALL);
   }
 
   @AfterEach

--- a/src/test/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolverTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolverTest.java
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.http;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -36,7 +37,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -55,7 +56,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -70,7 +71,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.0", "10.1.1.1");
     register("2.example.com", "10.1.1.2", "10.1.1.3");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -85,7 +86,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.0", "10.1.1.1");
     register("2.example.com", "10.1.1.2", "10.1.1.3");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -99,7 +100,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -118,7 +119,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -136,7 +137,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.0", "10.1.1.1");
     register("2.example.com", "10.1.1.2", "10.1.1.3");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -159,7 +160,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.0", "10.1.1.1");
     register("2.example.com", "10.1.1.2", "10.1.1.3");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -178,7 +179,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("1.example.com").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("1.example.com").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -197,7 +198,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("1.example.com").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("1.example.com").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -216,7 +217,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("1.example.com").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("1.example.com").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -235,7 +236,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("1.example.com").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("1.example.com").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.http;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.common.NetworkAddressRules.ALLOW_ALL;
+import static com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules.ALLOW_ALL;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static com.github.tomakehurst.wiremock.crypto.X509CertificateVersion.V3;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
@@ -36,6 +36,8 @@ import com.github.tomakehurst.wiremock.crypto.CertificateSpecification;
 import com.github.tomakehurst.wiremock.crypto.InMemoryKeyStore;
 import com.github.tomakehurst.wiremock.crypto.Secret;
 import com.github.tomakehurst.wiremock.crypto.X509CertificateSpecification;
+import com.github.tomakehurst.wiremock.http.client.ApacheBackedHttpClient;
+import com.github.tomakehurst.wiremock.http.client.HttpClient;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.store.InMemorySettingsStore;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
@@ -67,6 +69,9 @@ import org.mockito.Mockito;
 public class ProxyResponseRendererTest {
 
   private static final int PROXY_TIMEOUT = 200_000;
+
+  CloseableHttpClient reverseProxyApacheClient;
+  CloseableHttpClient forwardProxyApacheClient;
 
   @RegisterExtension
   public WireMockExtension origin =
@@ -163,13 +168,10 @@ public class ProxyResponseRendererTest {
 
   @Test
   void doesNotAddEntityIfEmptyBodyReverseProxy() throws IOException {
-    CloseableHttpClient clientSpy =
-        reflectiveSpyField(CloseableHttpClient.class, "reverseProxyClient", proxyResponseRenderer);
-
     ServeEvent serveEvent = reverseProxyServeEvent("/proxied");
 
     proxyResponseRenderer.render(serveEvent);
-    Mockito.verify(clientSpy)
+    Mockito.verify(reverseProxyApacheClient)
         .execute(
             argThat(request -> request.getEntity() == null),
             ArgumentMatchers.any(HttpClientResponseHandler.class));
@@ -177,13 +179,10 @@ public class ProxyResponseRendererTest {
 
   @Test
   void doesNotAddEntityIfEmptyBodyForwardProxy() throws IOException {
-    CloseableHttpClient clientSpy =
-        reflectiveSpyField(CloseableHttpClient.class, "forwardProxyClient", proxyResponseRenderer);
-
     ServeEvent serveEvent = forwardProxyServeEvent("/proxied");
 
     proxyResponseRenderer.render(serveEvent);
-    Mockito.verify(clientSpy)
+    Mockito.verify(forwardProxyApacheClient)
         .execute(
             argThat(request -> request.getEntity() == null),
             ArgumentMatchers.any(HttpClientResponseHandler.class));
@@ -191,14 +190,11 @@ public class ProxyResponseRendererTest {
 
   @Test
   void addsEntityIfNotEmptyBodyReverseProxy() throws IOException {
-    CloseableHttpClient clientSpy =
-        reflectiveSpyField(CloseableHttpClient.class, "reverseProxyClient", proxyResponseRenderer);
-
     ServeEvent serveEvent =
         serveEvent("/proxied", false, "Text body".getBytes(StandardCharsets.UTF_8));
 
     proxyResponseRenderer.render(serveEvent);
-    Mockito.verify(clientSpy)
+    Mockito.verify(reverseProxyApacheClient)
         .execute(
             argThat(request -> request.getEntity() != null),
             ArgumentMatchers.any(HttpClientResponseHandler.class));
@@ -206,14 +202,11 @@ public class ProxyResponseRendererTest {
 
   @Test
   void addsEntityIfNotEmptyBodyForwardProxy() throws IOException {
-    CloseableHttpClient clientSpy =
-        reflectiveSpyField(CloseableHttpClient.class, "forwardProxyClient", proxyResponseRenderer);
-
     ServeEvent serveEvent =
         serveEvent("/proxied", true, "Text body".getBytes(StandardCharsets.UTF_8));
 
     proxyResponseRenderer.render(serveEvent);
-    Mockito.verify(clientSpy)
+    Mockito.verify(forwardProxyApacheClient)
         .execute(
             argThat(request -> request.getEntity() != null),
             ArgumentMatchers.any(HttpClientResponseHandler.class));
@@ -222,10 +215,6 @@ public class ProxyResponseRendererTest {
   @Test
   void addsEmptyEntityIfEmptyBodyForwardProxyPOST() throws IOException {
     ProxyResponseRenderer trustAllProxyResponseRenderer = buildProxyResponseRenderer(true);
-    CloseableHttpClient clientSpy =
-        reflectiveSpyField(
-            CloseableHttpClient.class, "forwardProxyClient", trustAllProxyResponseRenderer);
-
     origin.stubFor(post("/proxied/empty-post").willReturn(aResponse().withBody("Result")));
 
     ServeEvent serveEvent =
@@ -237,7 +226,7 @@ public class ProxyResponseRendererTest {
             new HttpHeaders(new HttpHeader("Content-Length", "0")));
 
     trustAllProxyResponseRenderer.render(serveEvent);
-    Mockito.verify(clientSpy)
+    Mockito.verify(forwardProxyApacheClient)
         .execute(
             argThat(request -> request.getEntity() != null),
             ArgumentMatchers.any(HttpClientResponseHandler.class));
@@ -252,10 +241,6 @@ public class ProxyResponseRendererTest {
   @Test
   void addsEmptyEntityIfEmptyBodyForwardProxyGET() throws IOException {
     ProxyResponseRenderer trustAllProxyResponseRenderer = buildProxyResponseRenderer(true);
-    CloseableHttpClient clientSpy =
-        reflectiveSpyField(
-            CloseableHttpClient.class, "forwardProxyClient", trustAllProxyResponseRenderer);
-
     origin.stubFor(get("/proxied/empty-get").willReturn(aResponse().withBody("Result")));
 
     ServeEvent serveEvent =
@@ -267,7 +252,7 @@ public class ProxyResponseRendererTest {
             new HttpHeaders(new HttpHeader("Content-Length", "0")));
 
     trustAllProxyResponseRenderer.render(serveEvent);
-    Mockito.verify(clientSpy)
+    Mockito.verify(forwardProxyApacheClient)
         .execute(
             argThat(request -> request.getEntity() != null),
             ArgumentMatchers.any(HttpClientResponseHandler.class));
@@ -282,11 +267,9 @@ public class ProxyResponseRendererTest {
   @Test
   void usesCorrectProxyRequestTimeout() {
     RequestConfig forwardProxyClientRequestConfig =
-        reflectiveInnerSpyField(
-            RequestConfig.class, "forwardProxyClient", "defaultConfig", proxyResponseRenderer);
+        reflectiveSpyField(RequestConfig.class, "defaultConfig", forwardProxyApacheClient);
     RequestConfig reverseProxyClientRequestConfig =
-        reflectiveInnerSpyField(
-            RequestConfig.class, "reverseProxyClient", "defaultConfig", proxyResponseRenderer);
+        reflectiveSpyField(RequestConfig.class, "defaultConfig", reverseProxyApacheClient);
 
     assertThat(
         forwardProxyClientRequestConfig.getResponseTimeout().toMilliseconds(),
@@ -322,6 +305,10 @@ public class ProxyResponseRendererTest {
     } catch (NoSuchFieldException | IllegalAccessException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private static <T> T spyField(T object) {
+    return spy(object);
   }
 
   private ServeEvent reverseProxyServeEvent(String path) {
@@ -393,17 +380,40 @@ public class ProxyResponseRendererTest {
 
   private ProxyResponseRenderer buildProxyResponseRenderer(
       boolean trustAllProxyTargets, boolean stubCorsEnabled) {
+
+    reverseProxyApacheClient =
+        spy(
+            HttpClientFactory.createClient(
+                1000,
+                PROXY_TIMEOUT,
+                ProxySettings.NO_PROXY,
+                KeyStoreSettings.NO_STORE,
+                true,
+                Collections.emptyList(),
+                true,
+                ALLOW_ALL));
+    HttpClient reverseProxyClient = new ApacheBackedHttpClient(reverseProxyApacheClient);
+
+    forwardProxyApacheClient =
+        spy(
+            HttpClientFactory.createClient(
+                1000,
+                PROXY_TIMEOUT,
+                ProxySettings.NO_PROXY,
+                KeyStoreSettings.NO_STORE,
+                trustAllProxyTargets,
+                Collections.emptyList(),
+                false,
+                ALLOW_ALL));
+    HttpClient forwardProxyClient = new ApacheBackedHttpClient(forwardProxyApacheClient);
+
     return new ProxyResponseRenderer(
-        ProxySettings.NO_PROXY,
-        KeyStoreSettings.NO_STORE,
         /* preserveHostHeader= */ false,
         /* hostHeaderValue= */ null,
         new InMemorySettingsStore(),
-        trustAllProxyTargets,
-        Collections.emptyList(),
         stubCorsEnabled,
-        ALLOW_ALL,
-        PROXY_TIMEOUT);
+        reverseProxyClient,
+        forwardProxyClient);
   }
 
   // Just exists to make the compiler happy by having the throws clause

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -29,12 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
-import com.github.tomakehurst.wiremock.common.ClasspathFileSource;
-import com.github.tomakehurst.wiremock.common.FileSource;
-import com.github.tomakehurst.wiremock.common.Limit;
-import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
-import com.github.tomakehurst.wiremock.common.ProxySettings;
-import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
+import com.github.tomakehurst.wiremock.common.*;
 import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
 import com.github.tomakehurst.wiremock.core.MappingsSaver;
 import com.github.tomakehurst.wiremock.core.Options;

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockWireMockServices.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockWireMockServices.java
@@ -24,6 +24,8 @@ import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.extension.Extensions;
 import com.github.tomakehurst.wiremock.extension.WireMockServices;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
+import com.github.tomakehurst.wiremock.http.client.HttpClient;
+import com.github.tomakehurst.wiremock.http.client.HttpClientFactory;
 import com.github.tomakehurst.wiremock.store.Stores;
 import com.google.common.base.Suppliers;
 import java.util.Map;
@@ -66,6 +68,16 @@ public class MockWireMockServices implements WireMockServices {
   @Override
   public TemplateEngine getTemplateEngine() {
     return templateEngine.get();
+  }
+
+  @Override
+  public HttpClientFactory getHttpClientFactory() {
+    return null;
+  }
+
+  @Override
+  public HttpClient getDefaultHttpClient() {
+    return null;
   }
 
   public MockWireMockServices setFileSource(FileSource fileSource) {

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
@@ -385,6 +385,7 @@ public class WireMockTestClient {
 
   private static CloseableHttpClient httpClient() {
     return HttpClientBuilder.create()
+        .setUserAgent("WireMock Test Client")
         .disableAuthCaching()
         .disableAutomaticRetries()
         .disableCookieManagement()


### PR DESCRIPTION
This change creates an `HttpClient` abstraction within WireMock with a default Apache backed implementation. This is used in the proxy renderer and webhooks extension in place of the original directly referenced Apache clients.

The HTTP client factory and a default implementation are made available as services to extensions.

The factory for the client can be substituted via the `Options` object or via an extension, following the same pattern as for the HTTP server.

Doing this enables a few useful things:
* Allows full customisation of the client if you want to e.g. add custom security logic and wrap calls in common behaviour.
* Paves the way for a "dependency light" version of WireMock that uses Java's HTTP client and server. This could also make a better Android build.
* Means you can supply network rules programmatically if you need to express a rule that's not possible with the current declarative rules code.
* The gRPC extension can start to support record and playback (by wrapping the client and translating to/from proto).