### PR TITLE
Fix json-body not escaping special characters

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class Json {
 
@@ -106,6 +108,32 @@ public final class Json {
     } catch (IOException ioe) {
       return throwUnchecked(ioe, byte[].class);
     }
+  }
+
+  public static byte[] toByteArrayEscaped(JsonNode jsonNode) {
+    String string = toStringEscaped(jsonNode);
+    return string != null ? Strings.bytesFromString(string) : new byte[0];
+  }
+
+  public static String toStringEscaped(JsonNode jsonNode) {
+    if (jsonNode.isValueNode()) {
+      if (jsonNode.isTextual()) {
+        return "\"" + jsonNode.asText() + "\"";
+      } else {
+        return jsonNode.asText();
+      }
+    } else if (jsonNode.isArray()) {
+      return Stream.generate(jsonNode.elements()::next)
+          .limit(jsonNode.size())
+          .map(Json::toStringEscaped)
+          .collect(Collectors.joining(",", "[", "]"));
+    } else if (jsonNode.isObject()) {
+      return Stream.generate(jsonNode.fields()::next)
+          .limit(jsonNode.size())
+          .map(field -> "\"" + field.getKey() + "\":" + toStringEscaped(field.getValue()))
+          .collect(Collectors.joining(",", "{", "}"));
+    }
+    return null;
   }
 
   public static JsonNode node(String json) {

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -702,5 +703,41 @@ public class StandaloneAcceptanceTest {
 
   public static String padRight(String s, int paddingLength) {
     return String.format("%1$-" + paddingLength + "s", s);
+  }
+
+  @Nested
+  class JsonResponseBodyStandaloneAcceptanceTest {
+
+    private static final String MAPPING_REQUEST_WITH_JSON_RESPONSE_BODY =
+        "{\n"
+            + "  \"metadata\": {\n"
+            + "    \"description\": \"matches helper example\"\n"
+            + "  },\n"
+            + "  \"request\": {\n"
+            + "    \"method\": \"GET\",\n"
+            + "    \"urlPattern\": \"/matches/\\\\?string=[^&]+\"\n"
+            + "  },\n"
+            + "  \"response\": {\n"
+            + "    \"status\": 200,\n"
+            + "    \"headers\": {\n"
+            + "      \"Content-Type\": \"application/json\"\n"
+            + "    },\n"
+            + "    \"transformers\": [\n"
+            + "      \"response-template\"\n"
+            + "    ],\n"
+            + "    \"jsonBody\": {\n"
+            + "\"string matches\": \"{{#matches request.query.string 'lor\\\\w+'}}Matched{{/matches}}\"\n"
+            + "    }\n"
+            + "  }\n"
+            + "}\n";
+
+    @Test
+    void readEscapeSequenceProperly() {
+      writeMappingFile("test-mapping-1.json", MAPPING_REQUEST_WITH_JSON_RESPONSE_BODY);
+      startRunner();
+      assertThat(
+          testClient.get("/matches/?string=lorem").content(),
+          is("{\"string matches\":\"Matched\"}"));
+    }
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
@@ -166,8 +166,7 @@ class BodyTest {
             + "    \"newline : \\n padding\",\n"
             + "    \"carriage return : \\r padding\",\n"
             + "    \"horizontal tab: \\t padding\",\n"
-            + "    \"hex digit: \\u12ab"
-            + " padding\"\n"
+            + "    \"hex digit: \\u12ab padding\"\n"
             + "  ]\n"
             + "}\n";
     byte[] jsonBytes = bytesFromString(jsonString);

--- a/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
@@ -25,13 +25,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.IntNode;
-import com.github.tomakehurst.wiremock.common.Encoding;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.JsonException;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
-import io.netty.handler.codec.base64.Base64Encoder;
 import org.junit.jupiter.api.Test;
 
 class BodyTest {

--- a/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
@@ -15,6 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import static com.github.tomakehurst.wiremock.common.Encoding.*;
+import static com.github.tomakehurst.wiremock.common.Strings.bytesFromString;
 import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
 import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -23,10 +25,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.IntNode;
+import com.github.tomakehurst.wiremock.common.Encoding;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.JsonException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+
+import io.netty.handler.codec.base64.Base64Encoder;
 import org.junit.jupiter.api.Test;
 
 class BodyTest {
@@ -39,10 +44,10 @@ class BodyTest {
 
     assertThat(body.asString(), is(content));
     assertThat(body.isBinary(), is(true));
-    assertThat(body.asBytes(), is(content.getBytes(StandardCharsets.UTF_8)));
+    assertThat(body.asBytes(), is(bytesFromString(content)));
     assertThat(body.isJson(), is(false));
     assertThatThrownBy(body::asJson).isInstanceOf(JsonException.class);
-    assertThat(body.asBase64(), is(base64EncodeToString(content)));
+    assertThat(body.asBase64(), is(encodeBase64(bytesFromString(content))));
   }
 
   @Test
@@ -53,10 +58,10 @@ class BodyTest {
 
     assertThat(body.asString(), is(content));
     assertThat(body.isBinary(), is(true));
-    assertThat(body.asBytes(), is(content.getBytes(StandardCharsets.UTF_8)));
+    assertThat(body.asBytes(), is(bytesFromString(content)));
     assertThat(body.isJson(), is(false));
     assertThat(body.asJson(), is(Json.node(content)));
-    assertThat(body.asBase64(), is(base64EncodeToString(content)));
+    assertThat(body.asBase64(), is(encodeBase64(bytesFromString(content))));
   }
 
   @Test
@@ -66,10 +71,10 @@ class BodyTest {
 
     assertThat(body.asString(), is(content));
     assertThat(body.isBinary(), is(false));
-    assertThat(body.asBytes(), is(content.getBytes(StandardCharsets.UTF_8)));
+    assertThat(body.asBytes(), is(bytesFromString(content)));
     assertThat(body.isJson(), is(false));
     assertThatThrownBy(body::asJson).isInstanceOf(JsonException.class);
-    assertThat(body.asBase64(), is(base64EncodeToString(content)));
+    assertThat(body.asBase64(), is(encodeBase64(bytesFromString(content))));
   }
 
   @Test
@@ -79,10 +84,10 @@ class BodyTest {
 
     assertThat(body.asString(), is("1"));
     assertThat(body.isBinary(), is(false));
-    assertThat(body.asBytes(), is("1".getBytes(StandardCharsets.UTF_8)));
+    assertThat(body.asBytes(), is(bytesFromString("1")));
     assertThat(body.isJson(), is(true));
     assertThat(body.asJson(), is(jsonContent));
-    assertThat(body.asBase64(), is(base64EncodeToString("1")));
+    assertThat(body.asBase64(), is(encodeBase64(bytesFromString("1"))));
   }
 
   @Test
@@ -118,16 +123,16 @@ class BodyTest {
 
     assertThat(body.asString(), is(jsonCompressedAndEscaped));
     assertThat(body.isBinary(), is(false));
-    assertThat(body.asBytes(), is(jsonCompressedAndEscaped.getBytes(StandardCharsets.UTF_8)));
+    assertThat(body.asBytes(), is(bytesFromString(jsonCompressedAndEscaped)));
     assertThat(body.isJson(), is(true));
     assertThat(body.asJson(), is(jsonNode));
-    assertThat(body.asBase64(), is(base64EncodeToString(jsonCompressedAndEscaped)));
+    assertThat(body.asBase64(), is(encodeBase64(bytesFromString(jsonCompressedAndEscaped))));
   }
 
   @Test
   void constructsFromBase64() {
     String content = "this content";
-    byte[] base64Encoded = base64Encode(content);
+    byte[] base64Encoded = bytesFromString(encodeBase64(bytesFromString(content)));
     String encodedText = stringFromBytes(base64Encoded);
     Body body = Body.fromOneOf(null, null, null, encodedText);
 
@@ -143,14 +148,14 @@ class BodyTest {
   void constructsFromJsonBytes() {
     String jsonString = "{\"name\":\"wiremock\",\"isCool\":true}";
     JsonNode jsonNode = Json.node(jsonString);
-    Body body = Body.fromJsonBytes(jsonString.getBytes(StandardCharsets.UTF_8));
+    Body body = Body.fromJsonBytes(bytesFromString(jsonString));
 
     assertThat(body.asString(), is(jsonString));
     assertThat(body.isBinary(), is(false));
-    assertThat(body.asBytes(), is(jsonString.getBytes(StandardCharsets.UTF_8)));
+    assertThat(body.asBytes(), is(bytesFromString(jsonString)));
     assertThat(body.isJson(), is(true));
     assertThat(body.asJson(), is(jsonNode));
-    assertThat(body.asBase64(), is(base64EncodeToString(jsonString)));
+    assertThat(body.asBase64(), is(encodeBase64(bytesFromString(jsonString))));
   }
 
   @Test
@@ -169,7 +174,7 @@ class BodyTest {
             + " padding\"\n"
             + "  ]\n"
             + "}\n";
-    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+    byte[] jsonBytes = bytesFromString(jsonString);
     JsonNode jsonNode = Json.node(jsonString);
     String jsonCompressedAndEscaped =
         jsonNode
@@ -187,10 +192,10 @@ class BodyTest {
 
     assertThat(body.asString(), is(jsonCompressedAndEscaped));
     assertThat(body.isBinary(), is(false));
-    assertThat(body.asBytes(), is(jsonCompressedAndEscaped.getBytes(StandardCharsets.UTF_8)));
+    assertThat(body.asBytes(), is(bytesFromString(jsonCompressedAndEscaped)));
     assertThat(body.isJson(), is(true));
     assertThat(body.asJson(), is(jsonNode));
-    assertThat(body.asBase64(), is(base64EncodeToString(jsonCompressedAndEscaped)));
+    assertThat(body.asBase64(), is(encodeBase64(bytesFromString(jsonCompressedAndEscaped))));
   }
 
   @Test
@@ -210,13 +215,5 @@ class BodyTest {
     Body body2 = new Body(primes2);
 
     assertEquals(body.hashCode(), body2.hashCode());
-  }
-
-  private String base64EncodeToString(String string) {
-    return new String(base64Encode(string), StandardCharsets.UTF_8);
-  }
-
-  private byte[] base64Encode(String string) {
-    return Base64.getEncoder().encode(string.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
@@ -86,6 +86,45 @@ class BodyTest {
   }
 
   @Test
+  void mustEscapeWhenConstructedFromJson() {
+    String jsonString =
+        "{\n"
+            + "  \"escape\": [\n"
+            + "    \"quotation mark : \\\" padding\",\n"
+            + "    \"reverse solidas : \\\\ padding\",\n"
+            + "    \"backspace : \\b padding\",\n"
+            + "    \"formfeed : \\f padding\",\n"
+            + "    \"newline : \\n padding\",\n"
+            + "    \"carriage return : \\r padding\",\n"
+            + "    \"horizontal tab: \\t padding\",\n"
+            + "    \"hex digit: \\u12ab"
+            + " padding\"\n"
+            + "  ]\n"
+            + "}\n";
+    JsonNode jsonNode = Json.node(jsonString);
+    String jsonCompressedAndEscaped =
+        jsonNode
+            .toString()
+            .replace("\\\"", "\"")
+            .replace("\\\\", "\\")
+            .replace("\\b", "\b")
+            .replace("\\f", "\f")
+            .replace("\\n", "\n")
+            .replace("\\r", "\r")
+            .replace("\\t", "\t")
+            .replaceAll("\\\\u12ab", "\u12ab");
+
+    Body body = Body.fromOneOf(null, null, jsonNode, "lskdjflsjdflks");
+
+    assertThat(body.asString(), is(jsonCompressedAndEscaped));
+    assertThat(body.isBinary(), is(false));
+    assertThat(body.asBytes(), is(jsonCompressedAndEscaped.getBytes(StandardCharsets.UTF_8)));
+    assertThat(body.isJson(), is(true));
+    assertThat(body.asJson(), is(jsonNode));
+    assertThat(body.asBase64(), is(base64EncodeToString(jsonCompressedAndEscaped)));
+  }
+
+  @Test
   void constructsFromBase64() {
     String content = "this content";
     byte[] base64Encoded = base64Encode(content);
@@ -112,6 +151,46 @@ class BodyTest {
     assertThat(body.isJson(), is(true));
     assertThat(body.asJson(), is(jsonNode));
     assertThat(body.asBase64(), is(base64EncodeToString(jsonString)));
+  }
+
+  @Test
+  void mustEscapeWhenConstructedFromJsonBytes() {
+    String jsonString =
+        "{\n"
+            + "  \"escape\": [\n"
+            + "    \"quotation mark : \\\" padding\",\n"
+            + "    \"reverse solidas : \\\\ padding\",\n"
+            + "    \"backspace : \\b padding\",\n"
+            + "    \"formfeed : \\f padding\",\n"
+            + "    \"newline : \\n padding\",\n"
+            + "    \"carriage return : \\r padding\",\n"
+            + "    \"horizontal tab: \\t padding\",\n"
+            + "    \"hex digit: \\u12ab"
+            + " padding\"\n"
+            + "  ]\n"
+            + "}\n";
+    byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+    JsonNode jsonNode = Json.node(jsonString);
+    String jsonCompressedAndEscaped =
+        jsonNode
+            .toString()
+            .replace("\\\"", "\"")
+            .replace("\\\\", "\\")
+            .replace("\\b", "\b")
+            .replace("\\f", "\f")
+            .replace("\\n", "\n")
+            .replace("\\r", "\r")
+            .replace("\\t", "\t")
+            .replaceAll("\\\\u12ab", "\u12ab");
+
+    Body body = Body.fromJsonBytes(jsonBytes);
+
+    assertThat(body.asString(), is(jsonCompressedAndEscaped));
+    assertThat(body.isBinary(), is(false));
+    assertThat(body.asBytes(), is(jsonCompressedAndEscaped.getBytes(StandardCharsets.UTF_8)));
+    assertThat(body.isJson(), is(true));
+    assertThat(body.asJson(), is(jsonNode));
+    assertThat(body.asBase64(), is(base64EncodeToString(jsonCompressedAndEscaped)));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
@@ -232,12 +232,6 @@ public class JsonTest {
     assertThat(result, is(jsonCompressedAndEscaped));
   }
 
-  @Test
-  public void test2() {
-    String str = "\"quotation mark : \\\"\"".replace("\\\"", "\"");
-    assertEquals("\"quotation mark : \"\"", str);
-  }
-
   private static class TestPojo {
     public String property;
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
@@ -17,7 +17,6 @@ package com.github.tomakehurst.wiremock.stubbing;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Thomas Akehurst
+ * Copyright (C) 2012-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,12 @@ package com.github.tomakehurst.wiremock.stubbing;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.common.Json;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 public class JsonTest {
@@ -108,6 +111,131 @@ public class JsonTest {
     int count = Json.deepSize(Json.node("{}"));
 
     assertThat(count, is(1));
+  }
+
+  @Test
+  public void testToStringEscaped() {
+    // language=JSON
+    String json =
+        "{\n"
+            + "  \"string\": \"This is a text\",\n"
+            + "  \"number\": 1,\n"
+            + "  \"boolean\": true,\n"
+            + "  \"null\": null,\n"
+            + "  \"simple_array\": [\n"
+            + "    \"element1\",\n"
+            + "    \"element2\",\n"
+            + "    \"element3\"\n"
+            + "  ],\n"
+            + "  \"object\": {\n"
+            + "    \"children_string\": \"This is a text\",\n"
+            + "    \"children_number\": 1\n"
+            + "  },\n"
+            + "  \"object_array\": [\n"
+            + "    {\n"
+            + "      \"id\": 1,\n"
+            + "      \"name\": \"one\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"id\": 2,\n"
+            + "      \"name\": \"two\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"id\": 3,\n"
+            + "      \"name\": \"three\"\n"
+            + "    }\n"
+            + "  ],\n"
+            + "  \"escape_sequence\":[\n"
+            + "    \"quotation mark : \\\" padding\",\n"
+            + "    \"reverse solidas : \\\\ padding\",\n"
+            + "    \"backspace : \\b padding\",\n"
+            + "    \"formfeed : \\f padding\",\n"
+            + "    \"newline : \\n padding\",\n"
+            + "    \"carriage return : \\r padding\",\n"
+            + "    \"horizontal tab: \\t padding\",\n"
+            + "    \"hex digit: \\u12ab padding\"\n"
+            + "  ]\n"
+            + "}";
+    JsonNode jsonNode = Json.node(json);
+    String result = Json.toStringEscaped(jsonNode);
+    String jsonCompressedAndEscaped =
+        jsonNode
+            .toString()
+            .replace("\\\"", "\"")
+            .replace("\\\\", "\\")
+            .replace("\\b", "\b")
+            .replace("\\f", "\f")
+            .replace("\\n", "\n")
+            .replace("\\r", "\r")
+            .replace("\\t", "\t")
+            .replaceAll("\\\\u12ab", "\u12ab");
+    assertThat(result, is(jsonCompressedAndEscaped));
+  }
+
+  @Test
+  public void testToByteArrayEscaped() {
+    // language=JSON
+    String json =
+        "{\n"
+            + "  \"string\": \"This is a text\",\n"
+            + "  \"number\": 1,\n"
+            + "  \"boolean\": true,\n"
+            + "  \"null\": null,\n"
+            + "  \"simple_array\": [\n"
+            + "    \"element1\",\n"
+            + "    \"element2\",\n"
+            + "    \"element3\"\n"
+            + "  ],\n"
+            + "  \"object\": {\n"
+            + "    \"children_string\": \"This is a text\",\n"
+            + "    \"children_number\": 1\n"
+            + "  },\n"
+            + "  \"object_array\": [\n"
+            + "    {\n"
+            + "      \"id\": 1,\n"
+            + "      \"name\": \"one\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"id\": 2,\n"
+            + "      \"name\": \"two\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"id\": 3,\n"
+            + "      \"name\": \"three\"\n"
+            + "    }\n"
+            + "  ],\n"
+            + "  \"escape_sequence\":[\n"
+            + "    \"quotation mark : \\\" padding\",\n"
+            + "    \"reverse solidas : \\\\ padding\",\n"
+            + "    \"backspace : \\b padding\",\n"
+            + "    \"formfeed : \\f padding\",\n"
+            + "    \"newline : \\n padding\",\n"
+            + "    \"carriage return : \\r padding\",\n"
+            + "    \"horizontal tab: \\t padding\",\n"
+            + "    \"hex digit: \\u12ab padding\"\n"
+            + "  ]\n"
+            + "}";
+    JsonNode jsonNode = Json.node(json);
+    byte[] result = Json.toByteArrayEscaped(jsonNode);
+    byte[] jsonCompressedAndEscaped =
+        jsonNode
+            .toString()
+            .replace("\\\"", "\"")
+            .replace("\\\\", "\\")
+            .replace("\\b", "\b")
+            .replace("\\f", "\f")
+            .replace("\\n", "\n")
+            .replace("\\r", "\r")
+            .replace("\\t", "\t")
+            .replaceAll("\\\\u12ab", "\u12ab")
+            .getBytes(StandardCharsets.UTF_8);
+    assertThat(result, is(jsonCompressedAndEscaped));
+  }
+
+  @Test
+  public void test2() {
+    String str = "\"quotation mark : \\\"\"".replace("\\\"", "\"");
+    assertEquals("\"quotation mark : \"\"", str);
   }
 
   private static class TestPojo {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This pull request fixes json-body not escaping special characters.

When Response-Body object is constructed from JSON file, it is stored as byte-array (plain text). So, the escape sequences are never replaced with their correct representation. They remain as is.
This creates problem when the JSON has special meaning after escaping. Such as the issue reported in : https://github.com/wiremock/wiremock/issues/2547

## References

- `JsonNode` of Jackson offers a method `asText()` which return the actual value of `ValueNode`. This will return a escaped string for a `TextNode`
- [Javadoc for `JsonNode#asText()`](https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/2.10.0/com/fasterxml/jackson/databind/JsonNode.html#asText--)
- [Difference Between asText() and toString() in JsonNode](https://www.baeldung.com/java-jsonnode-astext-vs-tostring#special-characters)
- New member variable added to `Body` which stores the parsed JSON-nodes. This helps to avoid converting between escaped and non-escaped string many times.
- The constructors of `Body` are modified to store the escaped JSON string when necessary.
- Another Pull Requests(https://github.com/wiremock/wiremock/pull/2559) adds a few tests which is used in this PR to prove that the behavior is not changing for non-JSON body.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
