### PR TITLE
Add the version number to the output when wiremock starts

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -770,7 +770,7 @@ public class CommandLineOptions implements Options {
     Map<String, Object> map = new LinkedHashMap<>();
 
     map.put(VERSION, Version.getCurrentVersion());
-    
+
     if (actualHttpPort != null) {
       map.put(PORT, actualHttpPort);
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -29,6 +29,7 @@ import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
 import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSourceFactory;
 import com.github.tomakehurst.wiremock.core.MappingsSaver;
 import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.core.Version;
 import com.github.tomakehurst.wiremock.core.WireMockApp;
 import com.github.tomakehurst.wiremock.extension.ExtensionDeclarations;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
@@ -768,6 +769,8 @@ public class CommandLineOptions implements Options {
   public String toString() {
     Map<String, Object> map = new LinkedHashMap<>();
 
+    map.put(VERSION, Version.getCurrentVersion());
+    
     if (actualHttpPort != null) {
       map.put(PORT, actualHttpPort);
     }


### PR DESCRIPTION
This is a very simple PR to add the version number to the output when wiremock starts. I added it to the `CommandlineOptions` `toString()` method so the version is output regardless of whether the banner is enabled or not.  I thought this might be better than adding the code in multiple places in the startup process. As far as I could tell there are no tests that validate the output of the startup process. 

Output looks like this:
```
██     ██ ██ ██████  ███████ ███    ███  ██████   ██████ ██   ██ 
██     ██ ██ ██   ██ ██      ████  ████ ██    ██ ██      ██  ██  
██  █  ██ ██ ██████  █████   ██ ████ ██ ██    ██ ██      █████   
██ ███ ██ ██ ██   ██ ██      ██  ██  ██ ██    ██ ██      ██  ██  
 ███ ███  ██ ██   ██ ███████ ██      ██  ██████   ██████ ██   ██ 

----------------------------------------------------------------
|               Cloud: https://wiremock.io/cloud               |
|                                                              |
|               Slack: https://slack.wiremock.org              |
----------------------------------------------------------------

version:                      3.3.1
port:                         8080
enable-browser-proxying:      false
disable-banner:               false
no-request-journal:           false
verbose:                      false

extensions:                   response-template,webhook
```

## References

https://wiremock-community.slack.com/archives/C03NAEH5LVA/p1699519576603569

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
