### PR TITLE
Request matching performance regression

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchResult.java
@@ -21,7 +21,6 @@ import static java.util.stream.Collectors.toUnmodifiableList;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.tomakehurst.wiremock.common.Lazy;
 import com.github.tomakehurst.wiremock.stubbing.SubEvent;
 import java.util.List;
 import java.util.Queue;

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchResult.java
@@ -91,49 +91,7 @@ public abstract class MatchResult implements Comparable<MatchResult> {
   }
 
   public static MatchResult aggregateWeighted(final List<WeightedMatchResult> matchResults) {
-
-    return new MatchResult() {
-
-      private final Lazy<Boolean> exactMatch =
-          Lazy.lazy(() -> matchResults.stream().allMatch(ARE_EXACT_MATCH));
-      private final Lazy<Double> distance =
-          Lazy.lazy(
-              () -> {
-                double totalDistance = 0;
-                double sizeWithWeighting = 0;
-                for (WeightedMatchResult matchResult : matchResults) {
-                  totalDistance += matchResult.getDistance();
-                  sizeWithWeighting += matchResult.getWeighting();
-                }
-
-                return (totalDistance / sizeWithWeighting);
-              });
-
-      private final Lazy<List<SubEvent>> subEvents =
-          Lazy.lazy(
-              () -> {
-                isExactMatch(); // TODO: Find a less icky way to do this
-                return matchResults.stream()
-                    .flatMap(
-                        weightedResult -> weightedResult.getMatchResult().getSubEvents().stream())
-                    .collect(Collectors.toList());
-              });
-
-      @Override
-      public boolean isExactMatch() {
-        return exactMatch.get();
-      }
-
-      @Override
-      public double getDistance() {
-        return distance.get();
-      }
-
-      @Override
-      public List<SubEvent> getSubEvents() {
-        return subEvents.get();
-      }
-    };
+    return new WeightedAggregateMatchResult(matchResults);
   }
 
   @JsonIgnore

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/WeightedAggregateMatchResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/WeightedAggregateMatchResult.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import static com.github.tomakehurst.wiremock.common.Lazy.lazy;
+import static com.github.tomakehurst.wiremock.common.Pair.pair;
+
+import com.github.tomakehurst.wiremock.common.Lazy;
+import com.github.tomakehurst.wiremock.common.Pair;
+import com.github.tomakehurst.wiremock.stubbing.SubEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WeightedAggregateMatchResult extends MatchResult {
+
+  private final List<WeightedMatchResult> matchResults;
+
+  private final Lazy<Pair<Boolean, List<SubEvent>>> resultAndEvents;
+
+  public WeightedAggregateMatchResult(List<WeightedMatchResult> matchResults) {
+    this.matchResults = matchResults;
+    resultAndEvents =
+        lazy(
+            () -> {
+              final List<SubEvent> subEvents = new ArrayList<>(matchResults.size());
+              return pair(
+                  matchResults.stream()
+                      .peek(
+                          weightedResult ->
+                              subEvents.addAll(weightedResult.getMatchResult().getSubEvents()))
+                      .allMatch(WeightedMatchResult::isExactMatch),
+                  subEvents);
+            });
+  }
+
+  @Override
+  public boolean isExactMatch() {
+    return resultAndEvents.get().a;
+  }
+
+  @Override
+  public double getDistance() {
+    double totalDistance = 0;
+    double sizeWithWeighting = 0;
+    for (WeightedMatchResult matchResult : matchResults) {
+      totalDistance += matchResult.getDistance();
+      sizeWithWeighting += matchResult.getWeighting();
+    }
+
+    return (totalDistance / sizeWithWeighting);
+  }
+
+  @Override
+  public List<SubEvent> getSubEvents() {
+    return resultAndEvents.get().b;
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/WeightedAggregateMatchResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/WeightedAggregateMatchResult.java
@@ -38,10 +38,12 @@ public class WeightedAggregateMatchResult extends MatchResult {
               final List<SubEvent> subEvents = new ArrayList<>(matchResults.size());
               return pair(
                   matchResults.stream()
-                      .peek(
-                          weightedResult ->
-                              subEvents.addAll(weightedResult.getMatchResult().getSubEvents()))
-                      .allMatch(WeightedMatchResult::isExactMatch),
+                      .allMatch(
+                          weightedMatchResult -> {
+                            final boolean exactMatch = weightedMatchResult.isExactMatch();
+                            subEvents.addAll(weightedMatchResult.getMatchResult().getSubEvents());
+                            return exactMatch;
+                          }),
                   subEvents);
             });
   }


### PR DESCRIPTION
Fixes a bug that was causing matchers within a request pattern to continue to be evaluated after a non-match has been found, leading to a lot of redundant processing in some setups and degraded performance.

## References

https://github.com/wiremock/wiremock/issues/2541