### PR TITLE
Version number add to the endpoint /health - healthcheck Issue Nro 1339

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/admin/model/HealthCheckResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/model/HealthCheckResult.java
@@ -15,18 +15,25 @@
  */
 package com.github.tomakehurst.wiremock.admin.model;
 
+import com.github.tomakehurst.wiremock.core.Version;
 import java.lang.management.ManagementFactory;
 import java.time.Instant;
+import java.util.Properties;
 
 public class HealthCheckResult {
   private final String status;
   private final String message;
+  private final String version;
+
   private final long uptimeInSeconds;
   private final Instant timestamp;
+
+  private final Properties properties = new Properties();
 
   public HealthCheckResult(String status, String message) {
     this.status = status;
     this.message = message;
+    this.version = Version.getCurrentVersion();
     this.timestamp = Instant.now();
     this.uptimeInSeconds = ManagementFactory.getRuntimeMXBean().getUptime() / 1000;
   }
@@ -37,6 +44,10 @@ public class HealthCheckResult {
 
   public String getMessage() {
     return message;
+  }
+
+  public String getVersion() {
+    return version;
   }
 
   public Instant getTimestamp() {

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/model/HealthCheckResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/model/HealthCheckResult.java
@@ -18,17 +18,13 @@ package com.github.tomakehurst.wiremock.admin.model;
 import com.github.tomakehurst.wiremock.core.Version;
 import java.lang.management.ManagementFactory;
 import java.time.Instant;
-import java.util.Properties;
 
 public class HealthCheckResult {
   private final String status;
   private final String message;
   private final String version;
-
   private final long uptimeInSeconds;
   private final Instant timestamp;
-
-  private final Properties properties = new Properties();
 
   public HealthCheckResult(String status, String message) {
     this.status = status;

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/tasks/HealthCheckTaskTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/tasks/HealthCheckTaskTest.java
@@ -26,6 +26,7 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import java.net.HttpURLConnection;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -46,5 +47,6 @@ class HealthCheckTaskTest {
         response.getStatusMessage(),
         equalTo(response.getReponseBody().asJson().get("message").asText()));
     assertThat(response.getReponseBody().asJson().get("status").asText(), is("healthy"));
+    assertThat(response.getReponseBody().asJson().get("version").asText(), Matchers.notNullValue());
   }
 }


### PR DESCRIPTION
The version number was added  to the endpoint /health 
This partly covers the request on #1339 

## References
#1339 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
