### PR TITLE
Improve Scenario error message for unsupported state

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/Scenario.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/Scenario.java
@@ -86,7 +86,7 @@ public class Scenario {
   Scenario setState(String newState) {
     if (!getPossibleStates().contains(newState)) {
       throw new InvalidInputException(
-          Errors.single(11, "Scenario my-scenario does not support state " + newState));
+          Errors.single(11, "Scenario " + id + " does not support state " + newState));
     }
 
     return new Scenario(id, newState, stubMappings);

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/Scenario.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/Scenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2023 Thomas Akehurst
+ * Copyright (C) 2012-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update the error message in 'setState' method of 'Scenario' class to contain the name of the scenario instead of 'my-scenario'. This makes the error message more informative and useful.

<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
