### PR TITLE
Fix network address rules breaking change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ allprojects {
     mavenCentral()
   }
 
-  version = '3.3.0'
+  version = '3.3.1'
 
 
   sourceCompatibility = 11

--- a/src/main/java/com/github/tomakehurst/wiremock/common/DefaultNetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/DefaultNetworkAddressRules.java
@@ -17,25 +17,16 @@ package com.github.tomakehurst.wiremock.common;
 
 import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL;
 import static com.github.tomakehurst.wiremock.common.NetworkAddressUtils.isValidInet4Address;
-import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toSet;
 
-import java.util.HashSet;
 import java.util.Set;
 
 public class DefaultNetworkAddressRules implements NetworkAddressRules {
-
-  public static Builder builder() {
-    return new Builder();
-  }
 
   private final Set<NetworkAddressRange> allowed;
   private final Set<NetworkAddressRange> allowedHostPatterns;
   private final Set<NetworkAddressRange> denied;
   private final Set<NetworkAddressRange> deniedHostPatterns;
-
-  public static final NetworkAddressRules ALLOW_ALL =
-      new DefaultNetworkAddressRules(Set.of(ALL), emptySet());
 
   public DefaultNetworkAddressRules(
       Set<NetworkAddressRange> allowed, Set<NetworkAddressRange> denied) {
@@ -87,29 +78,6 @@ public class DefaultNetworkAddressRules implements NetworkAddressRules {
     } else {
       return allowedHostPatterns.stream().anyMatch(rule -> rule.isIncluded(testValue))
           && deniedHostPatterns.stream().noneMatch(rule -> rule.isIncluded(testValue));
-    }
-  }
-
-  public static class Builder {
-    private final Set<NetworkAddressRange> allowed = new HashSet<>();
-    private final Set<NetworkAddressRange> denied = new HashSet<>();
-
-    public Builder allow(String expression) {
-      allowed.add(NetworkAddressRange.of(expression));
-      return this;
-    }
-
-    public Builder deny(String expression) {
-      denied.add(NetworkAddressRange.of(expression));
-      return this;
-    }
-
-    public NetworkAddressRules build() {
-      Set<NetworkAddressRange> allowedRanges = allowed;
-      if (allowedRanges.isEmpty()) {
-        allowedRanges = Set.of(ALL);
-      }
-      return new DefaultNetworkAddressRules(Set.copyOf(allowedRanges), Set.copyOf(denied));
     }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -15,6 +15,41 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
+import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL;
+import static java.util.Collections.emptySet;
+
+import java.util.HashSet;
+import java.util.Set;
+
 public interface NetworkAddressRules {
+  NetworkAddressRules ALLOW_ALL = new DefaultNetworkAddressRules(Set.of(ALL), emptySet());
+
+  static Builder builder() {
+    return new Builder();
+  }
+
   boolean isAllowed(String testValue);
+
+  public static class Builder {
+    private final Set<NetworkAddressRange> allowed = new HashSet<>();
+    private final Set<NetworkAddressRange> denied = new HashSet<>();
+
+    public Builder allow(String expression) {
+      allowed.add(NetworkAddressRange.of(expression));
+      return this;
+    }
+
+    public Builder deny(String expression) {
+      denied.add(NetworkAddressRange.of(expression));
+      return this;
+    }
+
+    public NetworkAddressRules build() {
+      Set<NetworkAddressRange> allowedRanges = allowed;
+      if (allowedRanges.isEmpty()) {
+        allowedRanges = Set.of(ALL);
+      }
+      return new DefaultNetworkAddressRules(Set.copyOf(allowedRanges), Set.copyOf(denied));
+    }
+  }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -134,7 +134,7 @@ public class WireMockConfiguration implements Options {
 
   private Limit responseBodySizeLimit = UNLIMITED;
 
-  private NetworkAddressRules proxyTargetRules = DefaultNetworkAddressRules.ALLOW_ALL;
+  private NetworkAddressRules proxyTargetRules = NetworkAddressRules.ALLOW_ALL;
 
   private int proxyTimeout = DEFAULT_TIMEOUT;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
@@ -23,7 +23,6 @@ import static com.github.tomakehurst.wiremock.http.RequestMethod.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.ProxySettings;
 import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
@@ -241,7 +240,7 @@ public class HttpClientFactory {
         NO_PROXY,
         NO_STORE,
         true,
-        DefaultNetworkAddressRules.ALLOW_ALL);
+        NetworkAddressRules.ALLOW_ALL);
   }
 
   public static CloseableHttpClient createClient(int timeoutMilliseconds) {
@@ -255,7 +254,7 @@ public class HttpClientFactory {
         proxySettings,
         NO_STORE,
         true,
-        DefaultNetworkAddressRules.ALLOW_ALL);
+        NetworkAddressRules.ALLOW_ALL);
   }
 
   public static CloseableHttpClient createClient() {

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -238,7 +238,7 @@ public class WarConfiguration implements Options {
 
   @Override
   public NetworkAddressRules getProxyTargetRules() {
-    return DefaultNetworkAddressRules.ALLOW_ALL;
+    return NetworkAddressRules.ALLOW_ALL;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -904,7 +904,7 @@ public class CommandLineOptions implements Options {
 
   @Override
   public NetworkAddressRules getProxyTargetRules() {
-    DefaultNetworkAddressRules.Builder builder = DefaultNetworkAddressRules.builder();
+    DefaultNetworkAddressRules.Builder builder = NetworkAddressRules.builder();
     if (optionSet.has(ALLOW_PROXY_TARGETS)) {
       Arrays.stream(((String) optionSet.valueOf(ALLOW_PROXY_TARGETS)).split(","))
           .forEach(builder::allow);

--- a/src/main/resources/swagger/wiremock-admin-api.json
+++ b/src/main/resources/swagger/wiremock-admin-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "WireMock",
-    "version": "3.3.0"
+    "version": "3.3.1"
   },
   "externalDocs": {
     "description": "WireMock user documentation",

--- a/src/main/resources/swagger/wiremock-admin-api.yaml
+++ b/src/main/resources/swagger/wiremock-admin-api.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 
 info:
   title: WireMock
-  version: 3.3.0
+  version: 3.3.1
 
 externalDocs:
   description: WireMock user documentation

--- a/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.ProxySettings;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -637,7 +637,7 @@ public class ProxyAcceptanceTest {
     init(
         wireMockConfig()
             .limitProxyTargets(
-                DefaultNetworkAddressRules.builder()
+                NetworkAddressRules.builder()
                     .deny("10.1.2.3")
                     .deny("192.168.10.1-192.168.11.254")
                     .build()));
@@ -656,8 +656,7 @@ public class ProxyAcceptanceTest {
   void preventsProxyingToExcludedHostnames() {
     init(
         wireMockConfig()
-            .limitProxyTargets(
-                DefaultNetworkAddressRules.builder().deny("*.wiremock.org").build()));
+            .limitProxyTargets(NetworkAddressRules.builder().deny("*.wiremock.org").build()));
 
     proxy.register(proxyAllTo("http://noway.wiremock.org"));
     assertThat(
@@ -669,7 +668,7 @@ public class ProxyAcceptanceTest {
   void preventsProxyingToNonIncludedHostnames() {
     init(
         wireMockConfig()
-            .limitProxyTargets(DefaultNetworkAddressRules.builder().allow("wiremock.org").build()));
+            .limitProxyTargets(NetworkAddressRules.builder().allow("wiremock.org").build()));
 
     proxy.register(proxyAllTo("http://wiremock.io"));
     assertThat(
@@ -681,7 +680,7 @@ public class ProxyAcceptanceTest {
   void preventsProxyingToIpResolvedFromHostname() {
     init(
         wireMockConfig()
-            .limitProxyTargets(DefaultNetworkAddressRules.builder().deny("127.0.0.1").build()));
+            .limitProxyTargets(NetworkAddressRules.builder().deny("127.0.0.1").build()));
 
     proxy.register(proxyAllTo("http://localhost"));
     assertThat(

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
@@ -32,7 +32,7 @@ import static org.wiremock.webhooks.Webhooks.webhook;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
-import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
@@ -92,9 +92,7 @@ public class WebhooksAcceptanceViaPostServeActionTest {
                   .dynamicPort()
                   .notifier(notifier)
                   .limitProxyTargets(
-                      DefaultNetworkAddressRules.builder()
-                          .deny("169.254.0.0-169.254.255.255")
-                          .build()))
+                      NetworkAddressRules.builder().deny("169.254.0.0-169.254.255.255").build()))
           .configureStaticDsl(true)
           .build();
 

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
@@ -32,7 +32,7 @@ import static org.wiremock.webhooks.Webhooks.webhook;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
-import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
@@ -92,9 +92,7 @@ public class WebhooksAcceptanceViaServeEventTest {
                   .dynamicPort()
                   .notifier(notifier)
                   .limitProxyTargets(
-                      DefaultNetworkAddressRules.builder()
-                          .deny("169.254.0.0-169.254.255.255")
-                          .build()))
+                      NetworkAddressRules.builder().deny("169.254.0.0-169.254.255.255").build()))
           .configureStaticDsl(true)
           .build();
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
@@ -25,7 +25,7 @@ public class NetworkAddressRulesTest {
   @Test
   void allowsAddressIncludedAndNotExcluded() {
     NetworkAddressRules rules =
-        DefaultNetworkAddressRules.builder()
+        NetworkAddressRules.builder()
             .allow("10.1.1.1-10.2.1.1")
             .allow("192.168.1.1-192.168.2.1")
             .deny("10.1.2.3")
@@ -41,7 +41,7 @@ public class NetworkAddressRulesTest {
 
   @Test
   void onlyAllowSingleIp() {
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
 
     assertThat(rules.isAllowed("10.1.1.1"), is(true));
     assertThat(rules.isAllowed("10.1.1.0"), is(false));
@@ -50,7 +50,7 @@ public class NetworkAddressRulesTest {
 
   @Test
   void onlyDenySingleIp() {
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
 
     assertThat(rules.isAllowed("10.1.1.1"), is(false));
     assertThat(rules.isAllowed("10.1.1.0"), is(true));
@@ -60,7 +60,7 @@ public class NetworkAddressRulesTest {
   @Test
   void allowAndDenySingleIps() {
     NetworkAddressRules rules =
-        DefaultNetworkAddressRules.builder().deny("10.1.1.1").allow("10.1.1.3").build();
+        NetworkAddressRules.builder().deny("10.1.1.1").allow("10.1.1.3").build();
 
     assertThat(rules.isAllowed("10.1.1.0"), is(false));
     assertThat(rules.isAllowed("10.1.1.1"), is(false));
@@ -72,7 +72,7 @@ public class NetworkAddressRulesTest {
   @Test
   void allowRangeAndDenySingleIp() {
     NetworkAddressRules rules =
-        DefaultNetworkAddressRules.builder().allow("10.1.1.1-10.1.1.3").deny("10.1.1.2").build();
+        NetworkAddressRules.builder().allow("10.1.1.1-10.1.1.3").deny("10.1.1.2").build();
 
     assertThat(rules.isAllowed("10.1.1.0"), is(false));
     assertThat(rules.isAllowed("10.1.1.1"), is(true));
@@ -84,7 +84,7 @@ public class NetworkAddressRulesTest {
   @Test
   void denyRangeAndAllowSingleIp() {
     NetworkAddressRules rules =
-        DefaultNetworkAddressRules.builder().deny("10.1.1.1-10.1.1.3").allow("10.1.1.2").build();
+        NetworkAddressRules.builder().deny("10.1.1.1-10.1.1.3").allow("10.1.1.2").build();
 
     assertThat(rules.isAllowed("10.1.1.0"), is(false));
     assertThat(rules.isAllowed("10.1.1.1"), is(false));

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
@@ -22,7 +22,7 @@ import static com.github.tomakehurst.wiremock.crypto.X509CertificateVersion.V3;
 import static java.util.Collections.emptyList;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
 import com.github.tomakehurst.wiremock.crypto.CertificateSpecification;
 import com.github.tomakehurst.wiremock.crypto.InMemoryKeyStore;
@@ -94,7 +94,7 @@ public abstract class HttpClientFactoryCertificateVerificationTest {
             /* trustSelfSignedCertificates= */ false,
             trustedHosts,
             false,
-            DefaultNetworkAddressRules.ALLOW_ALL);
+            NetworkAddressRules.ALLOW_ALL);
   }
 
   @AfterEach

--- a/src/test/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolverTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolverTest.java
@@ -18,7 +18,6 @@ package com.github.tomakehurst.wiremock.http;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -38,7 +37,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -57,7 +56,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -72,7 +71,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.0", "10.1.1.1");
     register("2.example.com", "10.1.1.2", "10.1.1.3");
 
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -87,7 +86,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.0", "10.1.1.1");
     register("2.example.com", "10.1.1.2", "10.1.1.3");
 
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -101,7 +100,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -120,7 +119,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -138,7 +137,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.0", "10.1.1.1");
     register("2.example.com", "10.1.1.2", "10.1.1.3");
 
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -161,7 +160,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.0", "10.1.1.1");
     register("2.example.com", "10.1.1.2", "10.1.1.3");
 
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -180,7 +179,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("1.example.com").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().deny("1.example.com").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -199,7 +198,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("1.example.com").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().deny("1.example.com").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -218,7 +217,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("1.example.com").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().allow("1.example.com").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -237,7 +236,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("1.example.com").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().allow("1.example.com").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -249,7 +248,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
   void resolveIgnoresIpv6Addresses() throws UnknownHostException {
     register("1.example.com", "10.1.1.1", "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
 
-    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
@@ -16,7 +16,6 @@
 package com.github.tomakehurst.wiremock.http;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules.ALLOW_ALL;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static com.github.tomakehurst.wiremock.crypto.X509CertificateVersion.V3;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
@@ -30,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.spy;
 
+import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.ProxySettings;
 import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
 import com.github.tomakehurst.wiremock.crypto.CertificateSpecification;
@@ -391,7 +391,7 @@ public class ProxyResponseRendererTest {
                 true,
                 Collections.emptyList(),
                 true,
-                ALLOW_ALL));
+                NetworkAddressRules.ALLOW_ALL));
     HttpClient reverseProxyClient = new ApacheBackedHttpClient(reverseProxyApacheClient);
 
     forwardProxyApacheClient =
@@ -404,7 +404,7 @@ public class ProxyResponseRendererTest {
                 trustAllProxyTargets,
                 Collections.emptyList(),
                 false,
-                ALLOW_ALL));
+                NetworkAddressRules.ALLOW_ALL));
     HttpClient forwardProxyClient = new ApacheBackedHttpClient(forwardProxyApacheClient);
 
     return new ProxyResponseRenderer(

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiremock-ui-resources",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "WireMock UI resources processor",
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
3.3.0 accidentally introduced a breaking change when `NetworkAddressRules` was renamed to `DefaultNetworkAddressRules`.

This change moves the static/builder methods etc. back up to the `NetworkAddressRules` interface.