### PR TITLE
Add CLI option to specify Notifier class

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -698,6 +698,26 @@ public class CommandLineOptionsTest {
     MappingsSaver mappingsSaver = options.mappingsSaver();
 
     assertThat(mappingsSaver, instanceOf(JsonFileMappingsSource.class));
+  }
+
+  @Test
+  public void customNotifier() {
+    CommandLineOptions options =
+        new CommandLineOptions(
+            "--notifier-class", "com.github.tomakehurst.wiremock.common.Slf4jNotifier");
+
+    Notifier mappingsSaver = options.notifier();
+
+    assertThat(mappingsSaver, instanceOf(Slf4jNotifier.class));
+  }
+
+  @Test
+  public void defaultNotifier() {
+    CommandLineOptions options = new CommandLineOptions();
+
+    Notifier mappingsSaver = options.notifier();
+
+    assertThat(mappingsSaver, instanceOf(ConsoleNotifier.class));
   }
 
   @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Adds an optional CLI option to specify a fully-qualified class name. Defaults to using `ConsoleNotifier` to align with existing behavior.

This allows custom standalone implementations to specify their preferred logging system while avoiding a hard dependency on any logging library.

You can for example, create an application with Logback (Spring Boot defaults used):

```kotlin
plugins {
    application
}

repositories {
    mavenCentral()
    mavenLocal()
}

java {
    toolchain {
        languageVersion = JavaLanguageVersion.of(21)
    }
}

application {
    mainClass = "io.mateo.WireMockRunner"
}

dependencies {
    implementation("org.wiremock:wiremock:3.3.1-local")
    implementation("org.springframework.boot:spring-boot:3.2.1")
    implementation("org.springframework.boot:spring-boot-starter-logging:3.2.1")
    implementation("net.logstash.logback:logstash-logback-encoder:7.4")
}

tasks.processResources {
    if (providers.environmentVariable("CI").isPresent) {
        rename("logback-json.xml", "logback.xml")
    } else {
        rename("logback-console.xml", "logback.xml")
    }
}
```

```java
package io.mateo;

import com.github.tomakehurst.wiremock.standalone.WireMockServerRunner;

public class WireMockRunner {

    final WireMockServerRunner wireMockRunner;

    public WireMockRunner() {
        this.wireMockRunner = new WireMockServerRunner();
    }

    public static void main(String[] args) {
        new WireMockRunner().wireMockRunner.run(args);
    }

}
```

And include a configuration specific to logback on the classpath (`src/main/resources/logback.xml`):

```xml
<?xml version="1.0" encoding="UTF-8"?>
<configuration>
    <include resource="org/springframework/boot/logging/logback/defaults.xml" />
    <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
    <root level="INFO">
        <appender-ref ref="CONSOLE" />
    </root>
</configuration>
```

Which yields:

```
2024-01-22T22:43:04.039-06:00  INFO   --- [           main] org.eclipse.jetty.server.Server          : jetty-11.0.19; built: 2023-12-15T20:54:39.802Z; git: f781e475c8fa9e9c8ce18b1eaa03110d510f905f; jvm 21.0.1+12-LTS
2024-01-22T22:43:04.055-06:00  INFO   --- [           main] o.e.jetty.server.handler.ContextHandler  : Started o.e.j.s.ServletContextHandler@511505e7{/__admin,null,AVAILABLE}
2024-01-22T22:43:04.058-06:00  INFO   --- [           main] o.e.j.s.handler.ContextHandler.ROOT      : RequestHandlerClass from context returned com.github.tomakehurst.wiremock.http.StubRequestHandler. Normalized mapped under returned 'null'
2024-01-22T22:43:04.058-06:00  INFO   --- [           main] o.e.jetty.server.handler.ContextHandler  : Started o.e.j.s.ServletContextHandler@2098d37d{/,null,AVAILABLE}
2024-01-22T22:43:04.061-06:00  INFO   --- [           main] o.e.jetty.server.AbstractConnector       : Started NetworkTrafficServerConnector@9cd25ff{HTTP/1.1, (http/1.1, h2c)}{0.0.0.0:8080}
2024-01-22T22:43:04.066-06:00  INFO   --- [           main] org.eclipse.jetty.server.Server          : Started Server@53692008{STARTING}[11.0.19,sto=1000] @554ms

██     ██ ██ ██████  ███████ ███    ███  ██████   ██████ ██   ██ 
██     ██ ██ ██   ██ ██      ████  ████ ██    ██ ██      ██  ██  
██  █  ██ ██ ██████  █████   ██ ████ ██ ██    ██ ██      █████   
██ ███ ██ ██ ██   ██ ██      ██  ██  ██ ██    ██ ██      ██  ██  
 ███ ███  ██ ██   ██ ███████ ██      ██  ██████   ██████ ██   ██ 

----------------------------------------------------------------
|               Cloud: https://wiremock.io/cloud               |
|                                                              |
|               Slack: https://slack.wiremock.org              |
----------------------------------------------------------------

version:                      3.3.1
port:                         8080
enable-browser-proxying:      false
disable-banner:               false
no-request-journal:           false
verbose:                      false

extensions:                   response-template,webhook
```

