### PR TITLE
chore: use List.of where possible if only one argument is passed

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/UniqueFilenameGenerator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/UniqueFilenameGenerator.java
@@ -26,7 +26,7 @@ public class UniqueFilenameGenerator {
 
   public static String generate(String url, String prefix, String id, String extension) {
     String pathPart = Urls.urlToPathParts(URI.create(url));
-    pathPart = pathPart.isEmpty() ? "(root)" : sanitise(pathPart);
+    pathPart = pathPart.isBlank() ? "(root)" : sanitise(pathPart);
 
     if (pathPart.length() > 150) {
       pathPart = StringUtils.truncate(pathPart, 150);

--- a/src/main/java/com/github/tomakehurst/wiremock/common/UniqueFilenameGenerator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/UniqueFilenameGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Thomas Akehurst
+ * Copyright (C) 2013-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,13 +32,7 @@ public class UniqueFilenameGenerator {
       pathPart = StringUtils.truncate(pathPart, 150);
     }
 
-    return prefix +
-            "-" +
-            pathPart +
-            "-" +
-            id +
-            "." +
-            extension;
+    return prefix + "-" + pathPart + "-" + id + "." + extension;
   }
 
   private static String sanitise(String input) {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/UniqueFilenameGenerator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/UniqueFilenameGenerator.java
@@ -26,20 +26,19 @@ public class UniqueFilenameGenerator {
 
   public static String generate(String url, String prefix, String id, String extension) {
     String pathPart = Urls.urlToPathParts(URI.create(url));
-    pathPart = pathPart.equals("") ? "(root)" : sanitise(pathPart);
+    pathPart = pathPart.isEmpty() ? "(root)" : sanitise(pathPart);
 
     if (pathPart.length() > 150) {
       pathPart = StringUtils.truncate(pathPart, 150);
     }
 
-    return new StringBuilder(prefix)
-        .append("-")
-        .append(pathPart)
-        .append("-")
-        .append(id)
-        .append(".")
-        .append(extension)
-        .toString();
+    return prefix +
+            "-" +
+            pathPart +
+            "-" +
+            id +
+            "." +
+            extension;
   }
 
   private static String sanitise(String input) {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonData.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonData.java
@@ -158,7 +158,7 @@ public abstract class JsonData<T> {
     }
 
     public boolean containsAll(Collection<?> c) {
-      return new HashSet<>(data).containsAll(c);
+      return data.containsAll(c);
     }
 
     public boolean addAll(Collection<?> c) {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonData.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Thomas Akehurst
+ * Copyright (C) 2018-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
 import com.github.tomakehurst.wiremock.common.Json;
-
 import java.util.*;
 
 public abstract class JsonData<T> {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonData.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonData.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
 import com.github.tomakehurst.wiremock.common.Json;
+
 import java.util.*;
 
 public abstract class JsonData<T> {
@@ -158,7 +159,7 @@ public abstract class JsonData<T> {
     }
 
     public boolean containsAll(Collection<?> c) {
-      return data.containsAll(c);
+      return new HashSet<>(data).containsAll(c);
     }
 
     public boolean addAll(Collection<?> c) {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelper.java
@@ -56,7 +56,7 @@ public class ParseJsonHelper extends HandlebarsHelper<Object> {
 
       // Edge case if JSON object is empty {}
       String jsonAsStringWithoutSpace = jsonAsString.replaceAll("\\s", "");
-      if (jsonAsStringWithoutSpace.equals("{}") || jsonAsStringWithoutSpace.equals("")) {
+      if (jsonAsStringWithoutSpace.equals("{}") || jsonAsStringWithoutSpace.isEmpty()) {
         result = new HashMap<String, Object>();
       } else {
         if (jsonAsString.startsWith("[") && jsonAsString.endsWith("]")) {

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
@@ -27,10 +27,8 @@ import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 
 class ResponseDefinitionBuilderTest {

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
@@ -29,6 +29,8 @@ import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 class ResponseDefinitionBuilderTest {
@@ -121,7 +123,7 @@ class ResponseDefinitionBuilderTest {
 
     assertThat(
         proxyDefinition.getAdditionalProxyRequestHeaders(),
-        equalTo(new HttpHeaders(Arrays.asList(new HttpHeader("header", "value")))));
+        equalTo(new HttpHeaders(List.of(new HttpHeader("header", "value")))));
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
   }
 
@@ -137,7 +139,7 @@ class ResponseDefinitionBuilderTest {
 
     assertThat(
         proxyDefinition.getAdditionalProxyRequestHeaders(),
-        equalTo(new HttpHeaders(Arrays.asList(new HttpHeader("header", "value")))));
+        equalTo(new HttpHeaders(List.of(new HttpHeader("header", "value")))));
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
   }
 
@@ -153,7 +155,7 @@ class ResponseDefinitionBuilderTest {
 
     assertThat(
         proxyDefinition.getAdditionalProxyRequestHeaders(),
-        equalTo(new HttpHeaders(Arrays.asList(new HttpHeader("header", "value")))));
+        equalTo(new HttpHeaders(List.of(new HttpHeader("header", "value")))));
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilderTest.java
@@ -15,14 +15,13 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
 
 public class MultipartValuePatternBuilderTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilderTest.java
@@ -15,24 +15,14 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
-import static com.github.tomakehurst.wiremock.client.WireMock.absent;
-import static com.github.tomakehurst.wiremock.client.WireMock.containing;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalToXml;
-import static java.util.Arrays.asList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.in;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MultipartValuePatternBuilderTest {
 
@@ -70,15 +60,7 @@ public class MultipartValuePatternBuilderTest {
             .withBody(equalToXml("<xml />"))
             .build();
 
-    Map<String, List<MultiValuePattern>> headerPatterns = new LinkedHashMap<>();
-    headerPatterns.put(
-        "Content-Disposition", asList(MultiValuePattern.of(containing("name=\"name\""))));
-    headerPatterns.put("X-Header", asList(MultiValuePattern.of(containing("something"))));
-    headerPatterns.put("X-Other", asList(MultiValuePattern.of(absent())));
-    //        assertThat(headerPatterns.entrySet(),
-    // everyItem(isIn(pattern.getMultipartHeaders().entrySet())));
-
-    List<ContentPattern<?>> bodyPatterns = Arrays.asList(equalToXml("<xml />"));
+    List<ContentPattern<?>> bodyPatterns = List.of(equalToXml("<xml />"));
     assertThat(bodyPatterns, everyItem(is(in(pattern.getBodyPatterns()))));
   }
 
@@ -97,30 +79,7 @@ public class MultipartValuePatternBuilderTest {
             .withBody(equalToXml("<xml />"))
             .build();
 
-    Map<String, List<MultiValuePattern>> headerPatterns = new LinkedHashMap<>();
-    headerPatterns.put("X-Header", asList(MultiValuePattern.of(containing("something"))));
-    headerPatterns.put("X-Other", asList(MultiValuePattern.of(absent())));
-    //        assertThat(headerPatterns.entrySet(),
-    // everyItem(isIn(pattern.getHeaders().entrySet())));
-
-    List<ContentPattern<?>> bodyPatterns = Arrays.<ContentPattern<?>>asList(equalToXml("<xml />"));
+    List<ContentPattern<?>> bodyPatterns = List.of(equalToXml("<xml />"));
     assertThat(bodyPatterns, everyItem(is(in(pattern.getBodyPatterns()))));
-  }
-
-  @Test
-  public void testBuilderWithNameAndOtherContentDispositionHeaderMatcher() {
-    MultipartValuePattern pattern =
-        aMultipart("name")
-            .withHeader("Content-Disposition", containing("filename=\"something\""))
-            .build();
-
-    Map<String, List<MultiValuePattern>> headerPatterns = new LinkedHashMap<>();
-    headerPatterns.put(
-        "Content-Disposition",
-        asList(
-            MultiValuePattern.of(containing("name=\"name\"")),
-            MultiValuePattern.of(containing("filename=\"something\""))));
-    //        assertThat(headerPatterns.entrySet(),
-    // everyItem(isIn(pattern.getMultipartHeaders().entrySet())));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
@@ -15,16 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import com.github.tomakehurst.wiremock.client.BasicCredentials;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.extension.Parameters;
-import com.github.tomakehurst.wiremock.http.Request;
-import com.github.tomakehurst.wiremock.http.RequestMethod;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.Map;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static java.util.Collections.emptyMap;
@@ -32,6 +22,15 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
+
+import com.github.tomakehurst.wiremock.client.BasicCredentials;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
 
 public class RequestPatternBuilderTest {
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
@@ -15,26 +15,23 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.in;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.Is.is;
-
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
+import org.junit.jupiter.api.Test;
+
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.core.Is.is;
 
 public class RequestPatternBuilderTest {
   @Test
@@ -128,7 +125,7 @@ public class RequestPatternBuilderTest {
             List.of(WireMock.equalTo("BODY")),
             null,
             null,
-            asList(multipartPattern));
+            singletonList(multipartPattern));
 
     RequestPattern newRequestPattern = RequestPatternBuilder.like(requestPattern).build();
     assertThat(newRequestPattern, is(requestPattern));


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Cleaned up some Arrays.asList that were never adapted/only one arguments, and removed them in case they weren't used at all.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
