### PR TITLE
Revert "Fix json-body not escaped properly" 

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
@@ -31,8 +31,6 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public final class Json {
 
@@ -120,32 +118,6 @@ public final class Json {
     } catch (IOException ioe) {
       return throwUnchecked(ioe, byte[].class);
     }
-  }
-
-  public static byte[] toByteArrayEscaped(JsonNode jsonNode) {
-    String string = toStringEscaped(jsonNode);
-    return string != null ? Strings.bytesFromString(string) : new byte[0];
-  }
-
-  public static String toStringEscaped(JsonNode jsonNode) {
-    if (jsonNode.isValueNode()) {
-      if (jsonNode.isTextual()) {
-        return "\"" + jsonNode.asText() + "\"";
-      } else {
-        return jsonNode.asText();
-      }
-    } else if (jsonNode.isArray()) {
-      return Stream.generate(jsonNode.elements()::next)
-          .limit(jsonNode.size())
-          .map(Json::toStringEscaped)
-          .collect(Collectors.joining(",", "[", "]"));
-    } else if (jsonNode.isObject()) {
-      return Stream.generate(jsonNode.fields()::next)
-          .limit(jsonNode.size())
-          .map(field -> "\"" + field.getKey() + "\":" + toStringEscaped(field.getValue()))
-          .collect(Collectors.joining(",", "{", "}"));
-    }
-    return null;
   }
 
   public static JsonNode node(String json) {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
@@ -17,13 +17,13 @@ package com.github.tomakehurst.wiremock.http;
 
 import static com.github.tomakehurst.wiremock.common.Encoding.decodeBase64;
 import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
-import static com.github.tomakehurst.wiremock.common.Strings.bytesFromString;
 import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.github.tomakehurst.wiremock.common.ContentTypes;
 import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.common.Strings;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -32,46 +32,33 @@ public class Body {
   private final byte[] content;
   private final boolean binary;
   private final boolean json;
-  private final JsonNode jsonContent;
 
   public Body(byte[] content) {
     this(content, true);
   }
 
   public Body(String content) {
-    this.content = bytesFromString(content);
-    this.binary = false;
-    this.json = false;
-    this.jsonContent = null;
+    this.content = Strings.bytesFromString(content);
+    binary = false;
+    json = false;
   }
 
   private Body(byte[] content, boolean binary) {
     this.content = content;
     this.binary = binary;
-    this.json = false;
-    this.jsonContent = null;
+    json = false;
   }
 
   private Body(byte[] content, boolean binary, boolean json) {
-    if (json) {
-      JsonNode jsonNode = Json.node(stringFromBytes(content));
-      this.content = Json.toByteArrayEscaped(jsonNode);
-      this.binary = binary;
-      this.json = true;
-      this.jsonContent = jsonNode;
-    } else {
-      this.content = content;
-      this.binary = binary;
-      this.json = false;
-      this.jsonContent = null;
-    }
+    this.content = content;
+    this.binary = binary;
+    this.json = json;
   }
 
   private Body(JsonNode content) {
-    this.content = Json.toByteArrayEscaped(content);
+    this.content = Json.toByteArray(content);
     binary = false;
     json = true;
-    jsonContent = content;
   }
 
   static Body fromBytes(byte[] bytes) {
@@ -123,11 +110,7 @@ public class Body {
   }
 
   public JsonNode asJson() {
-    if (isJson()) {
-      return jsonContent;
-    } else {
-      return Json.node(asString());
-    }
+    return Json.node(asString());
   }
 
   public boolean isJson() {

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -52,7 +52,6 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -703,41 +702,5 @@ public class StandaloneAcceptanceTest {
 
   public static String padRight(String s, int paddingLength) {
     return String.format("%1$-" + paddingLength + "s", s);
-  }
-
-  @Nested
-  class JsonResponseBodyStandaloneAcceptanceTest {
-
-    private static final String MAPPING_REQUEST_WITH_JSON_RESPONSE_BODY =
-        "{\n"
-            + "  \"metadata\": {\n"
-            + "    \"description\": \"matches helper example\"\n"
-            + "  },\n"
-            + "  \"request\": {\n"
-            + "    \"method\": \"GET\",\n"
-            + "    \"urlPattern\": \"/matches/\\\\?string=[^&]+\"\n"
-            + "  },\n"
-            + "  \"response\": {\n"
-            + "    \"status\": 200,\n"
-            + "    \"headers\": {\n"
-            + "      \"Content-Type\": \"application/json\"\n"
-            + "    },\n"
-            + "    \"transformers\": [\n"
-            + "      \"response-template\"\n"
-            + "    ],\n"
-            + "    \"jsonBody\": {\n"
-            + "\"string matches\": \"{{#matches request.query.string 'lor\\\\w+'}}Matched{{/matches}}\"\n"
-            + "    }\n"
-            + "  }\n"
-            + "}\n";
-
-    @Test
-    void readEscapeSequenceProperly() {
-      writeMappingFile("test-mapping-1.json", MAPPING_REQUEST_WITH_JSON_RESPONSE_BODY);
-      startRunner();
-      assertThat(
-          testClient.get("/matches/?string=lorem").content(),
-          is("{\"string matches\":\"Matched\"}"));
-    }
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
@@ -87,45 +87,6 @@ class BodyTest {
   }
 
   @Test
-  void mustEscapeWhenConstructedFromJson() {
-    String jsonString =
-        "{\n"
-            + "  \"escape\": [\n"
-            + "    \"quotation mark : \\\" padding\",\n"
-            + "    \"reverse solidas : \\\\ padding\",\n"
-            + "    \"backspace : \\b padding\",\n"
-            + "    \"formfeed : \\f padding\",\n"
-            + "    \"newline : \\n padding\",\n"
-            + "    \"carriage return : \\r padding\",\n"
-            + "    \"horizontal tab: \\t padding\",\n"
-            + "    \"hex digit: \\u12ab"
-            + " padding\"\n"
-            + "  ]\n"
-            + "}\n";
-    JsonNode jsonNode = Json.node(jsonString);
-    String jsonCompressedAndEscaped =
-        jsonNode
-            .toString()
-            .replace("\\\"", "\"")
-            .replace("\\\\", "\\")
-            .replace("\\b", "\b")
-            .replace("\\f", "\f")
-            .replace("\\n", "\n")
-            .replace("\\r", "\r")
-            .replace("\\t", "\t")
-            .replaceAll("\\\\u12ab", "\u12ab");
-
-    Body body = Body.fromOneOf(null, null, jsonNode, "lskdjflsjdflks");
-
-    assertThat(body.asString(), is(jsonCompressedAndEscaped));
-    assertThat(body.isBinary(), is(false));
-    assertThat(body.asBytes(), is(bytesFromString(jsonCompressedAndEscaped)));
-    assertThat(body.isJson(), is(true));
-    assertThat(body.asJson(), is(jsonNode));
-    assertThat(body.asBase64(), is(encodeBase64(bytesFromString(jsonCompressedAndEscaped))));
-  }
-
-  @Test
   void constructsFromBase64() {
     String content = "this content";
     byte[] base64Encoded = bytesFromString(encodeBase64(bytesFromString(content)));
@@ -152,45 +113,6 @@ class BodyTest {
     assertThat(body.isJson(), is(true));
     assertThat(body.asJson(), is(jsonNode));
     assertThat(body.asBase64(), is(encodeBase64(bytesFromString(jsonString))));
-  }
-
-  @Test
-  void mustEscapeWhenConstructedFromJsonBytes() {
-    String jsonString =
-        "{\n"
-            + "  \"escape\": [\n"
-            + "    \"quotation mark : \\\" padding\",\n"
-            + "    \"reverse solidas : \\\\ padding\",\n"
-            + "    \"backspace : \\b padding\",\n"
-            + "    \"formfeed : \\f padding\",\n"
-            + "    \"newline : \\n padding\",\n"
-            + "    \"carriage return : \\r padding\",\n"
-            + "    \"horizontal tab: \\t padding\",\n"
-            + "    \"hex digit: \\u12ab padding\"\n"
-            + "  ]\n"
-            + "}\n";
-    byte[] jsonBytes = bytesFromString(jsonString);
-    JsonNode jsonNode = Json.node(jsonString);
-    String jsonCompressedAndEscaped =
-        jsonNode
-            .toString()
-            .replace("\\\"", "\"")
-            .replace("\\\\", "\\")
-            .replace("\\b", "\b")
-            .replace("\\f", "\f")
-            .replace("\\n", "\n")
-            .replace("\\r", "\r")
-            .replace("\\t", "\t")
-            .replaceAll("\\\\u12ab", "\u12ab");
-
-    Body body = Body.fromJsonBytes(jsonBytes);
-
-    assertThat(body.asString(), is(jsonCompressedAndEscaped));
-    assertThat(body.isBinary(), is(false));
-    assertThat(body.asBytes(), is(bytesFromString(jsonCompressedAndEscaped)));
-    assertThat(body.isJson(), is(true));
-    assertThat(body.asJson(), is(jsonNode));
-    assertThat(body.asBase64(), is(encodeBase64(bytesFromString(jsonCompressedAndEscaped))));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
@@ -19,9 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.common.Json;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 public class JsonTest {
@@ -110,125 +108,6 @@ public class JsonTest {
     int count = Json.deepSize(Json.node("{}"));
 
     assertThat(count, is(1));
-  }
-
-  @Test
-  public void testToStringEscaped() {
-    // language=JSON
-    String json =
-        "{\n"
-            + "  \"string\": \"This is a text\",\n"
-            + "  \"number\": 1,\n"
-            + "  \"boolean\": true,\n"
-            + "  \"null\": null,\n"
-            + "  \"simple_array\": [\n"
-            + "    \"element1\",\n"
-            + "    \"element2\",\n"
-            + "    \"element3\"\n"
-            + "  ],\n"
-            + "  \"object\": {\n"
-            + "    \"children_string\": \"This is a text\",\n"
-            + "    \"children_number\": 1\n"
-            + "  },\n"
-            + "  \"object_array\": [\n"
-            + "    {\n"
-            + "      \"id\": 1,\n"
-            + "      \"name\": \"one\"\n"
-            + "    },\n"
-            + "    {\n"
-            + "      \"id\": 2,\n"
-            + "      \"name\": \"two\"\n"
-            + "    },\n"
-            + "    {\n"
-            + "      \"id\": 3,\n"
-            + "      \"name\": \"three\"\n"
-            + "    }\n"
-            + "  ],\n"
-            + "  \"escape_sequence\":[\n"
-            + "    \"quotation mark : \\\" padding\",\n"
-            + "    \"reverse solidas : \\\\ padding\",\n"
-            + "    \"backspace : \\b padding\",\n"
-            + "    \"formfeed : \\f padding\",\n"
-            + "    \"newline : \\n padding\",\n"
-            + "    \"carriage return : \\r padding\",\n"
-            + "    \"horizontal tab: \\t padding\",\n"
-            + "    \"hex digit: \\u12ab padding\"\n"
-            + "  ]\n"
-            + "}";
-    JsonNode jsonNode = Json.node(json);
-    String result = Json.toStringEscaped(jsonNode);
-    String jsonCompressedAndEscaped =
-        jsonNode
-            .toString()
-            .replace("\\\"", "\"")
-            .replace("\\\\", "\\")
-            .replace("\\b", "\b")
-            .replace("\\f", "\f")
-            .replace("\\n", "\n")
-            .replace("\\r", "\r")
-            .replace("\\t", "\t")
-            .replaceAll("\\\\u12ab", "\u12ab");
-    assertThat(result, is(jsonCompressedAndEscaped));
-  }
-
-  @Test
-  public void testToByteArrayEscaped() {
-    // language=JSON
-    String json =
-        "{\n"
-            + "  \"string\": \"This is a text\",\n"
-            + "  \"number\": 1,\n"
-            + "  \"boolean\": true,\n"
-            + "  \"null\": null,\n"
-            + "  \"simple_array\": [\n"
-            + "    \"element1\",\n"
-            + "    \"element2\",\n"
-            + "    \"element3\"\n"
-            + "  ],\n"
-            + "  \"object\": {\n"
-            + "    \"children_string\": \"This is a text\",\n"
-            + "    \"children_number\": 1\n"
-            + "  },\n"
-            + "  \"object_array\": [\n"
-            + "    {\n"
-            + "      \"id\": 1,\n"
-            + "      \"name\": \"one\"\n"
-            + "    },\n"
-            + "    {\n"
-            + "      \"id\": 2,\n"
-            + "      \"name\": \"two\"\n"
-            + "    },\n"
-            + "    {\n"
-            + "      \"id\": 3,\n"
-            + "      \"name\": \"three\"\n"
-            + "    }\n"
-            + "  ],\n"
-            + "  \"escape_sequence\":[\n"
-            + "    \"quotation mark : \\\" padding\",\n"
-            + "    \"reverse solidas : \\\\ padding\",\n"
-            + "    \"backspace : \\b padding\",\n"
-            + "    \"formfeed : \\f padding\",\n"
-            + "    \"newline : \\n padding\",\n"
-            + "    \"carriage return : \\r padding\",\n"
-            + "    \"horizontal tab: \\t padding\",\n"
-            + "    \"hex digit: \\u12ab padding\"\n"
-            + "  ]\n"
-            + "}";
-    JsonNode jsonNode = Json.node(json);
-    byte[] result = Json.toByteArrayEscaped(jsonNode);
-    byte[] jsonCompressedAndEscaped =
-        jsonNode
-            .toString()
-            .replace("\\\"", "\"")
-            .replace("\\\\", "\\")
-            .replace("\\b", "\b")
-            .replace("\\f", "\f")
-            .replace("\\n", "\n")
-            .replace("\\r", "\r")
-            .replace("\\t", "\t")
-            .replaceAll("\\\\u12ab", "\u12ab")
-            .getBytes(StandardCharsets.UTF_8);
-    assertThat(result, is(jsonCompressedAndEscaped));
   }
 
   private static class TestPojo {


### PR DESCRIPTION
This produces badly formed JSON where there are escaped quotes present. Given the potential for other undiscovered edge-cases, we'll release a patch version without this fix for now.


