### PR TITLE
Adding webhooks as extension externally logs a warning

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -571,6 +571,18 @@ public class WireMock {
 
   public static MappingBuilder any(UrlPattern urlPattern) {
     return new BasicMappingBuilder(RequestMethod.ANY, urlPattern);
+  }
+
+  /**
+   * A mapping builder that can be used for both GET and HEAD http method. Returns a response body
+   * in case for GET and not in case of HEAD method. In case of tie the request is treated as a GET
+   * request
+   *
+   * @param urlPattern for the specified method
+   * @return a mapping builder for {@link RequestMethod#GET_OR_HEAD} http method
+   */
+  public static MappingBuilder getOrHead(UrlPattern urlPattern) {
+    return new BasicMappingBuilder(RequestMethod.GET_OR_HEAD, urlPattern);
   }
 
   public static MappingBuilder request(String method, UrlPattern urlPattern) {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/ExtensionDeclarations.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/ExtensionDeclarations.java
@@ -20,6 +20,7 @@ import static java.util.Arrays.asList;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import org.wiremock.webhooks.Webhooks;
 
 public class ExtensionDeclarations {
 
@@ -27,7 +28,6 @@ public class ExtensionDeclarations {
   private final List<Class<? extends Extension>> classes;
   private final Map<String, Extension> instances;
   private final List<ExtensionFactory> factories;
-  private static final String WEBHOOK_CLASSNAME = "org.wiremock.webhooks.Webhooks";
   private static final String WEBHOOK_MESSAGE =
       "Passing webhooks in extensions is no longer required and"
           + " may lead to compatibility issues in future";
@@ -76,7 +76,7 @@ public class ExtensionDeclarations {
   }
 
   private boolean removeWebhook(String className) {
-    if (className.equals(WEBHOOK_CLASSNAME)) {
+    if (className.equals(Webhooks.class.getName())) {
       notifier().info(WEBHOOK_MESSAGE);
       return false;
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class RequestMethod implements NamedValueMatcher<RequestMethod> {
   public static final RequestMethod HEAD = new RequestMethod("HEAD");
   public static final RequestMethod TRACE = new RequestMethod("TRACE");
   public static final RequestMethod ANY = new RequestMethod("ANY");
-
+  public static final RequestMethod GET_OR_HEAD = new RequestMethod("GET_OR_HEAD");
   private final String name;
 
   public RequestMethod(String name) {
@@ -56,7 +56,9 @@ public class RequestMethod implements NamedValueMatcher<RequestMethod> {
   }
 
   public MatchResult match(RequestMethod method) {
-    return MatchResult.of(this.equals(ANY) || this.equals(method));
+    boolean getOrHeadMatch =
+        this.equals(GET_OR_HEAD) && (method.equals(GET) || method.equals(HEAD));
+    return MatchResult.of(this.equals(ANY) || this.equals(method) || getOrHeadMatch);
   }
 
   @Override
@@ -75,7 +77,6 @@ public class RequestMethod implements NamedValueMatcher<RequestMethod> {
     if (o == null || getClass() != o.getClass()) return false;
 
     RequestMethod that = (RequestMethod) o;
-
     return name.equals(that.name);
   }
 
@@ -94,6 +95,8 @@ public class RequestMethod implements NamedValueMatcher<RequestMethod> {
   }
 
   public static RequestMethod[] values() {
-    return new RequestMethod[] {GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD, TRACE, ANY};
+    return new RequestMethod[] {
+      GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD, TRACE, ANY, GET_OR_HEAD
+    };
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -152,6 +152,11 @@ public class RequestPatternBuilder {
     return this;
   }
 
+  public RequestPatternBuilder withUrl(UrlPattern urlPattern) {
+    this.url = urlPattern;
+    return this;
+  }
+
   public RequestPatternBuilder withHeader(String key, StringValuePattern valuePattern) {
     headers.put(key, MultiValuePattern.of(valuePattern));
     return this;

--- a/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -54,6 +54,21 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
     this.templateEngine = lazy(wireMockServices::getTemplateEngine);
   }
 
+  /**
+   * @deprecated passing this class name is no longer required and may lead to compatibility issues
+   *     in the future.
+   */
+  @Deprecated(since = "3.3")
+  public Webhooks() {
+    this.scheduler = null;
+    this.lazyHttpClient = null;
+    this.transformers = null;
+    this.templateEngine = null;
+    notifier()
+        .info(
+            "Passing the class name is no longer required and may lead to compatibility issues in the future");
+  }
+
   private HttpClient getHttpClient() {
     return lazyHttpClient.get();
   }

--- a/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -54,21 +54,6 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
     this.templateEngine = lazy(wireMockServices::getTemplateEngine);
   }
 
-  /**
-   * @deprecated passing this class name is no longer required and may lead to compatibility issues
-   *     in the future.
-   */
-  @Deprecated(since = "3.3")
-  public Webhooks() {
-    this.scheduler = null;
-    this.lazyHttpClient = null;
-    this.transformers = null;
-    this.templateEngine = null;
-    notifier()
-        .info(
-            "Passing the class name is no longer required and may lead to compatibility issues in the future");
-  }
-
   private HttpClient getHttpClient() {
     return lazyHttpClient.get();
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@ package com.github.tomakehurst.wiremock.client;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,5 +72,67 @@ public class WireMockClientAcceptanceTest {
 
     assertThat(
         testClient.get("/my/new/resource").content(), is("{\"address\":\"Puerto Banús, Málaga\"}"));
+  }
+
+  @Test
+  void testGetOrHeadRequestWhenGetMatchesShouldReturnAResponseBody() {
+    String path = "/get-or-head-test";
+    WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
+    wireMock.register(
+        getOrHead(urlEqualTo(path))
+            .willReturn(okJson("{\"key\": \"value\"}").withHeader("Content-Length", "16")));
+
+    WireMockResponse response = testClient.get(path);
+
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.firstHeader("Content-Type"), is("application/json"));
+    assertThat(response.firstHeader("Content-Length"), is("16"));
+    assertThat(response.content(), not(emptyOrNullString()));
+  }
+
+  @Test
+  void testGetOrHeadRequestWhenHeadMatchesShouldNotReturnAResponseBody() {
+    String path = "/get-or-head-test";
+    WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
+
+    wireMock.register(
+        getOrHead(urlEqualTo(path))
+            .willReturn(
+                okJson("{\"key\": \"value\"}")
+                    .withHeader("Content-Type", "application/json")
+                    .withHeader("Content-Length", "16")));
+    WireMockResponse response = testClient.head(path);
+
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.firstHeader("Content-Type"), is("application/json"));
+    assertThat(response.firstHeader("Content-Length"), is("16"));
+    assertThat(response.content(), is(emptyOrNullString()));
+  }
+
+  @Test
+  void testGetOrHeadRequestWhenNoMethodNotMatchesShouldReturn404() {
+    String path = "/get-or-head-test";
+    WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
+    wireMock.register(
+        getOrHead(urlEqualTo(path))
+            .willReturn(ok().withHeader("Content-Type", "application/json")));
+    WireMockResponse response = testClient.delete(path);
+
+    assertThat(response.statusCode(), is(404));
+  }
+
+  @Test
+  void testGetOrHeadRequestWhenPathDoesNotMatchShouldReturn404() {
+    String correctPath = "/get-or-head-path-correct";
+    String incorrectPath = "/get-or-head-path-incorrect";
+    WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
+    wireMock.register(
+        getOrHead(urlEqualTo(correctPath))
+            .willReturn(ok().withHeader("Content-Type", "application/json")));
+    WireMockResponse responseGet = testClient.get(incorrectPath);
+    WireMockResponse responseHead = testClient.head(incorrectPath);
+
+    assertThat(responseGet.statusCode(), is(404));
+    assertThat(responseHead.statusCode(), is(404));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/webhooks/WebhooksRegistrationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/webhooks/WebhooksRegistrationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2023-2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.webhooks;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.standalone.WireMockServerRunner;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wiremock.webhooks.Webhooks;
+
+class WebhooksRegistrationTest {
+  private static final String MESSAGE =
+      "Passing webhooks in extensions is no longer required and"
+          + " may lead to compatibility issues in future";
+  private final PrintStream stdOut = System.out;
+  private WireMockServerRunner runner;
+  private WireMockServer server;
+  private ByteArrayOutputStream out;
+
+  @BeforeEach
+  public void recordCommandLineMessages() {
+    startRecordingSystemOut();
+  }
+
+  @AfterEach
+  public void resetPrintStream() {
+    System.setOut(stdOut);
+    stopServer();
+  }
+
+  private void startRecordingSystemOut() {
+    out = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(out));
+  }
+
+  private void stopServer() {
+    if (server != null && server.isRunning()) {
+      server.stop();
+    }
+  }
+
+  private void stopRunner() {
+    if (runner != null && runner.isRunning()) {
+      runner.stop();
+    }
+  }
+
+  private String getSystemOutText() {
+    return out.toString();
+  }
+
+  @Test
+  void shouldLogMessageWhenWebhooksAreAddedViaClassName() {
+    server = new WireMockServer(wireMockConfig().extensions("org.wiremock.webhooks.Webhooks"));
+    server.start();
+    assertThat(getSystemOutText(), containsString(MESSAGE));
+  }
+
+  @Test
+  void shouldLogMessageWhenWebhooksAreAddedViaClass() {
+    server = new WireMockServer(wireMockConfig().extensions(Webhooks.class));
+    server.start();
+    assertThat(getSystemOutText(), containsString(MESSAGE));
+  }
+
+  @Test
+  void shouldLogAMessageWhenWebhooksAreAddedViaCLI() {
+    runner = new WireMockServerRunner();
+    runner.run("--extensions", "org.wiremock.webhooks.Webhooks");
+    assertThat(getSystemOutText(), containsString(MESSAGE));
+    stopRunner();
+  }
+
+  @Test
+  void shouldNotLogAMessageWhenWebhooksAreNotAddedExplicitly() {
+    server = new WireMockServer(wireMockConfig());
+    server.start();
+    assertThat(getSystemOutText(), not(containsString(MESSAGE)));
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,20 @@ public class RequestPatternBuilderTest {
         RequestPatternBuilder.like(requestPattern).but().withUrl("/foo").build();
 
     assertThat(newRequestPattern.getUrl(), is("/foo"));
+    assertThat(newRequestPattern, not(equalTo(requestPattern)));
+  }
+
+  @Test
+  public void likeRequestPatternWithDifferentUrlPath() {
+    RequestPattern requestPattern = RequestPattern.everything();
+
+    RequestPattern newRequestPattern =
+        RequestPatternBuilder.like(requestPattern)
+            .but()
+            .withUrl(WireMock.urlPathEqualTo("/foo"))
+            .build();
+
+    assertThat(newRequestPattern.getUrlPath(), is("/foo"));
     assertThat(newRequestPattern, not(equalTo(requestPattern)));
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,6 +107,12 @@ public class WireMockTestClient {
     String actualUrl = URI.create(url).isAbsolute() ? url : mockServiceUrlFor(url);
     HttpUriRequest httpRequest = new HttpGet(actualUrl);
     return executeMethodAndConvertExceptions(httpRequest, headers);
+  }
+
+  public WireMockResponse head(String url, TestHttpHeader... headers) {
+    String actualUrl = URI.create(url).isAbsolute() ? url : mockServiceUrlFor(url);
+    HttpUriRequest httpUriRequest = new HttpHead(actualUrl);
+    return executeMethodAndConvertExceptions(httpUriRequest, headers);
   }
 
   public WireMockResponse getWithBody(


### PR DESCRIPTION
Closes #2528.
This PR adds a deprecated constructor for ```org.wiremock.webhooks.Webhooks``` class with logging that passing the class name is no longer required and may lead to compatibility issues in the future.