### PR TITLE
Add extensionScanningEnabled option to @WireMockTest.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -205,6 +205,7 @@ public class WireMockExtension extends DslWrapper
     WireMockConfiguration options =
         WireMockConfiguration.options()
             .port(annotation.httpPort())
+            .extensionScanningEnabled(annotation.extensionScanningEnabled())
             .enableBrowserProxying(annotation.proxyMode());
 
     if (annotation.httpsEnabled()) {

--- a/src/test/java/com/github/tomakehurst/wiremock/ExtensionFactoryTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ExtensionFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,8 @@ public class ExtensionFactoryTest {
     assertThat(content, jsonPartEquals("requestCount", 2));
     assertThat(content, jsonPartEquals("stubCorsEnabled", true));
     assertThat(
-        content, jsonPartEquals("extensionCount", 4)); // Includes the two service loaded extensions
+        content,
+        jsonPartEquals("extensionCount", 5)); // Includes the three service loaded extensions
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionExtensionScanningEnabledDeclarativeTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionExtensionScanningEnabledDeclarativeTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.junit5;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.requestMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import java.io.IOException;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class JUnitJupiterExtensionExtensionScanningEnabledDeclarativeTest {
+
+  private static int responseCode(String url) {
+    try (CloseableHttpClient client = HttpClientFactory.createClient();
+        CloseableHttpResponse response = client.execute(new HttpGet(url))) {
+      return response.getCode();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Nested
+  @WireMockTest
+  class Default {
+
+    @Test
+    void extension_scanning_defaults_to_false(WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(requestMatching("mock").willReturn(ok()));
+      assertNotEquals(responseCode(wmRuntimeInfo.getHttpBaseUrl()), 200);
+    }
+  }
+
+  @Nested
+  @WireMockTest(extensionScanningEnabled = false)
+  class Disabled {
+
+    @Test
+    void extension_scanning_disabled(WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(requestMatching("mock").willReturn(ok()));
+      assertNotEquals(responseCode(wmRuntimeInfo.getHttpBaseUrl()), 200);
+    }
+  }
+
+  @Nested
+  @WireMockTest(extensionScanningEnabled = true)
+  class Enabled {
+
+    @Test
+    void extension_scanning_enabled(WireMockRuntimeInfo wmRuntimeInfo) {
+      stubFor(requestMatching("mock").willReturn(ok()));
+      assertEquals(responseCode(wmRuntimeInfo.getHttpBaseUrl()), 200);
+    }
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionExtensionScanningEnabledProgrammaticTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionExtensionScanningEnabledProgrammaticTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.junit5;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.requestMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import java.io.IOException;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class JUnitJupiterExtensionExtensionScanningEnabledProgrammaticTest {
+
+  private static int responseCode(String url) {
+    try (CloseableHttpClient client = HttpClientFactory.createClient();
+        CloseableHttpResponse response = client.execute(new HttpGet(url))) {
+      return response.getCode();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Nested
+  class Default {
+    @RegisterExtension
+    WireMockExtension wm =
+        WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+    @Test
+    void extension_scanning_defaults_to_false() {
+      wm.stubFor(requestMatching("mock").willReturn(ok()));
+      assertNotEquals(responseCode(wm.getRuntimeInfo().getHttpBaseUrl()), 200);
+    }
+  }
+
+  @Nested
+  class Disabled {
+    @RegisterExtension
+    WireMockExtension disabled =
+        WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort().extensionScanningEnabled(false))
+            .build();
+
+    @Test
+    void extension_scanning_disabled() {
+      disabled.stubFor(requestMatching("mock").willReturn(ok()));
+      assertNotEquals(responseCode(disabled.getRuntimeInfo().getHttpBaseUrl()), 200);
+    }
+  }
+
+  @Nested
+  class Enabled {
+    @RegisterExtension
+    WireMockExtension enabled =
+        WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort().extensionScanningEnabled(true))
+            .build();
+
+    @Test
+    void extension_scanning_enabled() {
+      enabled.stubFor(requestMatching("mock").willReturn(ok()));
+      assertEquals(responseCode(enabled.getRuntimeInfo().getHttpBaseUrl()), 200);
+    }
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/MockExtension.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/MockExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Thomas Akehurst
+ * Copyright (C) 2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,24 +15,20 @@
  */
 package com.github.tomakehurst.wiremock.junit5;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import org.junit.jupiter.api.extension.ExtendWith;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.matching.MatchResult;
+import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
 
-@Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(WireMockExtension.class)
-public @interface WireMockTest {
+public class MockExtension extends RequestMatcherExtension {
 
-  boolean extensionScanningEnabled() default false;
+  @Override
+  public MatchResult match(Request request, Parameters parameters) {
+    return MatchResult.exactMatch();
+  }
 
-  int httpPort() default 0;
-
-  boolean httpsEnabled() default false;
-
-  int httpsPort() default 0;
-
-  boolean proxyMode() default false;
+  @Override
+  public String getName() {
+    return "mock";
+  }
 }

--- a/src/test/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.Extension
+++ b/src/test/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.Extension
@@ -1,0 +1,1 @@
+com.github.tomakehurst.wiremock.junit5.MockExtension


### PR DESCRIPTION
When using extensions that utilize service loading (e.g. [wiremock/wiremock-graphql-extension](https://github.com/wiremock/wiremock-graphql-extension)) it would be preferable to use the declarative option to enable extension scanning, rather than being forced to use the programmatic approach to manually define extensions.

## References

- https://github.com/wiremock/wiremock.org/pull/242
<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
