### PR TITLE
Fixed xPath concurrency issues

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/XmlNode.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/XmlNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Thomas Akehurst
+ * Copyright (C) 2020-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,44 +39,40 @@ import org.xml.sax.XMLReader;
 
 public class XmlNode {
 
-  protected static final InheritableThreadLocal<XPath> XPATH_CACHE =
-      new InheritableThreadLocal<>() {
-        @Override
-        protected XPath initialValue() {
-          final XPathFactory xPathfactory = XPathFactory.newInstance();
-          return xPathfactory.newXPath();
-        }
-      };
+  protected static final ThreadLocal<XPath> XPATH_CACHE =
+      ThreadLocal.withInitial(
+          () -> {
+            final XPathFactory xPathfactory = XPathFactory.newInstance();
+            return xPathfactory.newXPath();
+          });
 
-  protected static final InheritableThreadLocal<Transformer> TRANSFORMER_CACHE =
-      new InheritableThreadLocal<>() {
-        @Override
-        protected Transformer initialValue() {
-          TransformerFactory transformerFactory;
-          try {
-            // Optimization to get likely transformerFactory directly, rather than going through
-            // FactoryFinder#find
-            transformerFactory =
-                (TransformerFactory)
-                    Class.forName(
-                            "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl")
-                        .getDeclaredConstructor()
-                        .newInstance();
-          } catch (Exception e) {
-            transformerFactory = TransformerFactory.newInstance();
-          }
-          transformerFactory.setAttribute("indent-number", 2);
+  protected static final ThreadLocal<Transformer> TRANSFORMER_CACHE =
+      ThreadLocal.withInitial(
+          () -> {
+            TransformerFactory transformerFactory;
+            try {
+              // Optimization to get likely transformerFactory directly, rather than going through
+              // FactoryFinder#find
+              transformerFactory =
+                  (TransformerFactory)
+                      Class.forName(
+                              "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl")
+                          .getDeclaredConstructor()
+                          .newInstance();
+            } catch (Exception e) {
+              transformerFactory = TransformerFactory.newInstance();
+            }
+            transformerFactory.setAttribute("indent-number", 2);
 
-          try {
-            Transformer transformer = transformerFactory.newTransformer();
-            transformer.setOutputProperty(INDENT, "yes");
-            transformer.setOutputProperty(OMIT_XML_DECLARATION, "yes");
-            return transformer;
-          } catch (TransformerConfigurationException e) {
-            return throwUnchecked(e, Transformer.class);
-          }
-        }
-      };
+            try {
+              Transformer transformer = transformerFactory.newTransformer();
+              transformer.setOutputProperty(INDENT, "yes");
+              transformer.setOutputProperty(OMIT_XML_DECLARATION, "yes");
+              return transformer;
+            } catch (TransformerConfigurationException e) {
+              return throwUnchecked(e, Transformer.class);
+            }
+          });
 
   private static final Class<XMLReader> DOM2SAX_XMLREADER_CLASS = getDom2SaxAvailability();
 


### PR DESCRIPTION
Using InheritableThreadLocal means that entity can be accessible by some threads at the same time, so access should be synced or entity should be read-only. In the XmlDocument class there is a not synced write operation in xPath object that is InheritableThreadLocal.

I encountered the following problem. A am running a lot of requests to wiremock and mappings have different namespaces. And sometimes (random and rarely) at the evaluating xPath expression time (XmlDocument.findNodes() method) another thread (parent or child) is changing namespace context of current xPath object and error "Prefix must resolve to a namespace" appears, but namespaces in mapping file are correct. So I suggest to use simple ThreadLocal here. This change fixed my problem.

<!-- Please describe your pull request here. -->

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
