### PR TITLE
Parsing config files with BOM character

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
@@ -56,14 +56,12 @@ public final class Json {
 
   private Json() {}
 
-  public static <T> T read(byte[] stream, Class<T> clazz)  {
+  public static <T> T read(byte[] stream, Class<T> clazz) throws IOException {
     try {
       ObjectMapper mapper = getObjectMapper();
       return mapper.readValue(stream, clazz);
     } catch (JsonProcessingException processingException) {
       throw JsonException.fromJackson(processingException);
-    } catch (IOException ioException) {
-      throw new RuntimeException(ioException);
     }
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
@@ -56,6 +56,17 @@ public final class Json {
 
   private Json() {}
 
+  public static <T> T read(byte[] stream, Class<T> clazz)  {
+    try {
+      ObjectMapper mapper = getObjectMapper();
+      return mapper.readValue(stream, clazz);
+    } catch (JsonProcessingException processingException) {
+      throw JsonException.fromJackson(processingException);
+    } catch (IOException ioException) {
+      throw new RuntimeException(ioException);
+    }
+  }
+
   public static <T> T read(String json, Class<T> clazz) {
     try {
       ObjectMapper mapper = getObjectMapper();

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSource.java
@@ -111,7 +111,7 @@ public class JsonFileMappingsSource implements MappingsSource {
     for (TextFile mappingFile : mappingFiles) {
       try {
         StubMappingCollection stubCollection =
-            Json.read(mappingFile.readContentsAsString(), StubMappingCollection.class);
+            Json.read(mappingFile.readContents(), StubMappingCollection.class);
         for (StubMapping mapping : stubCollection.getMappingOrMappings()) {
           mapping.setDirty(false);
           stubMappings.addMapping(mapping);

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSource.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.standalone;
 
 import static com.github.tomakehurst.wiremock.common.AbstractFileSource.byFileExtension;
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 import static com.github.tomakehurst.wiremock.common.Json.writePrivate;
 
 import com.github.tomakehurst.wiremock.common.*;
@@ -23,6 +24,8 @@ import com.github.tomakehurst.wiremock.common.filemaker.FilenameMaker;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.stubbing.StubMappingCollection;
 import com.github.tomakehurst.wiremock.stubbing.StubMappings;
+
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -121,6 +124,8 @@ public class JsonFileMappingsSource implements MappingsSource {
         }
       } catch (JsonException e) {
         throw new MappingFileException(mappingFile.getPath(), e.getErrors().first().getDetail());
+      } catch (IOException e) {
+        throwUnchecked(e);
       }
     }
   }


### PR DESCRIPTION
Hi, please look at this simple PR.

Description: Configuration file content passed as byte array to ObjectMapper readValue method so that it can skip BOM character.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
