### PR TITLE
Delegate parsing of media types to library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ dependencies {
   api "commons-io:commons-io:2.15.0"
 
   api 'com.networknt:json-schema-validator:1.0.87'
+  implementation 'me.jvt.http:media-type:1.1.3'
 
   testImplementation "junit:junit:4.13"
   testImplementation("org.junit.jupiter:junit-jupiter:$versions.junitJupiter")
@@ -316,6 +317,7 @@ shadowJar {
   relocate "org.yaml", "wiremock.org.yaml"
   relocate "com.ethlo", "wiremock.com.ethlo"
   relocate "com.networknt", "wiremock.com.networknt"
+  relocate 'me.jvt.http', 'wiremock.me.jvt.http'
 
   dependencies {
     exclude(dependency('junit:junit'))


### PR DESCRIPTION
Instead of us handling any media-type related parsing, we should instead
delegate to a library for this.

---

This is a reimplementation of https://github.com/wiremock/wiremock/pull/1686 in part to freshly recreate it to avoid the merge conflicts, but also shamelessly to see if it can count for Hacktoberfest :jack_o_lantern: 