### PR TITLE
Added GET_OR_HEAD method.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -571,6 +571,18 @@ public class WireMock {
 
   public static MappingBuilder any(UrlPattern urlPattern) {
     return new BasicMappingBuilder(RequestMethod.ANY, urlPattern);
+  }
+
+  /**
+   * A mapping builder that can be used for both GET and HEAD http method. Returns a response body
+   * in case for GET and not in case of HEAD method. In case of tie the request is treated as a GET
+   * request
+   *
+   * @param urlPattern for the specified method
+   * @return a mapping builder for {@link RequestMethod#GET_OR_HEAD} http method
+   */
+  public static MappingBuilder getOrHead(UrlPattern urlPattern) {
+    return new BasicMappingBuilder(RequestMethod.GET_OR_HEAD, urlPattern);
   }
 
   public static MappingBuilder request(String method, UrlPattern urlPattern) {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class RequestMethod implements NamedValueMatcher<RequestMethod> {
   public static final RequestMethod HEAD = new RequestMethod("HEAD");
   public static final RequestMethod TRACE = new RequestMethod("TRACE");
   public static final RequestMethod ANY = new RequestMethod("ANY");
-
+  public static final RequestMethod GET_OR_HEAD = new RequestMethod("GET_OR_HEAD");
   private final String name;
 
   public RequestMethod(String name) {
@@ -75,7 +75,9 @@ public class RequestMethod implements NamedValueMatcher<RequestMethod> {
     if (o == null || getClass() != o.getClass()) return false;
 
     RequestMethod that = (RequestMethod) o;
-
+    if (name.equals("GET_OR_HEAD") && (that.name.equals("GET") || that.name.equals("HEAD"))) {
+      return true;
+    }
     return name.equals(that.name);
   }
 
@@ -94,6 +96,8 @@ public class RequestMethod implements NamedValueMatcher<RequestMethod> {
   }
 
   public static RequestMethod[] values() {
-    return new RequestMethod[] {GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD, TRACE, ANY};
+    return new RequestMethod[] {
+      GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD, TRACE, ANY, GET_OR_HEAD
+    };
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
@@ -56,7 +56,9 @@ public class RequestMethod implements NamedValueMatcher<RequestMethod> {
   }
 
   public MatchResult match(RequestMethod method) {
-    return MatchResult.of(this.equals(ANY) || this.equals(method));
+    boolean getOrHeadMatch =
+        this.equals(GET_OR_HEAD) && (method.equals(GET) || method.equals(HEAD));
+    return MatchResult.of(this.equals(ANY) || this.equals(method) || getOrHeadMatch);
   }
 
   @Override
@@ -75,9 +77,6 @@ public class RequestMethod implements NamedValueMatcher<RequestMethod> {
     if (o == null || getClass() != o.getClass()) return false;
 
     RequestMethod that = (RequestMethod) o;
-    if (name.equals("GET_OR_HEAD") && (that.name.equals("GET") || that.name.equals("HEAD"))) {
-      return true;
-    }
     return name.equals(that.name);
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@ package com.github.tomakehurst.wiremock.client;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,5 +72,61 @@ public class WireMockClientAcceptanceTest {
 
     assertThat(
         testClient.get("/my/new/resource").content(), is("{\"address\":\"Puerto Banús, Málaga\"}"));
+  }
+
+  @Test
+  void testGetOrHeadRequestWhenGetMatchesShouldReturnAResponseBody() {
+    String path = "/get-or-head-test";
+    WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
+    wireMock.register(getOrHead(urlEqualTo(path)).willReturn(okJson("{\"key\": \"value\"}")));
+
+    WireMockResponse response = testClient.get(path);
+
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.firstHeader("Content-Type"), is("application/json"));
+    assertThat(response.content(), not(emptyOrNullString()));
+  }
+
+  @Test
+  void testGetOrHeadRequestWhenHeadMatchesShouldNotReturnAResponseBody() {
+    String path = "/get-or-head-test";
+    WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
+
+    wireMock.register(
+        getOrHead(urlEqualTo(path))
+            .willReturn(
+                okJson("{\"key\": \"value\"}").withHeader("Content-Type", "application/json")));
+    WireMockResponse response = testClient.head(path);
+
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.firstHeader("Content-Type"), is("application/json"));
+    assertThat(response.content(), is(emptyOrNullString()));
+  }
+
+  @Test
+  void testGetOrHeadRequestWhenNoMethodNotMatchesShouldReturn404() {
+    String path = "/get-or-head-test";
+    WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
+    wireMock.register(
+        getOrHead(urlEqualTo(path))
+            .willReturn(ok().withHeader("Content-Type", "application/json")));
+    WireMockResponse response = testClient.delete(path);
+
+    assertThat(response.statusCode(), is(404));
+  }
+
+  @Test
+  void testGetOrHeadRequestWhenPathDoesNotMatchShouldReturn404() {
+    String correctPath = "/get-or-head-path-correct";
+    String incorrectPath = "/get-or-head-path-incorrect";
+    WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
+    wireMock.register(
+        getOrHead(urlEqualTo(correctPath))
+            .willReturn(ok().withHeader("Content-Type", "application/json")));
+    WireMockResponse responseGet = testClient.get(incorrectPath);
+    WireMockResponse responseHead = testClient.head(incorrectPath);
+
+    assertThat(responseGet.statusCode(), is(404));
+    assertThat(responseHead.statusCode(), is(404));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
@@ -78,12 +78,15 @@ public class WireMockClientAcceptanceTest {
   void testGetOrHeadRequestWhenGetMatchesShouldReturnAResponseBody() {
     String path = "/get-or-head-test";
     WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
-    wireMock.register(getOrHead(urlEqualTo(path)).willReturn(okJson("{\"key\": \"value\"}")));
+    wireMock.register(
+        getOrHead(urlEqualTo(path))
+            .willReturn(okJson("{\"key\": \"value\"}").withHeader("Content-Length", "16")));
 
     WireMockResponse response = testClient.get(path);
 
     assertThat(response.statusCode(), is(200));
     assertThat(response.firstHeader("Content-Type"), is("application/json"));
+    assertThat(response.firstHeader("Content-Length"), is("16"));
     assertThat(response.content(), not(emptyOrNullString()));
   }
 
@@ -95,11 +98,14 @@ public class WireMockClientAcceptanceTest {
     wireMock.register(
         getOrHead(urlEqualTo(path))
             .willReturn(
-                okJson("{\"key\": \"value\"}").withHeader("Content-Type", "application/json")));
+                okJson("{\"key\": \"value\"}")
+                    .withHeader("Content-Type", "application/json")
+                    .withHeader("Content-Length", "16")));
     WireMockResponse response = testClient.head(path);
 
     assertThat(response.statusCode(), is(200));
     assertThat(response.firstHeader("Content-Type"), is("application/json"));
+    assertThat(response.firstHeader("Content-Length"), is("16"));
     assertThat(response.content(), is(emptyOrNullString()));
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,6 +107,12 @@ public class WireMockTestClient {
     String actualUrl = URI.create(url).isAbsolute() ? url : mockServiceUrlFor(url);
     HttpUriRequest httpRequest = new HttpGet(actualUrl);
     return executeMethodAndConvertExceptions(httpRequest, headers);
+  }
+
+  public WireMockResponse head(String url, TestHttpHeader... headers) {
+    String actualUrl = URI.create(url).isAbsolute() ? url : mockServiceUrlFor(url);
+    HttpUriRequest httpUriRequest = new HttpHead(actualUrl);
+    return executeMethodAndConvertExceptions(httpUriRequest, headers);
   }
 
   public WireMockResponse getWithBody(


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Closes #2414 . This PR adds a GET_OR_HEAD method. This stub method could be used for both get as well as head Http method. The response and http header information is returned accordingly

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
