### PR TITLE
Disable connection reuse only for proxy clients not for the admin client

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,8 @@ public class HttpClientFactory {
       boolean trustAllCertificates,
       final List<String> trustedHosts,
       boolean useSystemProperties,
-      NetworkAddressRules networkAddressRules) {
+      NetworkAddressRules networkAddressRules,
+      boolean disableConnectionReuse) {
 
     NetworkAddressRulesAdheringDnsResolver dnsResolver =
         new NetworkAddressRulesAdheringDnsResolver(networkAddressRules);
@@ -91,9 +92,13 @@ public class HttpClientFactory {
             .setDefaultRequestConfig(
                 RequestConfig.custom()
                     .setResponseTimeout(Timeout.ofMilliseconds(timeoutMilliseconds))
-                    .build())
-            .setConnectionReuseStrategy((request, response, context) -> false)
-            .setKeepAliveStrategy((response, context) -> TimeValue.ZERO_MILLISECONDS);
+                    .build());
+
+    if (disableConnectionReuse) {
+      builder
+          .setConnectionReuseStrategy((request, response, context) -> false)
+          .setKeepAliveStrategy((response, context) -> TimeValue.ZERO_MILLISECONDS);
+    }
 
     if (useSystemProperties) {
       builder.useSystemProperties();
@@ -175,7 +180,8 @@ public class HttpClientFactory {
       ProxySettings proxySettings,
       KeyStoreSettings trustStoreSettings,
       boolean useSystemProperties,
-      NetworkAddressRules networkAddressRules) {
+      NetworkAddressRules networkAddressRules,
+      boolean disableConnectionReuse) {
     return createClient(
         maxConnections,
         timeoutMilliseconds,
@@ -184,7 +190,8 @@ public class HttpClientFactory {
         true,
         Collections.emptyList(),
         useSystemProperties,
-        networkAddressRules);
+        networkAddressRules,
+        disableConnectionReuse);
   }
 
   private static SSLContext buildSSLContextWithTrustStore(
@@ -240,7 +247,8 @@ public class HttpClientFactory {
         NO_PROXY,
         NO_STORE,
         true,
-        NetworkAddressRules.ALLOW_ALL);
+        NetworkAddressRules.ALLOW_ALL,
+        false);
   }
 
   public static CloseableHttpClient createClient(int timeoutMilliseconds) {
@@ -254,7 +262,8 @@ public class HttpClientFactory {
         proxySettings,
         NO_STORE,
         true,
-        NetworkAddressRules.ALLOW_ALL);
+        NetworkAddressRules.ALLOW_ALL,
+        false);
   }
 
   public static CloseableHttpClient createClient() {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,8 @@ public class ApacheHttpClientFactory implements HttpClientFactory {
             trustAllCertificates,
             trustedHosts,
             useSystemProperties,
-            options.getProxyTargetRules());
+            options.getProxyTargetRules(),
+            true);
 
     return new ApacheBackedHttpClient(apacheClient);
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2023 Thomas Akehurst
+ * Copyright (C) 2012-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.admin.model.GetScenariosResult;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import java.io.IOException;
 import java.util.List;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpStatus;
