### PR TITLE
Supply lazy TemplateEngine, HttpClientFactory, and DefaultHttpClient.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/Extensions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/Extensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,13 @@ import com.github.jknack.handlebars.Helper;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.LazyTemplateEngine;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
 import com.github.tomakehurst.wiremock.http.client.HttpClient;
 import com.github.tomakehurst.wiremock.http.client.HttpClientFactory;
+import com.github.tomakehurst.wiremock.http.client.LazyHttpClient;
+import com.github.tomakehurst.wiremock.http.client.LazyHttpClientFactory;
 import com.github.tomakehurst.wiremock.store.Stores;
 import java.util.*;
 import java.util.concurrent.Executors;
@@ -191,17 +194,18 @@ public class Extensions implements WireMockServices {
 
   @Override
   public TemplateEngine getTemplateEngine() {
-    return templateEngine;
+    return new LazyTemplateEngine(() -> templateEngine);
   }
 
   @Override
   public HttpClientFactory getHttpClientFactory() {
-    return httpClientFactory;
+    return new LazyHttpClientFactory(() -> httpClientFactory);
   }
 
   @Override
   public HttpClient getDefaultHttpClient() {
-    return httpClientFactory.buildHttpClient(options, true, Collections.emptyList(), true);
+    return new LazyHttpClient(
+        () -> httpClientFactory.buildHttpClient(options, true, Collections.emptyList(), true));
   }
 
   public int getCount() {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/LazyTemplateEngine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/LazyTemplateEngine.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating;
+
+import com.github.tomakehurst.wiremock.common.Lazy;
+import java.util.function.Supplier;
+
+public class LazyTemplateEngine extends TemplateEngine {
+  private final Lazy<TemplateEngine> templateEngineLazy;
+
+  public LazyTemplateEngine(Supplier<TemplateEngine> templateEngineSupplier) {
+    this.templateEngineLazy = Lazy.lazy(templateEngineSupplier);
+  }
+
+  @Override
+  public HandlebarsOptimizedTemplate getTemplate(Object key, String content) {
+    return templateEngineLazy.get().getTemplate(key, content);
+  }
+
+  @Override
+  public HandlebarsOptimizedTemplate getUncachedTemplate(String content) {
+    return templateEngineLazy.get().getUncachedTemplate(content);
+  }
+
+  @Override
+  public long getCacheSize() {
+    return templateEngineLazy.get().getCacheSize();
+  }
+
+  @Override
+  public void invalidateCache() {
+    templateEngineLazy.get().invalidateCache();
+  }
+
+  @Override
+  public Long getMaxCacheEntries() {
+    return templateEngineLazy.get().getMaxCacheEntries();
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,12 @@ public class TemplateEngine {
     cache = cacheBuilder.build();
 
     addHelpers(helpers, permittedSystemKeys);
+  }
+
+  protected TemplateEngine() {
+    this.handlebars = null;
+    this.maxCacheEntries = null;
+    this.cache = null;
   }
 
   private void addHelpers(Map<String, Helper<?>> helpers, Set<String> permittedSystemKeys) {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/LazyHttpClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/LazyHttpClient.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http.client;
+
+import com.github.tomakehurst.wiremock.common.Lazy;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.Response;
+import java.io.IOException;
+import java.util.function.Supplier;
+
+public class LazyHttpClient implements HttpClient {
+
+  private final Lazy<HttpClient> httpClientLazy;
+
+  public LazyHttpClient(Supplier<HttpClient> httpClientSupplier) {
+    this.httpClientLazy = Lazy.lazy(httpClientSupplier);
+  }
+
+  @Override
+  public Response execute(Request request) throws IOException {
+    return httpClientLazy.get().execute(request);
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/LazyHttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/LazyHttpClientFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http.client;
+
+import com.github.tomakehurst.wiremock.common.Lazy;
+import com.github.tomakehurst.wiremock.core.Options;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class LazyHttpClientFactory implements HttpClientFactory {
+
+  private final Lazy<HttpClientFactory> httpClientFactoryLazy;
+
+  public LazyHttpClientFactory(Supplier<HttpClientFactory> httpClientFactorySupplier) {
+    this.httpClientFactoryLazy = Lazy.lazy(httpClientFactorySupplier);
+  }
+
+  @Override
+  public String getName() {
+    return httpClientFactoryLazy.get().getName();
+  }
+
+  @Override
+  public HttpClient buildHttpClient(
+      Options options,
+      boolean trustAllCertificates,
+      List<String> trustedHosts,
+      boolean useSystemProperties) {
+    return httpClientFactoryLazy
+        .get()
+        .buildHttpClient(options, trustAllCertificates, trustedHosts, useSystemProperties);
+  }
+}


### PR DESCRIPTION
Draft for issue in which ExtensionFactories are supplied a null TemplateEngine, HttpClientFactory, and DefaultHttpClient from Extensions. 

## References

- closes https://github.com/wiremock/wiremock/issues/2562

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
