### PR TITLE
Add gzipDisabled at the ResponseDefinitionBuilder level

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.client;
 
 import static com.github.tomakehurst.wiremock.common.ContentTypes.APPLICATION_JSON;
+import static com.github.tomakehurst.wiremock.common.ContentTypes.CONTENT_ENCODING;
 import static com.github.tomakehurst.wiremock.common.ContentTypes.CONTENT_TYPE;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.util.Arrays.asList;
@@ -186,6 +187,13 @@ public class ResponseDefinitionBuilder {
   public ProxyResponseDefinitionBuilder proxiedFrom(String proxyBaseUrl) {
     this.proxyBaseUrl = proxyBaseUrl;
     return new ProxyResponseDefinitionBuilder(this);
+  }
+
+  public ResponseDefinitionBuilder withGzipDisabled(boolean gzipDisabled) {
+    if (gzipDisabled) {
+      this.headers.add(new HttpHeader(CONTENT_ENCODING, "none"));
+    }
+    return this;
   }
 
   public static ResponseDefinitionBuilder responseDefinition() {

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
@@ -15,17 +15,31 @@
  */
 package com.github.tomakehurst.wiremock.client;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.common.ContentTypes.CONTENT_ENCODING;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.http.Body;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.testsupport.TestHttpHeader;
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
@@ -155,5 +169,55 @@ class ResponseDefinitionBuilderTest {
         proxyDefinition.getAdditionalProxyRequestHeaders(),
         equalTo(new HttpHeaders(Arrays.asList(new HttpHeader("header", "value")))));
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
+  }
+
+  @Test
+  void responseDefinitionBuilderWithGzipDisabled() {
+    ResponseDefinition responseDefinition =
+        ResponseDefinitionBuilder.responseDefinition().withGzipDisabled(true).build();
+
+    assertNotNull(responseDefinition);
+    assertEquals(
+        "none", responseDefinition.getHeaders().getHeader(CONTENT_ENCODING).getValues().get(0));
+  }
+
+  @Test
+  void wireMockServerWithStubForWithGzipDisabledTrue() {
+    WireMockServer wireMockServer = new WireMockServer(options().dynamicPort().dynamicHttpsPort());
+    wireMockServer.start();
+    WireMockTestClient client = new WireMockTestClient(wireMockServer.port());
+
+    wireMockServer.stubFor(
+        get(urlEqualTo("/todo/items"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withResponseBody(
+                        new Body(
+                            "Here is some kind of response body"
+                                + "Here is some kind of response body"
+                                + "Here is some kind of response body"))));
+
+    WireMockResponse compressedResponse =
+        client.get("/todo/items", new TestHttpHeader("Accept-Encoding", "gzip"));
+
+    wireMockServer.stubFor(
+        get(urlEqualTo("/todo/items"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withGzipDisabled(true)
+                    .withResponseBody(
+                        new Body(
+                            "Here is some kind of response body"
+                                + "Here is some kind of response body"
+                                + "Here is some kind of response body"))));
+
+    WireMockResponse ordinaryResponse =
+        client.get("/todo/items", new TestHttpHeader("Accept-Encoding", "gzip"));
+
+    assertTrue(compressedResponse.content().length() < ordinaryResponse.content().length());
+    assertFalse(compressedResponse.content().contains("Here is some kind of response body"));
+    assertTrue(ordinaryResponse.content().contains("Here is some kind of response body"));
   }
 }


### PR DESCRIPTION
Greetings, please look at my PR for #2071 

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
