### PR TITLE
Add null check for actual date/time truncation (#2466)

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/DateTimeTruncation.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/DateTimeTruncation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public enum DateTimeTruncation {
   }
 
   public ZonedDateTime truncate(ZonedDateTime input) {
-    return fn.apply(input);
+    return input != null ? fn.apply(input) : null;
   }
 
   public Date truncate(Date input) {


### PR DESCRIPTION
A missing null check in `DateTimeTruncation#truncate` results in null pointer exceptions whenever the user uses a matcher which includes `truncateActual`. This largely makes `truncateActual` unusable since it breaks functionality, especially when the mapping including `truncateActual` is added last.

## References
Fixes https://github.com/wiremock/wiremock/issues/2466
<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
