### PR TITLE
Fix `NullPointerException` in `ResponseDefinition.getProxyUrl()`

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -33,6 +33,7 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
 public class ResponseDefinition {
@@ -396,7 +397,9 @@ public class ResponseDefinition {
       return browserProxyUrl;
     }
 
-    return proxyBaseUrl + StringUtils.removeStart(originalRequest.getUrl(), proxyUrlPrefixToRemove);
+    String originalRequestUrl =
+        Optional.ofNullable(originalRequest).map(Request::getUrl).orElse(StringUtils.EMPTY);
+    return proxyBaseUrl + StringUtils.removeStart(originalRequestUrl, proxyUrlPrefixToRemove);
   }
 
   public String getProxyBaseUrl() {

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ResponseDefinitionTest.java
@@ -97,4 +97,11 @@ public class ResponseDefinitionTest {
 
     assertThat(response.getProxyUrl(), equalTo("null/path"));
   }
+
+  @Test
+  public void getProxyUrlGivesBackTheProxyUrlWhenOriginalRequestIsNull() {
+    ResponseDefinition response = ResponseDefinitionBuilder.responseDefinition().build();
+
+    assertThat(response.getProxyUrl(), equalTo("null"));
+  }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Added safe programming when we instantiate `ResponseDefinition` class and use `getProxyUrl()` method when  `originalRequest` field is set to null


## References

- Issue reported: [Issue-2489](https://github.com/wiremock/wiremock/issues/2489)

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
