### PR TITLE
Remove and log warning before loading webhooks

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/ExtensionDeclarations.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/ExtensionDeclarations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
  */
 package com.github.tomakehurst.wiremock.extension;
 
+import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static java.util.Arrays.asList;
 
 import java.util.*;
+import java.util.stream.Collectors;
+import org.wiremock.webhooks.Webhooks;
 
 public class ExtensionDeclarations {
 
@@ -25,6 +28,9 @@ public class ExtensionDeclarations {
   private final List<Class<? extends Extension>> classes;
   private final Map<String, Extension> instances;
   private final List<ExtensionFactory> factories;
+  private static final String WEBHOOK_MESSAGE =
+      "Passing webhooks in extensions is no longer required and"
+          + " may lead to compatibility issues in future";
 
   public ExtensionDeclarations() {
     this.classNames = new ArrayList<>();
@@ -34,7 +40,9 @@ public class ExtensionDeclarations {
   }
 
   public void add(String... classNames) {
-    this.classNames.addAll(asList(classNames));
+    List<String> processedClassNames =
+        Arrays.stream(classNames).filter(this::removeWebhook).collect(Collectors.toList());
+    this.classNames.addAll(processedClassNames);
   }
 
   public void add(Extension... extensionInstances) {
@@ -42,7 +50,9 @@ public class ExtensionDeclarations {
   }
 
   public void add(Class<? extends Extension>... classes) {
-    this.classes.addAll(asList(classes));
+    List<Class<? extends Extension>> processedClasses =
+        Arrays.stream(classes).filter(c -> removeWebhook(c.getName())).collect(Collectors.toList());
+    this.classes.addAll(processedClasses);
   }
 
   public void add(ExtensionFactory... factories) {
@@ -63,5 +73,13 @@ public class ExtensionDeclarations {
 
   public List<ExtensionFactory> getFactories() {
     return factories;
+  }
+
+  private boolean removeWebhook(String className) {
+    if (className.equals(Webhooks.class.getName())) {
+      notifier().info(WEBHOOK_MESSAGE);
+      return false;
+    }
+    return true;
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/webhooks/WebhooksRegistrationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/webhooks/WebhooksRegistrationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2023-2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.webhooks;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.standalone.WireMockServerRunner;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wiremock.webhooks.Webhooks;
+
+class WebhooksRegistrationTest {
+  private static final String MESSAGE =
+      "Passing webhooks in extensions is no longer required and"
+          + " may lead to compatibility issues in future";
+  private final PrintStream stdOut = System.out;
+  private WireMockServerRunner runner;
+  private WireMockServer server;
+  private ByteArrayOutputStream out;
+
+  @BeforeEach
+  public void recordCommandLineMessages() {
+    startRecordingSystemOut();
+  }
+
+  @AfterEach
+  public void resetPrintStream() {
+    System.setOut(stdOut);
+    stopServer();
+  }
+
+  private void startRecordingSystemOut() {
+    out = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(out));
+  }
+
+  private void stopServer() {
+    if (server != null && server.isRunning()) {
+      server.stop();
+    }
+  }
+
+  private void stopRunner() {
+    if (runner != null && runner.isRunning()) {
+      runner.stop();
+    }
+  }
+
+  private String getSystemOutText() {
+    return out.toString();
+  }
+
+  @Test
+  void shouldLogMessageWhenWebhooksAreAddedViaClassName() {
+    server = new WireMockServer(wireMockConfig().extensions("org.wiremock.webhooks.Webhooks"));
+    server.start();
+    assertThat(getSystemOutText(), containsString(MESSAGE));
+  }
+
+  @Test
+  void shouldLogMessageWhenWebhooksAreAddedViaClass() {
+    server = new WireMockServer(wireMockConfig().extensions(Webhooks.class));
+    server.start();
+    assertThat(getSystemOutText(), containsString(MESSAGE));
+  }
+
+  @Test
+  void shouldLogAMessageWhenWebhooksAreAddedViaCLI() {
+    runner = new WireMockServerRunner();
+    runner.run("--extensions", "org.wiremock.webhooks.Webhooks");
+    assertThat(getSystemOutText(), containsString(MESSAGE));
+    stopRunner();
+  }
+
+  @Test
+  void shouldNotLogAMessageWhenWebhooksAreNotAddedExplicitly() {
+    server = new WireMockServer(wireMockConfig());
+    server.start();
+    assertThat(getSystemOutText(), not(containsString(MESSAGE)));
+  }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Closes #2528.
This PR removes externally added webhooks as extensions and logs a warning that passing webhook class name is no longer required and may lead to compatibility issues in future.

Supersedes #2550 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
