### PR TITLE
Expose numberOfParameters on PathTemplate

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/url/PathTemplate.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/url/PathTemplate.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 
 public class PathTemplate {
   static final Pattern SPECIAL_SYMBOL_REGEX =
-      Pattern.compile("(?:\\{(?<variable>[^}]+)\\})|(?<wildcard>\\*\\*)");
+      Pattern.compile("\\{(?<variable>[^}]+)}|(?<wildcard>\\*\\*)");
 
   private final String templateString;
   private final Parser parser;
@@ -110,6 +110,10 @@ public class PathTemplate {
   public int hashCode() {
     return Objects.hash(templateString);
   }
+
+  public int numberOfParameters() {
+    return parser.numberOfParameters();
+  }
 }
 
 class Parser {
@@ -138,6 +142,10 @@ class Parser {
     }
 
     return pathParams;
+  }
+
+  int numberOfParameters() {
+    return templateParameters.size();
   }
 }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/url/PathTemplateTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/url/PathTemplateTest.java
@@ -26,6 +26,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class PathTemplateTest {
 
@@ -252,5 +254,22 @@ public class PathTemplateTest {
   void ignoresQueryParameter() {
     PathTemplate pathTemplate = new PathTemplate("/things/{thingId}/stuff");
     assertTrue(pathTemplate.matches("/things/123/stuff?query=param"));
+  }
+
+  @ParameterizedTest()
+  @CsvSource({
+    "/things,0",
+    "/things/{id},1",
+    "/things/{id}/otherthings/{subId},2",
+    "/things/stuff,0",
+    "/things/**,1",
+    "/things/**/,1",
+    "/things/{id}/**,2",
+    "/things/**/{id},2",
+    "/one/{.first}/two/{;second*},2",
+  })
+  void exposesNumberOfParameters(String template, int expectedNumberOfParameters) {
+    PathTemplate pathTemplate = new PathTemplate(template);
+    assertThat(pathTemplate.numberOfParameters(), is(expectedNumberOfParameters));
   }
 }


### PR DESCRIPTION
Some specifications (e.g. [OpenAPI v3](https://spec.openapis.org/oas/v3.0.3#path-templating-matching)) require choosing a path template by how specific they are.

Exposing the number of parameters allows sorting a set of templates by how specific they are.

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
