### PR TITLE
Generalize function calculating normalized distance between date/time values

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractDateTimeMatchResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractDateTimeMatchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 
 public abstract class AbstractDateTimeMatchResult extends MatchResult {
+
+  private static final long ONE_YEAR_IN_MILLIS = 365 * 24 * 60 * 60 * 1000L;
 
   private final boolean isZoned;
   private final boolean isLocal;
@@ -83,8 +85,7 @@ public abstract class AbstractDateTimeMatchResult extends MatchResult {
   }
 
   private double calculateDistance(Temporal start, Temporal end) {
-    double distance = ((double) ChronoUnit.YEARS.between(start, end)) / 100;
-    distance = Math.abs(distance);
-    return Math.min(distance, 1.0);
+    long absoluteTimeDifference = Math.abs((ChronoUnit.MILLIS.between(start, end)));
+    return (double) absoluteTimeDifference / (absoluteTimeDifference + 2 * ONE_YEAR_IN_MILLIS);
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/AfterDateTimePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/AfterDateTimePatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,10 @@ package com.github.tomakehurst.wiremock.matching;
 
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -97,10 +100,14 @@ public class AfterDateTimePatternTest {
   @Test
   public void returnsAReasonableDistanceWhenNoMatchForLocalExpectedZonedActual() {
     StringValuePattern matcher = WireMock.after("2021-01-01T00:00:00Z");
-    assertThat(matcher.match("1971-01-01T00:00:00Z").getDistance(), is(0.5));
-    assertThat(matcher.match("1921-01-01T00:00:00Z").getDistance(), is(1.0));
+    assertThat(matcher.match("2023-01-01T00:00:00Z").getDistance(), is(0.5));
+    assertThat(
+        matcher.match("1921-01-01T00:00:00Z").getDistance(),
+        allOf(greaterThan(0.5), lessThan(1.0)));
     assertThat(matcher.match(null).getDistance(), is(1.0));
-    assertThat(matcher.match("2020-01-01T00:00:00Z").getDistance(), is(0.01));
+    assertThat(
+        matcher.match("2020-01-01T00:00:00Z").getDistance(),
+        allOf(greaterThan(0.0), lessThan(0.5)));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/BeforeDateTimePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/BeforeDateTimePatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,10 @@ package com.github.tomakehurst.wiremock.matching;
 import static com.github.tomakehurst.wiremock.common.DateTimeTruncation.*;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -87,28 +90,38 @@ public class BeforeDateTimePatternTest {
   @Test
   public void returnsAReasonableDistanceWhenNoMatchForZonedExpectedZonedActual() {
     StringValuePattern matcher = WireMock.before("2021-01-01T00:00:00Z");
-    assertThat(matcher.match("2071-01-01T00:00:00Z").getDistance(), is(0.5));
-    assertThat(matcher.match("2121-01-01T00:00:00Z").getDistance(), is(1.0));
+    assertThat(matcher.match("2023-01-01T00:00:00Z").getDistance(), is(0.5));
+    assertThat(
+        matcher.match("2121-01-01T00:00:00Z").getDistance(),
+        allOf(greaterThan(0.5), lessThan(1.0)));
     assertThat(matcher.match(null).getDistance(), is(1.0));
-    assertThat(matcher.match("2022-01-01T00:00:00Z").getDistance(), is(0.01));
+    assertThat(
+        matcher.match("2022-01-01T00:00:00Z").getDistance(),
+        allOf(greaterThan(0.0), lessThan(0.5)));
   }
 
   @Test
   public void returnsAReasonableDistanceWhenNoMatchForLocalExpectedZonedActual() {
     StringValuePattern matcher = WireMock.before("2021-01-01T00:00:00");
-    assertThat(matcher.match("2071-01-01T00:00:00Z").getDistance(), is(0.5));
-    assertThat(matcher.match("2121-01-01T00:00:00Z").getDistance(), is(1.0));
+    assertThat(matcher.match("2023-01-01T00:00:00Z").getDistance(), is(0.5));
+    assertThat(
+        matcher.match("2121-01-01T00:00:00Z").getDistance(),
+        allOf(greaterThan(0.5), lessThan(1.0)));
     assertThat(matcher.match(null).getDistance(), is(1.0));
-    assertThat(matcher.match("2022-01-01T00:00:00Z").getDistance(), is(0.01));
+    assertThat(
+        matcher.match("2022-01-01T00:00:00Z").getDistance(),
+        allOf(greaterThan(0.0), lessThan(0.5)));
   }
 
   @Test
   public void returnsAReasonableDistanceWhenNoMatchForLocalExpectedLocalActual() {
     StringValuePattern matcher = WireMock.before("2021-01-01T00:00:00");
-    assertThat(matcher.match("2071-01-01T00:00:00").getDistance(), is(0.5));
-    assertThat(matcher.match("2121-01-01T00:00:00").getDistance(), is(1.0));
+    assertThat(matcher.match("2023-01-01T00:00:00").getDistance(), is(0.5));
+    assertThat(
+        matcher.match("2121-01-01T00:00:00").getDistance(), allOf(greaterThan(0.5), lessThan(1.0)));
     assertThat(matcher.match(null).getDistance(), is(1.0));
-    assertThat(matcher.match("2022-01-01T00:00:00").getDistance(), is(0.01));
+    assertThat(
+        matcher.match("2022-01-01T00:00:00").getDistance(), allOf(greaterThan(0.0), lessThan(0.5)));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToDateTimePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToDateTimePatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,10 @@ import static java.time.temporal.ChronoUnit.DAYS;
 import static java.time.temporal.ChronoUnit.HOURS;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -113,10 +116,14 @@ public class EqualToDateTimePatternTest {
   @Test
   public void returnsAReasonableDistanceWhenNoMatchForLocalExpectedZonedActual() {
     StringValuePattern matcher = WireMock.equalToDateTime("2021-01-01T00:00:00Z");
-    assertThat(matcher.match("2071-01-01T00:00:00Z").getDistance(), is(0.5));
-    assertThat(matcher.match("2121-01-01T00:00:00Z").getDistance(), is(1.0));
+    assertThat(matcher.match("2023-01-01T00:00:00Z").getDistance(), is(0.5));
+    assertThat(
+        matcher.match("2121-01-01T00:00:00Z").getDistance(),
+        allOf(greaterThan(0.5), lessThan(1.0)));
     assertThat(matcher.match(null).getDistance(), is(1.0));
-    assertThat(matcher.match("2022-01-01T00:00:00Z").getDistance(), is(0.01));
+    assertThat(
+        matcher.match("2022-01-01T00:00:00Z").getDistance(),
+        allOf(greaterThan(0.0), lessThan(0.5)));
   }
 
   @Test


### PR DESCRIPTION
Right now, multiple value matching for date/time values is broken for actual-to-expected differences smaller than a year.

For instance, given the matchers below:
```
  "request": {
    "method": "GET",
    "urlPath": "/resource",
    "queryParameters": {
      "datetime" : {
        "hasExactly" : [
          {
            "equalToDateTime": "now",
            "truncateActual": "first hour of day",
            "truncateExpected": "first hour of day"
          },
          {
            "equalToDateTime": "now +10 days",
            "truncateActual": "first hour of day",
            "truncateExpected": "first hour of day"
          }
        ]
      }
    }
  }
```
Then (assuming the current date is `2023-12-20`) a GET request to the following URI should be matched:
`/resource?datetime=2023-12-20T00:00:00.000Z&datetime=2023-12-30T00:00:00.000Z`
Instead, we get a "request was not matched" message.

The root cause is in the granularity of the calculation of the distance between the actual and the expected date/time. With the current implementation any date/time pair with a smaller than a year difference has a distance of zero. That means an actual date/time value that's ten minutes after the expected one has the same distance from it as one that's ten months after that.

So, in the example above, all four combinations of the `now` and `now +10 days` matchers on one side and the two date/time query parameters on the other have a distance of zero. This makes multi-value matching unusable for use cases such as retrieving records for the first day of each month within a year, for example.

This PR increases the granularity to the level of minutes allowing the user to also use multi-value matching for the range between a minute and a year. I didn't want to change the logic of the current implementation so I just moved from years to minutes which means the problem remains when matching any number of date/time pairs with a difference below the minute level. Keeping to the current logic, minutes was the most granular level that could be reached. When we turn to seconds functionality seems to break, probably due to floating point overflow/loss of precision.

I have added two tests that break with the current implementation and also tweaked a few existing ones so that they take under account leap years, which wasn't an issue before.

As a side note, the same problem exists for actual-to-expected differences of over 100 years. A date/time pair which is 100 years apart has the same distance (one) as a pair that's 2000 years apart.

## References
An older, related PR: #1925 

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
