### PR TITLE
Introduce @WireMockTest annotation parameter that allows every SSL certificate

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ssl/PermissiveCertificateAllower.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ssl/PermissiveCertificateAllower.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http.ssl;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+
+public class PermissiveCertificateAllower {
+
+  public static void allowAllCertificatesForHttpsURLConnection() {
+    HttpsURLConnection.setDefaultHostnameVerifier((f, b) -> true);
+    SSLContext context;
+    try {
+      context = SSLContext.getInstance("TLS");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException(e);
+    }
+    try {
+      context.init(
+          null,
+          new X509TrustManager[] {
+            new X509TrustManager() {
+              public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+              public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+
+              public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+              }
+            }
+          },
+          new SecureRandom());
+    } catch (KeyManagementException e) {
+      throw new IllegalStateException(e);
+    }
+    HttpsURLConnection.setDefaultSSLSocketFactory(context.getSocketFactory());
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockTest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2023 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,4 +33,6 @@ public @interface WireMockTest {
   int httpsPort() default 0;
 
   boolean proxyMode() default false;
+
+  boolean allowAllCertificatesForProxy() default false;
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JunitJupiterExtensionDeclarativeWithSSLAllowerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JunitJupiterExtensionDeclarativeWithSSLAllowerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021-2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.junit5;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.status;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import org.junit.jupiter.api.Test;
+
+@WireMockTest(proxyMode = true, allowAllCertificatesForProxy = false)
+class JunitJupiterExtensionDeclarativeWithSSLAllowerTest {
+  @Test
+  void annotation_allows_all_certificates() throws IOException {
+    stubFor(get("/foo").withHost(equalTo("example.com")).willReturn(status(418)));
+
+    URL url = new URL("https://example.com/foo");
+
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+    connection.setRequestMethod("GET");
+
+    int responseCode = connection.getResponseCode();
+
+    assertThat(responseCode, is(418));
+  }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a **subsequent PR** to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
