### PR TITLE
chore(refactor): pull up variable

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/ExactMatchMultiValuePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/ExactMatchMultiValuePattern.java
@@ -24,15 +24,15 @@ import java.util.List;
 @JsonDeserialize(as = ExactMatchMultiValuePattern.class)
 public class ExactMatchMultiValuePattern extends MultipleMatchMultiValuePattern {
 
-  public static final String JSON_KEY = "hasExactly";
   public static final String HAS_EXACTLY_OPERATOR = " exactly ";
 
-  @JsonProperty(JSON_KEY)
+  @JsonProperty(EXACT_MATCH_MULTI_VALUE_PATTERN_JSON_KEY)
   private List<StringValuePattern> stringValuePatterns;
 
   @JsonCreator
   public ExactMatchMultiValuePattern(
-      @JsonProperty(JSON_KEY) final List<StringValuePattern> valuePatterns) {
+      @JsonProperty(EXACT_MATCH_MULTI_VALUE_PATTERN_JSON_KEY)
+          final List<StringValuePattern> valuePatterns) {
     this.stringValuePatterns = valuePatterns;
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/IncludesMatchMultiValuePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/IncludesMatchMultiValuePattern.java
@@ -23,15 +23,15 @@ import java.util.List;
 @JsonDeserialize(as = IncludesMatchMultiValuePattern.class)
 public class IncludesMatchMultiValuePattern extends MultipleMatchMultiValuePattern {
 
-  public static final String JSON_KEY = "includes";
-  public static final String INCLUDING_OPERATOR = " including ";
+  private static final String INCLUDING_OPERATOR = " including ";
 
-  @JsonProperty(JSON_KEY)
+  @JsonProperty(INCLUDES_MATCH_MULTI_VALUE_PATTERN_JSON_KEY)
   private final List<StringValuePattern> stringValuePatterns;
 
   @JsonCreator
   public IncludesMatchMultiValuePattern(
-      @JsonProperty(JSON_KEY) final List<StringValuePattern> stringValuePatterns) {
+      @JsonProperty(INCLUDES_MATCH_MULTI_VALUE_PATTERN_JSON_KEY)
+          final List<StringValuePattern> stringValuePatterns) {
     this.stringValuePatterns = stringValuePatterns;
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MultiValuePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MultiValuePattern.java
@@ -27,6 +27,9 @@ import java.util.stream.Collectors;
 @JsonDeserialize(using = MultiValuePatternDeserializer.class)
 public abstract class MultiValuePattern implements NamedValueMatcher<MultiValue> {
 
+  protected static final String INCLUDES_MATCH_MULTI_VALUE_PATTERN_JSON_KEY = "includes";
+  protected static final String EXACT_MATCH_MULTI_VALUE_PATTERN_JSON_KEY = "hasExactly";
+
   public static MultiValuePattern of(StringValuePattern valuePattern) {
     return new SingleMatchMultiValuePattern(valuePattern);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MultiValuePatternDeserializer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MultiValuePatternDeserializer.java
@@ -29,9 +29,9 @@ public class MultiValuePatternDeserializer extends JsonDeserializer<MultiValuePa
       throws IOException {
     JsonNode rootNode = parser.readValueAsTree();
     final ObjectMapper mapper = (ObjectMapper) parser.getCodec();
-    if (rootNode.has(ExactMatchMultiValuePattern.JSON_KEY)) {
+    if (rootNode.has(MultiValuePattern.EXACT_MATCH_MULTI_VALUE_PATTERN_JSON_KEY)) {
       return mapper.treeToValue(rootNode, ExactMatchMultiValuePattern.class);
-    } else if (rootNode.has(IncludesMatchMultiValuePattern.JSON_KEY)) {
+    } else if (rootNode.has(MultiValuePattern.INCLUDES_MATCH_MULTI_VALUE_PATTERN_JSON_KEY)) {
       return mapper.treeToValue(rootNode, IncludesMatchMultiValuePattern.class);
     } else {
       return mapper.treeToValue(rootNode, SingleMatchMultiValuePattern.class);


### PR DESCRIPTION
`ExactMatchMultiValuePattern` and `IncludesMatchMultiValuePattern` has JSON_KEY which can be pulled up in its superclass `MultipleMatchMultiValuePattern`.

## References

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
