### PR TITLE
Refactor JsonNodeFactory(true) in favour of a JsonNodeFeature

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.cfg.JsonNodeFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
 import java.util.Map;
@@ -45,8 +45,8 @@ public final class Json {
         @Override
         protected ObjectMapper initialValue() {
           ObjectMapper objectMapper = new ObjectMapper();
-          objectMapper.setNodeFactory(new JsonNodeFactory(true));
           objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+          objectMapper.configure(JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES, false);
           objectMapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
           objectMapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
           objectMapper.configure(JsonParser.Feature.IGNORE_UNDEFINED, true);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

In PR [2588](https://github.com/wiremock/wiremock/pull/2588/files) the ObjectMapper was changed to not normalise BigDecimal values. This fixed the undesirable behavior of values such as this - {"float": 2.0} being changed to this - {"float": 2}. This PR maintains that behaviour.

To accomplish this a JsonNodeFactory was added to the ObjectMapper in the following way:
```java
objectMapper.setNodeFactory(new JsonNodeFactory(true));
```

The `true` parameter tells the object mapper to not normalise BigDecimal values.  This issue on the `jackson-databind` project explains that they will be deprecating the `JsonNodeFactory` method in favour of configuring the object mapper via a `JsonNodeFeature` - https://github.com/FasterXML/jackson-databind/issues/3651

This PR updates to configuring the object mapper via a `JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES`.  There should be no failing tests as a result of this change.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
