### PR TITLE
Optional default for SystemValueHelper.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/SystemValueHelper.java
@@ -33,6 +33,7 @@ public class SystemValueHelper extends HandlebarsHelper<Object> {
   public String apply(Object context, Options options) {
     String key = options.hash("key", "");
     String type = options.hash("type", "ENVIRONMENT");
+    String defaultValue = options.hash("default");
     if (isEmpty(key)) {
       return this.handleError("The key cannot be empty");
     }
@@ -45,10 +46,10 @@ public class SystemValueHelper extends HandlebarsHelper<Object> {
     try {
       switch (type) {
         case "ENVIRONMENT":
-          rawValue = getSystemEnvironment(key);
+          rawValue = getSystemEnvironment(key, defaultValue);
           break;
         case "PROPERTY":
-          rawValue = getSystemProperties(key);
+          rawValue = getSystemProperties(key, defaultValue);
           break;
       }
       return rawValue;
@@ -58,11 +59,11 @@ public class SystemValueHelper extends HandlebarsHelper<Object> {
     }
   }
 
-  private String getSystemEnvironment(final String key) {
-    return System.getenv(key);
+  private String getSystemEnvironment(final String key, final String defaultValue) {
+    return System.getenv().getOrDefault(key, defaultValue);
   }
 
-  private String getSystemProperties(final String key) {
-    return System.getProperty(key);
+  private String getSystemProperties(final String key, final String defaultValue) {
+    return System.getProperty(key, defaultValue);
   }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Allow an optional default value to be supplied when using the systemValue helper.

An example where this might be useful is having a safe default to proxy to a dev environment without requiring the environment variable to be set. It is also helpful to demonstrate what an appropriate value for the environment variable should be.
```json
{
    "request": {
        "method": "ANY",
        "urlPattern": "/"
    },
    "response": {
        "proxyBaseUrl": "{{systemValue type='ENVIRONMENT' key='WIREMOCK_PROXY_BASE_URL', default='https://dev.example.com'}}",
        "transformers": [
            "response-template"
        ]
    }
}
```

## References

- https://github.com/wiremock/wiremock.org/pull/262

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