@@ -78,5 +79,16 @@ public class HttpAdminClientTest {
     var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
 
     assertThat(client.getAllScenarios()).usingRecursiveComparison().isEqualTo(expectedResponse);
+  }
+
+  @Test
+  public void reuseConnections() throws InterruptedException, IOException {
+    var server = new SingleConnectionServer();
+    server.start();
+    var client = new HttpAdminClient("localhost", server.getPort(), ADMIN_TEST_PREFIX);
+
+    client.resetAll();
+    client.resetAll();
+    server.stop();
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/client/SingleConnectionServer.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/SingleConnectionServer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.client;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SingleConnectionServer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SingleConnectionServer.class);
+
+  private final Thread thread;
+  private final ServerSocket serverSocket;
+
+  public SingleConnectionServer() throws IOException {
+    this.serverSocket = new ServerSocket(0);
+    this.thread =
+        new Thread(
+            () -> {
+              Socket socket = null;
+              try {
+                socket = serverSocket.accept();
+                socket.setSoTimeout(500);
+                handleClientConnection(socket);
+                serverSocket.close();
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              } finally {
+                try {
+                  serverSocket.close();
+                  if (socket != null) {
+                    socket.close();
+                  }
+                } catch (IOException e) {
+                  LOG.error("Error closing socket", e);
+                }
+              }
+            });
+  }
+
+  public void start() {
+    thread.start();
+  }
+
+  public void stop() throws InterruptedException {
+    thread.interrupt();
+    thread.join();
+  }
+
+  public int getPort() {
+    return serverSocket.getLocalPort();
+  }
+
+  private void handleClientConnection(Socket clientSocket) throws IOException {
+    BufferedReader reader =
+        new BufferedReader(
+            new InputStreamReader(clientSocket.getInputStream(), StandardCharsets.UTF_8));
+    PrintWriter writer = new PrintWriter(clientSocket.getOutputStream(), true);
+
+    String requestLine;
+    try {
+      while ((requestLine = reader.readLine()) != null && !Thread.currentThread().isInterrupted()) {
+        if (requestLine.startsWith("POST /admin-test/__admin/reset")) {
+          String line;
+          while (!(line = reader.readLine()).isBlank()) {
+            // Discard headers
+          }
+
+          // Send the response with status 200 OK
+          String response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+          writer.println(response);
+        }
+      }
+    } catch (SocketTimeoutException e) {
+      // Ignore
+    }
+
+    clientSocket.close();
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Thomas Akehurst
+ * Copyright (C) 2020-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,8 @@ public abstract class HttpClientFactoryCertificateVerificationTest {
             /* trustSelfSignedCertificates= */ false,
             trustedHosts,
             false,
-            NetworkAddressRules.ALLOW_ALL);
+            NetworkAddressRules.ALLOW_ALL,
+            true);
   }
 
   @AfterEach

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Thomas Akehurst
+ * Copyright (C) 2020-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -391,7 +391,8 @@ public class ProxyResponseRendererTest {
                 true,
                 Collections.emptyList(),
                 true,
-                NetworkAddressRules.ALLOW_ALL));
+                NetworkAddressRules.ALLOW_ALL,
+                true));
     HttpClient reverseProxyClient = new ApacheBackedHttpClient(reverseProxyApacheClient);
 
     forwardProxyApacheClient =
@@ -404,7 +405,8 @@ public class ProxyResponseRendererTest {
                 trustAllProxyTargets,
                 Collections.emptyList(),
                 false,
-                NetworkAddressRules.ALLOW_ALL));
+                NetworkAddressRules.ALLOW_ALL,
+                true));
     HttpClient forwardProxyClient = new ApacheBackedHttpClient(forwardProxyApacheClient);
 
     return new ProxyResponseRenderer(


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
We are using WireMock for our integration tests. In one of our projects the test suite does ~ 29000 requests to the WireMock for stubbing, verifying, resetting ... requests. With the current implementation for each and every request a new TCP connection is created. This causes a lot of useless overhead. On powerful systems the test suite takes just 1 minute and a few seconds and it looks like we now reached a limit where some kind of ratelimiting (haven't yet found the reason for) on the network layer blocks the creation of new TCP connections to the WireMock. If I enable the connection reuse everything works as expected.
I just had a look through the history and it looks like disabling the connection reuse was introduced due to a bug that occurs when the WireMock server is running in proxy mode. Therefore this feature should only be disabled in these cases. (Btw. I don't think it's a good idea to mix-up the configuration of clients that are used for completely different use cases.)

To provide a test for this a added a small dummy server that just accepts a single connection. If you disable the connection reuse feature you will see it failing.

## References

- #1389

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
