### PR TITLE
Adding build function for all kind of UrlPattern in RequestPatternBuilder

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -152,6 +152,26 @@ public class RequestPatternBuilder {
     return this;
   }
 
+  public RequestPatternBuilder withUrlPath(String url) {
+    this.url = WireMock.urlPathEqualTo(url);
+    return this;
+  }
+
+  public RequestPatternBuilder withUrlPathTemplate(String templateUrl) {
+    this.url = WireMock.urlPathTemplate(templateUrl);
+    return this;
+  }
+
+  public RequestPatternBuilder withUrlMatching(String url) {
+    this.url = WireMock.urlMatching(url);
+    return this;
+  }
+
+  public RequestPatternBuilder withUrlPathMatching(String url) {
+    this.url = WireMock.urlPathMatching(url);
+    return this;
+  }
+
   public RequestPatternBuilder withHeader(String key, StringValuePattern valuePattern) {
     headers.put(key, MultiValuePattern.of(valuePattern));
     return this;

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -22,7 +22,6 @@ import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -22,6 +22,8 @@ import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
+import org.apache.hc.client5.http.impl.Wire;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -152,23 +154,8 @@ public class RequestPatternBuilder {
     return this;
   }
 
-  public RequestPatternBuilder withUrlPath(String url) {
-    this.url = WireMock.urlPathEqualTo(url);
-    return this;
-  }
-
-  public RequestPatternBuilder withUrlPathTemplate(String templateUrl) {
-    this.url = WireMock.urlPathTemplate(templateUrl);
-    return this;
-  }
-
-  public RequestPatternBuilder withUrlMatching(String url) {
-    this.url = WireMock.urlMatching(url);
-    return this;
-  }
-
-  public RequestPatternBuilder withUrlPathMatching(String url) {
-    this.url = WireMock.urlPathMatching(url);
+  public RequestPatternBuilder withUrl(UrlPattern urlPattern) {
+    this.url = urlPattern;
     return this;
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -22,7 +22,6 @@ import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-import org.apache.hc.client5.http.impl.Wire;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
@@ -49,7 +49,7 @@ public class RequestPatternBuilderTest {
     RequestPattern requestPattern = RequestPattern.everything();
 
     RequestPattern newRequestPattern =
-            RequestPatternBuilder.like(requestPattern).but().withUrlPath("/foo").build();
+            RequestPatternBuilder.like(requestPattern).but().withUrl(WireMock.urlPathEqualTo("/foo")).build();
 
     assertThat(newRequestPattern.getUrlPath(), is("/foo"));
     assertThat(newRequestPattern, not(equalTo(requestPattern)));

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
@@ -45,6 +45,17 @@ public class RequestPatternBuilderTest {
   }
 
   @Test
+  public void likeRequestPatternWithDifferentUrlPath() {
+    RequestPattern requestPattern = RequestPattern.everything();
+
+    RequestPattern newRequestPattern =
+            RequestPatternBuilder.like(requestPattern).but().withUrlPath("/foo").build();
+
+    assertThat(newRequestPattern.getUrlPath(), is("/foo"));
+    assertThat(newRequestPattern, not(equalTo(requestPattern)));
+  }
+
+  @Test
   public void likeRequestPatternWithoutCustomMatcher() {
     // Use a RequestPattern with everything defined except a custom matcher to ensure all fields are
     // set properly

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,10 @@ public class RequestPatternBuilderTest {
     RequestPattern requestPattern = RequestPattern.everything();
 
     RequestPattern newRequestPattern =
-            RequestPatternBuilder.like(requestPattern).but().withUrl(WireMock.urlPathEqualTo("/foo")).build();
+        RequestPatternBuilder.like(requestPattern)
+            .but()
+            .withUrl(WireMock.urlPathEqualTo("/foo"))
+            .build();
 
     assertThat(newRequestPattern.getUrlPath(), is("/foo"));
     assertThat(newRequestPattern, not(equalTo(requestPattern)));


### PR DESCRIPTION
In order to be able to customize `url` with every kind of `UrlPattern` from a `RequestPattern` using the `like` function, it would be useful if `RequestPatternBuilder` allows to do so.

I added test only for `urlPath` because I did not judge that it was necessary for other (since it wil be exactly the same and lead to a lot of duplicated code, but feel free to tell me otherwise.

## References

- Related issue: https://github.com/wiremock/wiremock/issues/2531

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)