### PR TITLE
Add support for custom logging by providing a Logback file as a CLI parameter for the standalone jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
   api "org.ow2.asm:asm:9.4"
 
   implementation "org.slf4j:slf4j-api:1.7.36"
-  standaloneOnly "org.slf4j:slf4j-nop:1.7.36"
+  standaloneOnly "ch.qos.logback:logback-classic:1.2.12"
 
   api "net.sf.jopt-simple:jopt-simple:5.0.4"
 
@@ -267,6 +267,7 @@ jar {
     attributes("Main-Class": "com.github.tomakehurst.wiremock.standalone.WireMockServerRunner")
     attributes("Add-Exports": "java.base/sun.security.x509")
   }
+  exclude '**/logback.xml'
 }
 
 shadowJar {
@@ -299,6 +300,7 @@ shadowJar {
   relocate "org.checkerframework", "wiremock.org.checkerframework"
   relocate "org.hamcrest", "wiremock.org.hamcrest"
   relocate "org.slf4j", "wiremock.org.slf4j"
+  relocate "ch.qos.logback", "wiremock.ch.qos.logback"
 
   dependencies {
     exclude(dependency('junit:junit'))

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Slf4jNotifier.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Slf4jNotifier.java
@@ -26,6 +26,10 @@ public class Slf4jNotifier implements Notifier {
 
   public Slf4jNotifier(boolean verbose) {
     this.verbose = verbose;
+
+    if (verbose) {
+      info("Verbose logging enabled");
+    }
   }
 
   @Override

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="wiremock.ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="error">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+  <logger name="WireMock" level="INFO"/>
+</configuration>

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -23,8 +23,10 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.github.tomakehurst.wiremock.common.*;
@@ -45,6 +47,7 @@ import com.github.tomakehurst.wiremock.security.Authenticator;
 import com.google.common.base.Optional;
 import java.util.Collections;
 import java.util.Map;
+import joptsimple.OptionException;
 import org.junit.jupiter.api.Test;
 
 public class CommandLineOptionsTest {
@@ -401,6 +404,27 @@ public class CommandLineOptionsTest {
         options.extensionsOfType(RequestMatcherExtension.class);
     assertThat(extensions.entrySet(), hasSize(1));
     assertThat(extensions.get("RequestMatcherExtension_One"), instanceOf(RequestExt1.class));
+  }
+
+  @Test
+  public void returnsCorrectLogbackFile() {
+    final String file = "logback.xml";
+
+    CommandLineOptions options =
+        new CommandLineOptions(
+            "--logback-config-file",
+            file);
+
+    assertTrue(options.logbackConfigFileProvided());
+    String logbackFile = System.getProperty("logback.configurationFile");
+
+    assertEquals(file, logbackFile);
+  }
+
+  @Test
+  public void throwsExceptionWhenLogbackConfigFileIsNotProvided() {
+    assertThrows(OptionException.class, () -> new CommandLineOptions(
+        "--logback-config-file"));
   }
 
   @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This change only impacts the standalone jar, and allows users to specify a `logback-config-file` CLI parameter to support custom logging.

i.e. `java -jar /path/wiremock-jre8-standalone-2.35.1-all.jar --logback-config-file=/path2/logback.xml`

Without this parameter, Logback is still used via the `Slf4jNotifier`, but the logging format is the same as it was before this change.

## References

- https://github.com/wiremock/wiremock/pull/1109
- Specifically this comment from @tomakehurst, was the desired outcome for this change: https://github.com/wiremock/wiremock/pull/1109#issuecomment-500991876 .

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
