### PR TITLE
[FIX] Add a custom number comparator to the Json Diff to trim trailing zeros

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToJsonPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToJsonPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,10 @@ public class EqualToJsonPattern extends StringValuePattern {
   @Override
   public MatchResult match(String value) {
     final CountingDiffListener diffListener = new CountingDiffListener();
-    Configuration diffConfig = Configuration.empty().withDifferenceListener(diffListener);
+    Configuration diffConfig =
+        Configuration.empty()
+            .withDifferenceListener(diffListener)
+            .withNumberComparator(new NormalisedNumberComparator());
 
     if (shouldIgnoreArrayOrder()) {
       diffConfig = diffConfig.withOptions(Option.IGNORING_ARRAY_ORDER);

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/NormalisedNumberComparator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/NormalisedNumberComparator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import java.math.BigDecimal;
+import net.javacrumbs.jsonunit.core.NumberComparator;
+
+public class NormalisedNumberComparator implements NumberComparator {
+  @Override
+  public boolean compare(BigDecimal expectedValue, BigDecimal actualValue, BigDecimal tolerance) {
+    var normalisedExpectedValue = expectedValue.stripTrailingZeros();
+    var normalisedActualValue = actualValue.stripTrailingZeros();
+    if (tolerance != null) {
+      var diff = normalisedExpectedValue.subtract(normalisedActualValue).abs();
+      return diff.compareTo(tolerance) <= 0;
+    } else {
+      return normalisedExpectedValue.equals(normalisedActualValue);
+    }
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/MappingsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MappingsAcceptanceTest.java
@@ -68,6 +68,46 @@ public class MappingsAcceptanceTest extends AcceptanceTestBase {
   }
 
   @Test
+  public void basicMappingWithNoTrailingZerosMatchingOnDecimalsWithNoTrailingZeros() {
+    testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_JSON_BODY_DECIMALS_NO_TRAILING_ZEROS);
+
+    WireMockResponse noTrailingZerosResponse =
+        testClient.postJson("/body/decimals", "{\"float\": 1.2}");
+
+    assertThat(noTrailingZerosResponse.statusCode(), is(200));
+  }
+
+  @Test
+  public void basicMappingWithNoTrailingZerosMatchingOnDecimalsWithTrailingZeros() {
+    testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_JSON_BODY_DECIMALS_NO_TRAILING_ZEROS);
+
+    WireMockResponse trailingZerosResponse =
+        testClient.postJson("/body/decimals", "{\"float\": 1.2000000}");
+
+    assertThat(trailingZerosResponse.statusCode(), is(200));
+  }
+
+  @Test
+  public void basicMappingWithTrailingZerosMatchingOnDecimalsWithNoTrailingZeros() {
+    testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_JSON_BODY_DECIMALS_TRAILING_ZEROS);
+
+    WireMockResponse noTrailingZerosResponse =
+        testClient.postJson("/body/decimals", "{\"float\": 1.2}");
+
+    assertThat(noTrailingZerosResponse.statusCode(), is(200));
+  }
+
+  @Test
+  public void basicMappingWithTrailingZerosMatchingOnDecimalsWithTrailingZeros() {
+    testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_JSON_BODY_DECIMALS_TRAILING_ZEROS);
+
+    WireMockResponse trailingZerosResponse =
+        testClient.postJson("/body/decimals", "{\"float\": 1.200}");
+
+    assertThat(trailingZerosResponse.statusCode(), is(200));
+  }
+
+  @Test
   public void mappingWithStatusOnlyResponseIsCreatedAndReturned() {
     testClient.addResponse(MappingJsonSamples.STATUS_ONLY_MAPPING_REQUEST);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,30 @@ public class MatchesJsonPathPatternTest {
     assertFalse(
         pattern.match("{ \"numbers\": [{\"number\": 7} ]}").isExactMatch(),
         "Expected no match when JSON attribute is absent");
+  }
+
+  @Test
+  public void matchesOnJsonPathsWithDecimalFilters() {
+    StringValuePattern pattern = WireMock.matchingJsonPath("$.numbers[?(@.decimal == '2.3')]");
+
+    assertTrue(
+        pattern.match("{ \"numbers\": [ {\"number\": 1}, {\"decimal\": 2.3} ]}").isExactMatch(),
+        "Expected match when JSON attribute is present and the same as the filter");
+    assertTrue(
+        pattern.match("{ \"numbers\": [ {\"number\": 1}, {\"decimal\": 2.3000} ]}").isExactMatch(),
+        "Expected match when JSON attribute is present, the same as the filter but with trailing zeros");
+  }
+
+  @Test
+  public void matchesOnJsonPathsWithDecimalFiltersWithTrailingZeros() {
+    StringValuePattern pattern = WireMock.matchingJsonPath("$.numbers[?(@.decimal == '2.3000')]");
+
+    assertTrue(
+        pattern.match("{ \"numbers\": [ {\"number\": 1}, {\"decimal\": 2.3} ]}").isExactMatch(),
+        "Expected match when JSON attribute is present, the same as the filter but without trailing zeros");
+    assertTrue(
+        pattern.match("{ \"numbers\": [ {\"number\": 1}, {\"decimal\": 2.3000} ]}").isExactMatch(),
+        "Expected match when JSON attribute is present and the same as the filter");
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MappingJsonSamples.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MappingJsonSamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -257,4 +257,21 @@ public class MappingJsonSamples {
           + "           \"body\": \"国家标准\"                       \n"
           + "   }                                                                                          \n"
           + "}\n";
+
+  public static final String MAPPING_REQUEST_JSON_BODY_DECIMALS_NO_TRAILING_ZEROS =
+      "{ 														\n"
+          + "	\"request\": {										\n"
+          + "		\"method\": \"POST\",							\n"
+          + "		\"url\": \"/body/decimals\",	        		\n"
+          + "		\"bodyPatterns\": [								\n"
+          + "			{ \"equalToJson\": {\"float\": 1.2} }   	\n"
+          + "		]												\n"
+          + "	},													\n"
+          + "	\"response\": {										\n"
+          + "		\"status\": 200									\n"
+          + "	}													\n"
+          + "}													";
+
+  public static final String MAPPING_REQUEST_JSON_BODY_DECIMALS_TRAILING_ZEROS =
+      MAPPING_REQUEST_JSON_BODY_DECIMALS_NO_TRAILING_ZEROS.replace("1.2", "1.20000000");
 }


### PR DESCRIPTION
In PR [2588](https://github.com/wiremock/wiremock/pull/2588/files) we set our ObjectMapper to not normalise BigDecimal values.  This fixed the undesirable behavior of values such as this - `{"float": 2.0}` being changed to this - `{"float": 2}`.  This PR maintains that behaviour.   

Because decimal values are no longer being normalised, this means we have an issue with the json Diff not seeing numbers like `1.2` and `1.2000` as the same values. This change adds a new `NumberComparator` to the Diff to normalise the BigDecimal values so we can continue to compare those values in the same way as we used to in versions prior to `3.4.0`.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

fixes #2610