### PR TITLE
chore(refactor): Change Bidirectional Association to Unidirectional

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/DefaultNetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/DefaultNetworkAddressRules.java
@@ -19,6 +19,7 @@ import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL;
 import static com.github.tomakehurst.wiremock.common.NetworkAddressUtils.isValidInet4Address;
 import static java.util.stream.Collectors.toSet;
 
+import java.util.HashSet;
 import java.util.Set;
 
 public class DefaultNetworkAddressRules implements NetworkAddressRules {
@@ -78,6 +79,33 @@ public class DefaultNetworkAddressRules implements NetworkAddressRules {
     } else {
       return allowedHostPatterns.stream().anyMatch(rule -> rule.isIncluded(testValue))
           && deniedHostPatterns.stream().noneMatch(rule -> rule.isIncluded(testValue));
+    }
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final Set<NetworkAddressRange> allowed = new HashSet<>();
+    private final Set<NetworkAddressRange> denied = new HashSet<>();
+
+    public Builder allow(String expression) {
+      allowed.add(NetworkAddressRange.of(expression));
+      return this;
+    }
+
+    public Builder deny(String expression) {
+      denied.add(NetworkAddressRange.of(expression));
+      return this;
+    }
+
+    public NetworkAddressRules build() {
+      Set<NetworkAddressRange> allowedRanges = allowed;
+      if (allowedRanges.isEmpty()) {
+        allowedRanges = Set.of(ALL);
+      }
+      return new DefaultNetworkAddressRules(Set.copyOf(allowedRanges), Set.copyOf(denied));
     }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -18,38 +18,10 @@ package com.github.tomakehurst.wiremock.common;
 import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL;
 import static java.util.Collections.emptySet;
 
-import java.util.HashSet;
 import java.util.Set;
 
 public interface NetworkAddressRules {
   NetworkAddressRules ALLOW_ALL = new DefaultNetworkAddressRules(Set.of(ALL), emptySet());
 
-  static Builder builder() {
-    return new Builder();
-  }
-
   boolean isAllowed(String testValue);
-
-  public static class Builder {
-    private final Set<NetworkAddressRange> allowed = new HashSet<>();
-    private final Set<NetworkAddressRange> denied = new HashSet<>();
-
-    public Builder allow(String expression) {
-      allowed.add(NetworkAddressRange.of(expression));
-      return this;
-    }
-
-    public Builder deny(String expression) {
-      denied.add(NetworkAddressRange.of(expression));
-      return this;
-    }
-
-    public NetworkAddressRules build() {
-      Set<NetworkAddressRange> allowedRanges = allowed;
-      if (allowedRanges.isEmpty()) {
-        allowedRanges = Set.of(ALL);
-      }
-      return new DefaultNetworkAddressRules(Set.copyOf(allowedRanges), Set.copyOf(denied));
-    }
-  }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -913,7 +913,7 @@ public class CommandLineOptions implements Options {
 
   @Override
   public NetworkAddressRules getProxyTargetRules() {
-    DefaultNetworkAddressRules.Builder builder = NetworkAddressRules.builder();
+    DefaultNetworkAddressRules.Builder builder = DefaultNetworkAddressRules.builder();
     if (optionSet.has(ALLOW_PROXY_TARGETS)) {
       Arrays.stream(((String) optionSet.valueOf(ALLOW_PROXY_TARGETS)).split(","))
           .forEach(builder::allow);

--- a/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.ProxySettings;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -637,7 +637,7 @@ public class ProxyAcceptanceTest {
     init(
         wireMockConfig()
             .limitProxyTargets(
-                NetworkAddressRules.builder()
+                DefaultNetworkAddressRules.builder()
                     .deny("10.1.2.3")
                     .deny("192.168.10.1-192.168.11.254")
                     .build()));
@@ -656,7 +656,8 @@ public class ProxyAcceptanceTest {
   void preventsProxyingToExcludedHostnames() {
     init(
         wireMockConfig()
-            .limitProxyTargets(NetworkAddressRules.builder().deny("*.wiremock.org").build()));
+            .limitProxyTargets(
+                DefaultNetworkAddressRules.builder().deny("*.wiremock.org").build()));
 
     proxy.register(proxyAllTo("http://noway.wiremock.org"));
     assertThat(
@@ -668,7 +669,7 @@ public class ProxyAcceptanceTest {
   void preventsProxyingToNonIncludedHostnames() {
     init(
         wireMockConfig()
-            .limitProxyTargets(NetworkAddressRules.builder().allow("wiremock.org").build()));
+            .limitProxyTargets(DefaultNetworkAddressRules.builder().allow("wiremock.org").build()));
 
     proxy.register(proxyAllTo("http://wiremock.io"));
     assertThat(
@@ -680,7 +681,7 @@ public class ProxyAcceptanceTest {
   void preventsProxyingToIpResolvedFromHostname() {
     init(
         wireMockConfig()
-            .limitProxyTargets(NetworkAddressRules.builder().deny("127.0.0.1").build()));
+            .limitProxyTargets(DefaultNetworkAddressRules.builder().deny("127.0.0.1").build()));
 
     proxy.register(proxyAllTo("http://localhost"));
     assertThat(

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
@@ -32,7 +32,7 @@ import static org.wiremock.webhooks.Webhooks.webhook;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
-import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
@@ -92,7 +92,9 @@ public class WebhooksAcceptanceViaPostServeActionTest {
                   .dynamicPort()
                   .notifier(notifier)
                   .limitProxyTargets(
-                      NetworkAddressRules.builder().deny("169.254.0.0-169.254.255.255").build()))
+                      DefaultNetworkAddressRules.builder()
+                          .deny("169.254.0.0-169.254.255.255")
+                          .build()))
           .configureStaticDsl(true)
           .build();
 

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
@@ -32,7 +32,7 @@ import static org.wiremock.webhooks.Webhooks.webhook;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
-import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
+import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
@@ -92,7 +92,9 @@ public class WebhooksAcceptanceViaServeEventTest {
                   .dynamicPort()
                   .notifier(notifier)
                   .limitProxyTargets(
-                      NetworkAddressRules.builder().deny("169.254.0.0-169.254.255.255").build()))
+                      DefaultNetworkAddressRules.builder()
+                          .deny("169.254.0.0-169.254.255.255")
+                          .build()))
           .configureStaticDsl(true)
           .build();
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/NetworkAddressRulesTest.java
@@ -25,7 +25,7 @@ public class NetworkAddressRulesTest {
   @Test
   void allowsAddressIncludedAndNotExcluded() {
     NetworkAddressRules rules =
-        NetworkAddressRules.builder()
+        DefaultNetworkAddressRules.builder()
             .allow("10.1.1.1-10.2.1.1")
             .allow("192.168.1.1-192.168.2.1")
             .deny("10.1.2.3")
@@ -41,7 +41,7 @@ public class NetworkAddressRulesTest {
 
   @Test
   void onlyAllowSingleIp() {
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
 
     assertThat(rules.isAllowed("10.1.1.1"), is(true));
     assertThat(rules.isAllowed("10.1.1.0"), is(false));
@@ -50,7 +50,7 @@ public class NetworkAddressRulesTest {
 
   @Test
   void onlyDenySingleIp() {
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
 
     assertThat(rules.isAllowed("10.1.1.1"), is(false));
     assertThat(rules.isAllowed("10.1.1.0"), is(true));
@@ -60,7 +60,7 @@ public class NetworkAddressRulesTest {
   @Test
   void allowAndDenySingleIps() {
     NetworkAddressRules rules =
-        NetworkAddressRules.builder().deny("10.1.1.1").allow("10.1.1.3").build();
+        DefaultNetworkAddressRules.builder().deny("10.1.1.1").allow("10.1.1.3").build();
 
     assertThat(rules.isAllowed("10.1.1.0"), is(false));
     assertThat(rules.isAllowed("10.1.1.1"), is(false));
@@ -72,7 +72,7 @@ public class NetworkAddressRulesTest {
   @Test
   void allowRangeAndDenySingleIp() {
     NetworkAddressRules rules =
-        NetworkAddressRules.builder().allow("10.1.1.1-10.1.1.3").deny("10.1.1.2").build();
+        DefaultNetworkAddressRules.builder().allow("10.1.1.1-10.1.1.3").deny("10.1.1.2").build();
 
     assertThat(rules.isAllowed("10.1.1.0"), is(false));
     assertThat(rules.isAllowed("10.1.1.1"), is(true));
@@ -84,7 +84,7 @@ public class NetworkAddressRulesTest {
   @Test
   void denyRangeAndAllowSingleIp() {
     NetworkAddressRules rules =
-        NetworkAddressRules.builder().deny("10.1.1.1-10.1.1.3").allow("10.1.1.2").build();
+        DefaultNetworkAddressRules.builder().deny("10.1.1.1-10.1.1.3").allow("10.1.1.2").build();
 
     assertThat(rules.isAllowed("10.1.1.0"), is(false));
     assertThat(rules.isAllowed("10.1.1.1"), is(false));

--- a/src/test/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolverTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolverTest.java
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.http;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.github.tomakehurst.wiremock.common.DefaultNetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -37,7 +38,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -56,7 +57,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -71,7 +72,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.0", "10.1.1.1");
     register("2.example.com", "10.1.1.2", "10.1.1.3");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -86,7 +87,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.0", "10.1.1.1");
     register("2.example.com", "10.1.1.2", "10.1.1.3");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -100,7 +101,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -119,7 +120,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -137,7 +138,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.0", "10.1.1.1");
     register("2.example.com", "10.1.1.2", "10.1.1.3");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -160,7 +161,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.0", "10.1.1.1");
     register("2.example.com", "10.1.1.2", "10.1.1.3");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -179,7 +180,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("1.example.com").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("1.example.com").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -198,7 +199,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().deny("1.example.com").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().deny("1.example.com").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -217,7 +218,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("1.example.com").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("1.example.com").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -236,7 +237,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
     register("1.example.com", "10.1.1.1");
     register("2.example.com", "10.1.1.2");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("1.example.com").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("1.example.com").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
@@ -248,7 +249,7 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
   void resolveIgnoresIpv6Addresses() throws UnknownHostException {
     register("1.example.com", "10.1.1.1", "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
 
-    NetworkAddressRules rules = NetworkAddressRules.builder().allow("10.1.1.1").build();
+    NetworkAddressRules rules = DefaultNetworkAddressRules.builder().allow("10.1.1.1").build();
 
     NetworkAddressRulesAdheringDnsResolver resolver =
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);


### PR DESCRIPTION
`DefaultNetworkAddressRules` and `NetworkAddressRules` had bidirectional association because `builder` method inside `NetworkAddressRules` was just abstraction of `DefaultNetworkAddressRules`, thus I moved it in `DefaultNetworkAddressRules` to make association unidirectional

## References

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
