### PR TITLE
Fixes #2606 - avoid appending identical sub-events repeatedly

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static java.util.stream.Collectors.toUnmodifiableList;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.tomakehurst.wiremock.common.Lazy;
 import com.github.tomakehurst.wiremock.stubbing.SubEvent;
 import java.util.List;
 import java.util.Queue;
@@ -91,27 +92,46 @@ public abstract class MatchResult implements Comparable<MatchResult> {
 
   public static MatchResult aggregateWeighted(final List<WeightedMatchResult> matchResults) {
 
-    final List<SubEvent> allSubEvents =
-        matchResults.stream()
-            .flatMap(weightedResult -> weightedResult.getMatchResult().getSubEvents().stream())
-            .collect(Collectors.toList());
+    return new MatchResult() {
 
-    return new MatchResult(allSubEvents) {
+      private final Lazy<Boolean> exactMatch =
+          Lazy.lazy(() -> matchResults.stream().allMatch(ARE_EXACT_MATCH));
+      private final Lazy<Double> distance =
+          Lazy.lazy(
+              () -> {
+                double totalDistance = 0;
+                double sizeWithWeighting = 0;
+                for (WeightedMatchResult matchResult : matchResults) {
+                  totalDistance += matchResult.getDistance();
+                  sizeWithWeighting += matchResult.getWeighting();
+                }
+
+                return (totalDistance / sizeWithWeighting);
+              });
+
+      private final Lazy<List<SubEvent>> subEvents =
+          Lazy.lazy(
+              () -> {
+                isExactMatch(); // TODO: Find a less icky way to do this
+                return matchResults.stream()
+                    .flatMap(
+                        weightedResult -> weightedResult.getMatchResult().getSubEvents().stream())
+                    .collect(Collectors.toList());
+              });
+
       @Override
       public boolean isExactMatch() {
-        return matchResults.stream().allMatch(ARE_EXACT_MATCH);
+        return exactMatch.get();
       }
 
       @Override
       public double getDistance() {
-        double totalDistance = 0;
-        double sizeWithWeighting = 0;
-        for (WeightedMatchResult matchResult : matchResults) {
-          totalDistance += matchResult.getDistance();
-          sizeWithWeighting += matchResult.getWeighting();
-        }
+        return distance.get();
+      }
 
-        return (totalDistance / sizeWithWeighting);
+      @Override
+      public List<SubEvent> getSubEvents() {
+        return subEvents.get();
       }
     };
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,8 +48,8 @@ public class MatchesJsonPathPattern extends PathPattern {
     if (value != null && value.trim().startsWith("<")) {
       final String message =
           String.format(
-              "Warning: JSON path expression '%s' failed to match document '%s' because it's not JSON but probably XML",
-              expectedValue, value);
+              "Warning: JSON path expression failed to match document '%s' because it's not JSON but probably XML",
+              value);
       notifier().info(message);
       return MatchResult.noMatch(SubEvent.warning(message));
     }
@@ -78,8 +78,8 @@ public class MatchesJsonPathPattern extends PathPattern {
 
       String message =
           String.format(
-              "Warning: JSON path expression '%s' failed to match document '%s' because %s",
-              expectedValue, value, error);
+              "Warning: JSON path expression failed to match document '%s' because %s",
+              value, error);
 
       return MatchResult.noMatch(SubEvent.warning(message));
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
@@ -192,7 +192,17 @@ public class ServeEvent {
   }
 
   public void appendSubEvent(SubEvent subEvent) {
-    subEvents.add(subEvent);
+    if (hasNotAlreadyBeenAppended(subEvent)) {
+      subEvents.add(subEvent);
+    }
+  }
+
+  private boolean hasNotAlreadyBeenAppended(SubEvent subEvent) {
+    if (!subEvent.isStandardType()) {
+      return true;
+    }
+
+    return subEvents.stream().noneMatch(subEvent::isEquivalentStandardTypedEventTo);
   }
 
   @JsonIgnore

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/SubEvent.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/SubEvent.java
@@ -18,6 +18,9 @@ package com.github.tomakehurst.wiremock.stubbing;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Message;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 public class SubEvent {
@@ -28,6 +31,11 @@ public class SubEvent {
   public static final String INFO = "INFO";
   public static final String WARNING = "WARNING";
   public static final String ERROR = "ERROR";
+
+  private static final List<String> STANDARD_TYPES = Arrays.asList(
+      NON_MATCH_TYPE, JSON_ERROR, XML_ERROR, INFO, WARNING, ERROR
+  );
+
   private final String type;
 
   private final Long timeOffsetNanos;
@@ -81,5 +89,15 @@ public class SubEvent {
 
   public <T> T getDataAs(Class<T> dataType) {
     return Json.mapToObject(data, dataType);
+  }
+
+  public boolean isEquivalentStandardTypedEventTo(SubEvent other) {
+    return isStandardType() && other.isStandardType() &&
+            type.equals(other.type) &&
+            data.equals(other.data);
+  }
+
+  boolean isStandardType() {
+    return STANDARD_TYPES.contains(type);
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/SubEvent.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/SubEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.github.tomakehurst.wiremock.stubbing;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Message;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -32,9 +31,8 @@ public class SubEvent {
   public static final String WARNING = "WARNING";
   public static final String ERROR = "ERROR";
 
-  private static final List<String> STANDARD_TYPES = Arrays.asList(
-      NON_MATCH_TYPE, JSON_ERROR, XML_ERROR, INFO, WARNING, ERROR
-  );
+  private static final List<String> STANDARD_TYPES =
+      Arrays.asList(NON_MATCH_TYPE, JSON_ERROR, XML_ERROR, INFO, WARNING, ERROR);
 
   private final String type;
 
@@ -92,9 +90,10 @@ public class SubEvent {
   }
 
   public boolean isEquivalentStandardTypedEventTo(SubEvent other) {
-    return isStandardType() && other.isStandardType() &&
-            type.equals(other.type) &&
-            data.equals(other.data);
+    return isStandardType()
+        && other.isStandardType()
+        && type.equals(other.type)
+        && data.equals(other.data);
   }
 
   boolean isStandardType() {

--- a/src/test/java/com/github/tomakehurst/wiremock/SubServeEventsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/SubServeEventsAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,10 @@ public class SubServeEventsAcceptanceTest extends AcceptanceTestBase {
     testClient.postXml("/json", "<whoops />");
 
     ServeEvent serveEvent = wm.getAllServeEvents().get(0);
-    assertThat(serveEvent.getSubEvents().stream()
-            .filter(sub -> sub.getType().equals(SubEvent.JSON_ERROR)).count(), is(1L));
+    assertThat(
+        serveEvent.getSubEvents().stream()
+            .filter(sub -> sub.getType().equals(SubEvent.JSON_ERROR))
+            .count(),
+        is(1L));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/SubServeEventsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/SubServeEventsAcceptanceTest.java
@@ -59,4 +59,17 @@ public class SubServeEventsAcceptanceTest extends AcceptanceTestBase {
     assertThat(
         error.getDetail(), containsString("Unexpected end-of-input within/between Object entries"));
   }
+
+  @Test
+  void onlyAppendsOneSubEventPerSpecificError() {
+    wm.stubFor(post("/json").withRequestBody(equalToJson("{ \"thing\": 1 }")).willReturn(ok()));
+    wm.stubFor(post("/json").withRequestBody(equalToJson("{ \"thing\": 2 }")).willReturn(ok()));
+    wm.stubFor(post("/json").withRequestBody(equalToJson("{ \"thing\": 3 }")).willReturn(ok()));
+
+    testClient.postXml("/json", "<whoops />");
+
+    ServeEvent serveEvent = wm.getAllServeEvents().get(0);
+    assertThat(serveEvent.getSubEvents().stream()
+            .filter(sub -> sub.getType().equals(SubEvent.JSON_ERROR)).count(), is(1L));
+  }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
@@ -132,7 +132,7 @@ public class MatchesJsonPathPatternTest {
     checkMessage(
         match,
         WARNING,
-        "Warning: JSON path expression '$.something' failed to match document 'Not a JSON document' because of error 'Expected to find an object with property ['something'] in path $ but found 'java.lang.String'. This is not a json object according to the JsonProvider: 'com.jayway.jsonpath.spi.json.JsonSmartJsonProvider'.'");
+        "Warning: JSON path expression failed to match document 'Not a JSON document' because of error 'Expected to find an object with property ['something'] in path $ but found 'java.lang.String'. This is not a json object according to the JsonProvider: 'com.jayway.jsonpath.spi.json.JsonSmartJsonProvider'.'");
   }
 
   private static void checkWarningMessageAndEvent(
@@ -150,7 +150,7 @@ public class MatchesJsonPathPatternTest {
     checkMessage(
         matchResult,
         WARNING,
-        "Warning: JSON path expression '$.something' failed to match document '{ \"nothing\": 1 }' because of error 'No results for path: $['something']'");
+        "Warning: JSON path expression failed to match document '{ \"nothing\": 1 }' because of error 'No results for path: $['something']'");
   }
 
   @Test
@@ -164,7 +164,7 @@ public class MatchesJsonPathPatternTest {
     checkWarningMessageAndEvent(
         notifier,
         matchResult,
-        "Warning: JSON path expression '$.something' failed to match document '<xml-stuff />' because it's not JSON but probably XML");
+        "Warning: JSON path expression failed to match document '<xml-stuff />' because it's not JSON but probably XML");
   }
 
   @Test


### PR DESCRIPTION
To avoid resource exhaustion during matching per https://github.com/wiremock/wiremock/issues/2606