### PR TITLE
correct handling of empty request body with Handlebars (#2546)

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ public class HandlebarsJsonPathHelper extends HandlebarsHelper<Object> {
 
   @Override
   public Object apply(final Object input, final Options options) throws IOException {
-    if (input == null) {
+    if (input == null || (input instanceof String && ((String) input).isEmpty())) {
       return "";
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ public class HandlebarsJsonPathHelperTest extends HandlebarsHelperTestBase {
   }
 
   @Test
-  public void incluesAnErrorInTheResponseBodyWhenTheJsonPathIsInvalid() {
+  public void includesAnErrorInTheResponseBodyWhenTheJsonPathIsInvalid() {
     final ResponseDefinition responseDefinition =
         transform(
             transformer,
@@ -262,6 +262,11 @@ public class HandlebarsJsonPathHelperTest extends HandlebarsHelperTestBase {
   @Test
   public void rendersAnEmptyStringWhenJsonIsNull() {
     testHelperError(helper, null, "$.test", is(""));
+  }
+
+  @Test
+  public void rendersAnEmptyStringWhenJsonIsEmptyString() {
+    testHelperError(helper, "", "$.test", is(""));
   }
 
   @Test


### PR DESCRIPTION
Instead of having `jsonpath` in handlebars throwing an `IllegalArgumentException`, empty bodies are handled the same way as `null` bodies: as empty string.

<!-- Please describe your pull request here. -->

#2546

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
