### PR TITLE
Allow matchesJsonSchema to be supplied as a json object.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,11 @@ public class MatchesJsonSchemaPattern extends StringValuePattern {
     this.schemaVersion = schemaVersion;
 
     schemaPropertyCount = Json.schemaPropertyCount(Json.read(schemaJson, JsonNode.class));
+  }
+
+  public MatchesJsonSchemaPattern(
+      JsonNode schemaJsonNode, WireMock.JsonSchemaVersion schemaVersion) {
+    this(Json.write(schemaJsonNode), schemaVersion);
   }
 
   public String getMatchesJsonSchema() {

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -168,7 +168,12 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
           "schemaVersion must be one of " + Json.write(JsonSchemaVersion.values()));
     }
 
-    return new MatchesJsonSchemaPattern(operand.textValue(), schemaVersion);
+    // Allow either a JSON value or a string containing JSON
+    if (operand.isTextual()) {
+      return new MatchesJsonSchemaPattern(operand.textValue(), schemaVersion);
+    } else {
+      return new MatchesJsonSchemaPattern(operand, schemaVersion);
+    }
   }
 
   private EqualToXmlPattern deserializeEqualToXml(JsonNode rootNode) throws JsonMappingException {

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ public class MatchesJsonSchemaPatternTest {
   }
 
   @Test
-  void deserialisesFromJsonCorrectlyWithDefaultSchemaVersion() {
+  void deserialisesFromJsonStringCorrectlyWithDefaultSchemaVersion() {
     String schemaJson =
         "{\n"
             + "    \"required\": [\n"
@@ -114,13 +114,14 @@ public class MatchesJsonSchemaPatternTest {
 
     String matcherJson = "{\n" + "  \"matchesJsonSchema\": " + stringify(schemaJson) + "\n" + "}";
 
-    MatchesJsonSchemaPattern pattern = Json.read(matcherJson, MatchesJsonSchemaPattern.class);
+    StringValuePattern pattern = Json.read(matcherJson, StringValuePattern.class);
 
-    assertThat(pattern.getMatchesJsonSchema(), jsonEquals(schemaJson));
+    assertThat(pattern, instanceOf(MatchesJsonSchemaPattern.class));
+    assertThat(((MatchesJsonSchemaPattern) pattern).getMatchesJsonSchema(), jsonEquals(schemaJson));
   }
 
   @Test
-  void deserialisesFromJsonCorrectlyWithProvidedSchemaVersion() {
+  void deserialisesFromJsonStringCorrectlyWithProvidedSchemaVersion() {
     String schemaJson =
         "{\n"
             + "    \"properties\": {\n"
@@ -138,9 +139,66 @@ public class MatchesJsonSchemaPatternTest {
             + "  \"schemaVersion\": \"V6\"\n"
             + "}";
 
-    MatchesJsonSchemaPattern pattern = Json.read(matcherJson, MatchesJsonSchemaPattern.class);
+    StringValuePattern pattern = Json.read(matcherJson, StringValuePattern.class);
 
-    assertThat(pattern.getSchemaVersion(), is(V6));
+    assertThat(pattern, instanceOf(MatchesJsonSchemaPattern.class));
+    assertThat(((MatchesJsonSchemaPattern) pattern).getMatchesJsonSchema(), jsonEquals(schemaJson));
+    assertThat(((MatchesJsonSchemaPattern) pattern).getSchemaVersion(), is(V6));
+  }
+
+  @Test
+  void deserialisesFromJsonValueCorrectlyWithDefaultSchemaVersion() {
+    String schemaJson =
+        "{\n"
+            + "    \"required\": [\n"
+            + "      \"itemCatalogueId\",\n"
+            + "      \"quantity\"\n"
+            + "    ],\n"
+            + "    \"properties\": {\n"
+            + "      \"itemCatalogueId\": {\n"
+            + "        \"type\": \"string\"\n"
+            + "      },\n"
+            + "      \"quantity\": {\n"
+            + "        \"type\": \"integer\"\n"
+            + "      },\n"
+            + "      \"fastDelivery\": {\n"
+            + "        \"type\": \"boolean\"\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }";
+
+    String matcherJson = "{\n" + "  \"matchesJsonSchema\": " + schemaJson + "\n" + "}";
+
+    StringValuePattern pattern = Json.read(matcherJson, StringValuePattern.class);
+
+    assertThat(pattern, instanceOf(MatchesJsonSchemaPattern.class));
+    assertThat(((MatchesJsonSchemaPattern) pattern).getMatchesJsonSchema(), jsonEquals(schemaJson));
+  }
+
+  @Test
+  void deserialisesFromJsonValueCorrectlyWithProvidedSchemaVersion() {
+    String schemaJson =
+        "{\n"
+            + "    \"properties\": {\n"
+            + "      \"itemCatalogueId\": {\n"
+            + "        \"type\": \"string\"\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }";
+
+    String matcherJson =
+        "{\n"
+            + "  \"matchesJsonSchema\": "
+            + schemaJson
+            + ",\n"
+            + "  \"schemaVersion\": \"V6\"\n"
+            + "}";
+
+    StringValuePattern pattern = Json.read(matcherJson, StringValuePattern.class);
+
+    assertThat(pattern, instanceOf(MatchesJsonSchemaPattern.class));
+    assertThat(((MatchesJsonSchemaPattern) pattern).getMatchesJsonSchema(), jsonEquals(schemaJson));
+    assertThat(((MatchesJsonSchemaPattern) pattern).getSchemaVersion(), is(V6));
   }
 
   private static final StringValuePattern stringSchema =


### PR DESCRIPTION
https://wiremock.org/docs/request-matching/#json-schema shows an example of using the `matchesJsonSchema` with an escaped json string:
```json
{
  "request" : {
    "urlPath" : "/schema-match",
    "method" : "POST",
    "bodyPatterns" : [ {
      "matchesJsonSchema" : "{\n  \"type\": \"object\",\n  \"required\": [\n    \"name\"\n  ],\n  \"properties\": {\n    \"name\": {\n      \"type\": \"string\"\n    },\n    \"tag\": {\n      \"type\": \"string\"\n    }\n  }\n}",
      "schemaVersion" : "V202012"
    } ]
  },
  "response" : {
    "status" : 200
  }
}
```

This PR would allow us to supply a json object (similar to `equalToJson`). For example:
```json
{
  "request" : {
    "urlPath" : "/schema-match",
    "method" : "POST",
    "bodyPatterns" : [ {
      "matchesJsonSchema" : {
        "type": "object",
        "required": [
          "name"
        ],
        "properties": {
          "name": {
            "type": "string"
          },
          "tag": {
            "type": "string"
          }
        }
      }
    } ]
  },
  "response" : {
    "status" : 200
  }
}
```

## References

- Will link wiremock.org PR for update to documentation if this PR is accepted

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
