### PR TITLE
chore: infer explicit type arguments where possible

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
@@ -34,7 +34,7 @@ public class AdminRoutes {
   private final Stores stores;
 
   public static AdminRoutes forClient() {
-    return new AdminRoutes(Collections.<AdminApiExtension>emptyList(), null);
+    return new AdminRoutes(Collections.emptyList(), null);
   }
 
   public static AdminRoutes forServer(Iterable<AdminApiExtension> apiExtensions, Stores stores) {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Exceptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Exceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Thomas Akehurst
+ * Copyright (C) 2013-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,12 +42,14 @@ public class Exceptions {
    * @return Never returns, always throws the passed in exception
    */
   public static <T> T throwUnchecked(final Throwable ex, final Class<T> returnType) {
-    Exceptions.<RuntimeException>throwsUnchecked(ex);
+    Exceptions.throwsUnchecked(ex);
     throw new AssertionError(
         "This code should be unreachable. Something went terribly wrong here!");
   }
 
-  /** @param ex The exception that will be thrown, unwrapped and unchecked */
+  /**
+   * @param ex The exception that will be thrown, unwrapped and unchecked
+   */
   public static void throwUnchecked(final Throwable ex) {
     throwUnchecked(ex, null);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
@@ -183,7 +183,7 @@ public class HttpClientFactory {
         proxySettings,
         trustStoreSettings,
         true,
-        Collections.<String>emptyList(),
+        Collections.emptyList(),
         useSystemProperties,
         networkAddressRules);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/QueryParameter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/QueryParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Thomas Akehurst
+ * Copyright (C) 2011-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class QueryParameter extends MultiValue {
   }
 
   public static QueryParameter absent(String key) {
-    return new QueryParameter(key, Collections.<String>emptyList());
+    return new QueryParameter(key, Collections.emptyList());
   }
 
   @JsonIgnore

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -178,7 +178,7 @@ public class ResponseDefinition {
         null,
         null,
         null,
-        Collections.<String>emptyList(),
+        Collections.emptyList(),
         Parameters.empty(),
         true);
   }
@@ -197,7 +197,7 @@ public class ResponseDefinition {
         null,
         null,
         null,
-        Collections.<String>emptyList(),
+        Collections.emptyList(),
         Parameters.empty(),
         true);
   }
@@ -216,7 +216,7 @@ public class ResponseDefinition {
         null,
         null,
         null,
-        Collections.<String>emptyList(),
+        Collections.emptyList(),
         Parameters.empty(),
         true);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -183,7 +183,7 @@ public class WireMockExtension extends DslWrapper
               .flatMap(
                   annotatedElement ->
                       AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class))
-              .<Boolean>map(WireMockTest::proxyMode)
+              .map(WireMockTest::proxyMode)
               .orElse(false);
     }
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotRecordResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotRecordResult.java
@@ -50,7 +50,7 @@ public class SnapshotRecordResult {
   }
 
   public static SnapshotRecordResult empty() {
-    return full(Collections.<StubMapping>emptyList());
+    return full(Collections.emptyList());
   }
 
   public static class Full extends SnapshotRecordResult {
@@ -69,7 +69,7 @@ public class SnapshotRecordResult {
     private final List<UUID> ids;
 
     public Ids(List<UUID> ids) {
-      super(Collections.<StubMapping>emptyList());
+      super(Collections.emptyList());
       this.ids = ids;
     }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/FindRequestsResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/FindRequestsResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Thomas Akehurst
+ * Copyright (C) 2011-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ public class FindRequestsResult extends JournalBasedResult {
   }
 
   public static FindRequestsResult withRequestJournalDisabled() {
-    return new FindRequestsResult(Collections.<LoggedRequest>emptyList(), true);
+    return new FindRequestsResult(Collections.emptyList(), true);
   }
 
   public static FindRequestsResult withRequests(List<LoggedRequest> requests) {

--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -35,7 +35,6 @@ import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.TextFile;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
-import com.github.tomakehurst.wiremock.http.DelayDistribution;
 import com.github.tomakehurst.wiremock.http.UniformDistribution;
 import com.github.tomakehurst.wiremock.junit.Stubbing;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
@@ -1125,9 +1124,7 @@ public class AdminApiTest extends AcceptanceTestBase {
     assertThat(response.statusCode(), is(200));
 
     GlobalSettings settings = wireMockServer.getGlobalSettings().getSettings();
-    assertThat(
-        settings.getDelayDistribution(),
-        Matchers.<DelayDistribution>instanceOf(UniformDistribution.class));
+    assertThat(settings.getDelayDistribution(), Matchers.instanceOf(UniformDistribution.class));
     assertThat(settings.getExtended().getInt("one"), is(1));
     assertThat(
         settings.getExtended().getMetadata("two").as(TestExtendedSettingsData.class).name,

--- a/src/test/java/com/github/tomakehurst/wiremock/DateHeaderAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/DateHeaderAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,6 @@ public class DateHeaderAcceptanceTest extends AcceptanceTestBase {
 
     WireMockResponse response = testClient.get("/nodateheader");
 
-    assertThat(response.headers().get("Date"), is(Matchers.<String>empty()));
+    assertThat(response.headers().get("Date"), is(Matchers.empty()));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/StubLifecycleListenerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubLifecycleListenerAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Thomas Akehurst
+ * Copyright (C) 2019-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ public class StubLifecycleListenerAcceptanceTest {
       wm.stubFor(get("/test").withName("Created").willReturn(ok()));
       fail("Expected an exception to be thrown");
     } catch (Exception e) {
-      assertThat(e, Matchers.<Exception>instanceOf(NotPermittedException.class));
+      assertThat(e, Matchers.instanceOf(NotPermittedException.class));
     }
 
     assertTrue(wm.listAllStubMappings().getMappings().isEmpty());

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
@@ -400,7 +400,7 @@ public class ProxyResponseRendererTest {
         /* hostHeaderValue= */ null,
         new InMemorySettingsStore(),
         trustAllProxyTargets,
-        Collections.<String>emptyList(),
+        Collections.emptyList(),
         stubCorsEnabled,
         ALLOW_ALL,
         PROXY_TIMEOUT);

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CertificateGeneratingX509ExtendedKeyManagerChooseEngineServerAliasDefaultsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CertificateGeneratingX509ExtendedKeyManagerChooseEngineServerAliasDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Thomas Akehurst
+ * Copyright (C) 2020-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,8 +128,7 @@ public class CertificateGeneratingX509ExtendedKeyManagerChooseEngineServerAliasD
 
   @Test
   public void returnsDefaultIfThereAreNoSNIServerNames() {
-    given(extendedSslSessionMock.getRequestedServerNames())
-        .willReturn(Collections.<SNIServerName>emptyList());
+    given(extendedSslSessionMock.getRequestedServerNames()).willReturn(Collections.emptyList());
 
     String alias =
         certificateGeneratingKeyManager.chooseEngineServerAlias(

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CertificateGeneratingX509ExtendedKeyManagerChooseServerAliasDefaultsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ssl/CertificateGeneratingX509ExtendedKeyManagerChooseServerAliasDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Thomas Akehurst
+ * Copyright (C) 2020-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,8 +137,7 @@ public class CertificateGeneratingX509ExtendedKeyManagerChooseServerAliasDefault
 
   @Test
   public void returnsDefaultIfThereAreNoSNIServerNames() {
-    given(extendedSslSessionMock.getRequestedServerNames())
-        .willReturn(Collections.<SNIServerName>emptyList());
+    given(extendedSslSessionMock.getRequestedServerNames()).willReturn(Collections.emptyList());
 
     String alias =
         certificateGeneratingKeyManager.chooseServerAlias("RSA", nullPrincipals, sslSocketMock);

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
 import org.skyscreamer.jsonassert.JSONCompareMode;
-import org.xmlunit.diff.ComparisonType;
 
 public class EqualToXmlPatternTest {
 
@@ -396,7 +395,7 @@ public class EqualToXmlPatternTest {
         placeholderClosingDelimiterRegex, equalToXmlPattern.getPlaceholderClosingDelimiterRegex());
     assertThat(
         equalToXmlPattern.getExemptedComparisons(),
-        Matchers.<Set<ComparisonType>>is(Set.of(SCHEMA_LOCATION, NAMESPACE_URI, ATTR_VALUE)));
+        Matchers.is(Set.of(SCHEMA_LOCATION, NAMESPACE_URI, ATTR_VALUE)));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
@@ -273,8 +273,7 @@ public class MatchesXPathPatternTest {
 
   @Test
   public void serialisesCorrectlyWithoutNamspaces() throws JSONException {
-    MatchesXPathPattern pattern =
-        new MatchesXPathPattern("//*", Collections.<String, String>emptyMap());
+    MatchesXPathPattern pattern = new MatchesXPathPattern("//*", Collections.emptyMap());
 
     String json = Json.write(pattern);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilderTest.java
@@ -78,7 +78,7 @@ public class MultipartValuePatternBuilderTest {
     //        assertThat(headerPatterns.entrySet(),
     // everyItem(isIn(pattern.getMultipartHeaders().entrySet())));
 
-    List<ContentPattern<?>> bodyPatterns = Arrays.<ContentPattern<?>>asList(equalToXml("<xml />"));
+    List<ContentPattern<?>> bodyPatterns = Arrays.asList(equalToXml("<xml />"));
     assertThat(bodyPatterns, everyItem(is(in(pattern.getBodyPatterns()))));
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/diff/PlainTextDiffRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/diff/PlainTextDiffRendererTest.java
@@ -56,8 +56,7 @@ public class PlainTextDiffRendererTest {
   public void init() {
     diffRenderer =
         new PlainTextDiffRenderer(
-            Collections.<String, RequestMatcherExtension>singletonMap(
-                "my-custom-matcher", new MyCustomMatcher()));
+            Collections.singletonMap("my-custom-matcher", new MyCustomMatcher()));
   }
 
   @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Inferred explicit type arguments where possible

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
