### PR TITLE
Do not return null objects in getAll of the InMemoryRequestJournalStore

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryRequestJournalStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryRequestJournalStore.java
@@ -36,7 +36,7 @@ public class InMemoryRequestJournalStore implements RequestJournalStore {
 
   @Override
   public Stream<ServeEvent> getAll() {
-    return deque.stream().map(serveEvents::get);
+    return deque.stream().map(serveEvents::get).filter(Objects::nonNull);
   }
 
   @Override


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Under heavy load it's possible that `serveEvents.get()` is called with an `UUID` that doesn't exist anymore in the `Map`. The reason for this is that the spliatator (required for `stream()`) of the `ConcurrentLinkedDeque` is weakly consistent. This means that it's not guaranteed that an element that is currently processed in a `Stream` still exists in the collection. So under heavy load it may happen, that one thread reads an element of the `ConcurrentLinkedDeque`. Then this thread gets paused and another thread gets activated which than completely runs the `remove` method of the `InMemoryRequestJournalStore`. Now the first thread gets activated again and calls the `get` method of the `serveEvents` with an `UUID` that doesn't exist anymore in the `Map` which results in a `null` value. As the remaining code doesn't expect `null` values in the `Stream` they should be filtered out. Another solution would be to `synchronize` the code of the `InMemoryRequestJournalStore` but this would slow down the whole thing dramatically.

I haven't added any tests for this as it's hard to reproduce a concurrency issue.

## References

- #2447 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
