### PR TITLE
Added a System.Logger Notifier implementation and deprecated the Slf4 notifier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,8 @@ project.ext {
     jackson        : '2.16.1',
     xmlUnit        : '2.9.1',
     jsonUnit       : '2.38.0',
-    junitJupiter   : '5.10.2'
+    junitJupiter   : '5.10.2',
+    slf4j          : '1.7.36'
   ]
 }
 
@@ -76,8 +77,8 @@ dependencies {
   }
   api "org.ow2.asm:asm:9.6"
 
-  implementation "org.slf4j:slf4j-api:1.7.36"
-  standaloneOnly "org.slf4j:slf4j-nop:1.7.36"
+  compileOnly "org.slf4j:slf4j-api:$versions.slf4j"
+  standaloneOnly "org.slf4j:slf4j-nop:$versions.slf4j"
 
   api "net.sf.jopt-simple:jopt-simple:5.0.4"
 
@@ -125,8 +126,8 @@ dependencies {
 
   testImplementation "org.eclipse.jetty:jetty-client"
   testImplementation "org.eclipse.jetty.http2:http2-http-client-transport"
-  testRuntimeOnly "org.slf4j:log4j-over-slf4j:2.0.12"
-  testRuntimeOnly "ch.qos.logback:logback-classic:1.4.0"
+  testRuntimeOnly 'org.slf4j:slf4j-jdk-platform-logging:2.0.12'
+  testRuntimeOnly 'ch.qos.logback:logback-classic:1.4.14'
   testRuntimeOnly files('src/test/resources/classpath file source/classpathfiles.zip', 'src/test/resources/classpath-filesource.jar')
 
   testImplementation ('net.jockx:littleproxy:1.1.3') {

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Thomas Akehurst
+ * Copyright (C) 2013-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import com.github.tomakehurst.wiremock.http.trafficlistener.DoNothingWiremockNet
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.jetty.JettyHttpServerFactory;
 import com.github.tomakehurst.wiremock.jetty.QueuedThreadPoolFactory;
+import com.github.tomakehurst.wiremock.logging.JavaSystemNotifier;
 import com.github.tomakehurst.wiremock.security.Authenticator;
 import com.github.tomakehurst.wiremock.security.BasicAuthenticator;
 import com.github.tomakehurst.wiremock.security.NoAuthenticator;
@@ -93,7 +94,7 @@ public class WireMockConfiguration implements Options {
   private MappingsSource mappingsSource;
   private FilenameMaker filenameMaker;
 
-  private Notifier notifier = new Slf4jNotifier(false);
+  private Notifier notifier = new JavaSystemNotifier(false);
   private boolean requestJournalDisabled = false;
   private Optional<Integer> maxRequestJournalEntries = Optional.empty();
   private List<CaseInsensitiveKey> matchingHeaders = emptyList();

--- a/src/main/java/com/github/tomakehurst/wiremock/logging/JavaSystemNotifier.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/logging/JavaSystemNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2024 Thomas Akehurst
+ * Copyright (C) 2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,39 +13,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.tomakehurst.wiremock.common;
+package com.github.tomakehurst.wiremock.logging;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static java.lang.System.Logger.Level.ERROR;
+import static java.lang.System.Logger.Level.INFO;
 
-/**
- * @deprecated Use {@link com.github.tomakehurst.wiremock.logging.JavaSystemNotifier} instead
- */
-@Deprecated
-public class Slf4jNotifier implements Notifier {
+import com.github.tomakehurst.wiremock.common.Notifier;
 
-  private static final Logger log = LoggerFactory.getLogger("WireMock");
+public class JavaSystemNotifier implements Notifier {
+
+  private final System.Logger log = System.getLogger("WireMock");
 
   private final boolean verbose;
 
-  public Slf4jNotifier(boolean verbose) {
+  public JavaSystemNotifier(boolean verbose) {
     this.verbose = verbose;
   }
 
   @Override
   public void info(String message) {
     if (verbose) {
-      log.info(message);
+      log.log(INFO, message);
     }
   }
 
   @Override
   public void error(String message) {
-    log.error(message);
+    log.log(ERROR, message);
   }
 
   @Override
   public void error(String message, Throwable t) {
-    log.error(message, t);
+    log.log(ERROR, message, t);
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockWebContextListener.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockWebContextListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2023 Thomas Akehurst
+ * Copyright (C) 2012-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,10 @@ package com.github.tomakehurst.wiremock.servlet;
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 
 import com.github.tomakehurst.wiremock.common.Notifier;
-import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockApp;
 import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
+import com.github.tomakehurst.wiremock.logging.JavaSystemNotifier;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
@@ -45,7 +45,7 @@ public class WireMockWebContextListener implements ServletContextListener {
     context.setAttribute(StubRequestHandler.class.getName(), wireMockApp.buildStubRequestHandler());
     context.setAttribute(
         AdminRequestHandler.class.getName(), wireMockApp.buildAdminRequestHandler());
-    context.setAttribute(Notifier.KEY, new Slf4jNotifier(verboseLoggingEnabled));
+    context.setAttribute(Notifier.KEY, new JavaSystemNotifier(verboseLoggingEnabled));
   }
 
   @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/client/SingleConnectionServer.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/SingleConnectionServer.java
@@ -23,12 +23,8 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SingleConnectionServer {
-
-  private static final Logger LOG = LoggerFactory.getLogger(SingleConnectionServer.class);
 
   private final Thread thread;
   private final ServerSocket serverSocket;
@@ -53,7 +49,7 @@ public class SingleConnectionServer {
                     socket.close();
                   }
                 } catch (IOException e) {
-                  LOG.error("Error closing socket", e);
+                  e.printStackTrace();
                 }
               }
             });

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -10,6 +10,7 @@
     <appender-ref ref="STDOUT" />
   </root>
 
+  <logger name="WireMock" level="INFO" />
   <logger name="org.apache.hc.client5.http.wire" level="DEBUG" />
   <logger name="org.eclipse.jetty.util.thread" level="WARN" />
   <logger name="org.eclipse.jetty.util.component" level="WARN" />


### PR DESCRIPTION
This attempts to address #2557 and more general concerns about slf4j versions and shading.

By removing WireMock's direct dependency on slf4j this frees the user to make their own arrangements and use `org:slf4j:slf4j-jdk-platform-logging` with their own library versions if needed.