Or with a JSON config:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<configuration>
    <include resource="org/springframework/boot/logging/logback/defaults.xml" />
    <appender name="JSON_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
    </appender>
    <root level="INFO">
        <appender-ref ref="JSON_APPENDER" />
    </root>
</configuration>
```

Which yields:

```
{"@timestamp":"2024-01-22T22:49:29.80629-06:00","@version":"1","message":"jetty-11.0.19; built: 2023-12-15T20:54:39.802Z; git: f781e475c8fa9e9c8ce18b1eaa03110d510f905f; jvm 21.0.1+12-LTS","logger_name":"org.eclipse.jetty.server.Server","thread_name":"main","level":"INFO","level_value":20000}
{"@timestamp":"2024-01-22T22:49:29.823408-06:00","@version":"1","message":"Started o.e.j.s.ServletContextHandler@7f9ab969{/__admin,null,AVAILABLE}","logger_name":"org.eclipse.jetty.server.handler.ContextHandler","thread_name":"main","level":"INFO","level_value":20000}
{"@timestamp":"2024-01-22T22:49:29.826565-06:00","@version":"1","message":"RequestHandlerClass from context returned com.github.tomakehurst.wiremock.http.StubRequestHandler. Normalized mapped under returned 'null'","logger_name":"org.eclipse.jetty.server.handler.ContextHandler.ROOT","thread_name":"main","level":"INFO","level_value":20000}
{"@timestamp":"2024-01-22T22:49:29.826681-06:00","@version":"1","message":"Started o.e.j.s.ServletContextHandler@3721177d{/,null,AVAILABLE}","logger_name":"org.eclipse.jetty.server.handler.ContextHandler","thread_name":"main","level":"INFO","level_value":20000}
{"@timestamp":"2024-01-22T22:49:29.831061-06:00","@version":"1","message":"Started NetworkTrafficServerConnector@6f8d7714{HTTP/1.1, (http/1.1, h2c)}{0.0.0.0:8080}","logger_name":"org.eclipse.jetty.server.AbstractConnector","thread_name":"main","level":"INFO","level_value":20000}
{"@timestamp":"2024-01-22T22:49:29.83573-06:00","@version":"1","message":"Started Server@30331109{STARTING}[11.0.19,sto=1000] @555ms","logger_name":"org.eclipse.jetty.server.Server","thread_name":"main","level":"INFO","level_value":20000}

██     ██ ██ ██████  ███████ ███    ███  ██████   ██████ ██   ██ 
██     ██ ██ ██   ██ ██      ████  ████ ██    ██ ██      ██  ██  
██  █  ██ ██ ██████  █████   ██ ████ ██ ██    ██ ██      █████   
██ ███ ██ ██ ██   ██ ██      ██  ██  ██ ██    ██ ██      ██  ██  
 ███ ███  ██ ██   ██ ███████ ██      ██  ██████   ██████ ██   ██ 

----------------------------------------------------------------
|               Cloud: https://wiremock.io/cloud               |
|                                                              |
|               Slack: https://slack.wiremock.org              |
----------------------------------------------------------------

version:                      3.3.1
port:                         8080
enable-browser-proxying:      false
disable-banner:               false
no-request-journal:           false
verbose:                      false

extensions:                   response-template,webhook
```
## References

- https://github.com/wiremock/wiremock/issues/1108
- https://github.com/wiremock/wiremock/pull/1109
- https://github.com/wiremock/wiremock/pull/2504

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
