### PR TITLE
chore(refactor): extract class JsonSchemaVersion to common package

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -1049,7 +1049,7 @@ public class WireMock {
 
   /**
    * @deprecated
-   * this method is moved to {@link com.github.tomakehurst.wiremock.common.Json.JsonSchemaVersion} and will be removed in next version
+   * this enum is moved to {@link com.github.tomakehurst.wiremock.common.Json.JsonSchemaVersion} and will be removed in next version
    */
   @Deprecated
   public enum JsonSchemaVersion {

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -1047,6 +1047,11 @@ public class WireMock {
     return defaultInstance.get().getGlobalSettings();
   }
 
+  /**
+   * @deprecated
+   * this method is moved to {@link com.github.tomakehurst.wiremock.common.Json.JsonSchemaVersion} and will be removed in next version
+   */
+  @Deprecated
   public enum JsonSchemaVersion {
     V4,
     V6,

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.networknt.schema.SpecVersion;
 import java.io.IOException;
 import java.util.Map;
 
@@ -168,5 +169,32 @@ public final class Json {
     }
 
     return count;
+  }
+
+  public enum JsonSchemaVersion {
+    V4,
+    V6,
+    V7,
+    V201909,
+    V202012;
+
+    public static final JsonSchemaVersion DEFAULT = V202012;
+
+    public SpecVersion.VersionFlag toVersionFlag() {
+      switch (this) {
+        case V4:
+          return SpecVersion.VersionFlag.V4;
+        case V6:
+          return SpecVersion.VersionFlag.V6;
+        case V7:
+          return SpecVersion.VersionFlag.V7;
+        case V201909:
+          return SpecVersion.VersionFlag.V201909;
+        case V202012:
+          return SpecVersion.VersionFlag.V202012;
+        default:
+          throw new IllegalArgumentException("Unknown schema version: " + this);
+      }
+    }
   }
 }


### PR DESCRIPTION
Feel free to close this PR if you don't want duplicates at all.

To avoid breaking changes we can keep `JsonSchemaVersion` where it is -> add deprecated flag -> link a method at a new point it is implemented (in this case Json.java in common package)

This PR implements [Extract Class](https://refactoring.guru/extract-class) refactoring:
I noticed JsonSchemaVersion should not be in WireMock class and saw that this was mentioned in the https://github.com/wiremock/wiremock/pull/2134#discussion_r1165986386.

## References

Refactoring task

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
