### PR TITLE
Allow removal of headers from a proxied request.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -79,6 +79,10 @@ public class ResponseDefinitionBuilder {
           responseDefinition.getAdditionalProxyRequestHeaders() != null
               ? (List<HttpHeader>) responseDefinition.getAdditionalProxyRequestHeaders().all()
               : new ArrayList<>();
+      proxyResponseDefinitionBuilder.removeRequestHeaders =
+          responseDefinition.getRemoveProxyRequestHeaders() != null
+              ? responseDefinition.getRemoveProxyRequestHeaders()
+              : new ArrayList<>();
 
       return proxyResponseDefinitionBuilder;
     }
@@ -232,6 +236,7 @@ public class ResponseDefinitionBuilder {
   public static class ProxyResponseDefinitionBuilder extends ResponseDefinitionBuilder {
 
     private List<HttpHeader> additionalRequestHeaders = new ArrayList<>();
+    private List<String> removeRequestHeaders = new ArrayList<>();
 
     public ProxyResponseDefinitionBuilder(ResponseDefinitionBuilder from) {
       this.status = from.status;
@@ -254,6 +259,11 @@ public class ResponseDefinitionBuilder {
       return this;
     }
 
+    public ProxyResponseDefinitionBuilder withRemoveRequestHeader(String key) {
+      removeRequestHeaders.add(key.toLowerCase());
+      return this;
+    }
+
     public ProxyResponseDefinitionBuilder withProxyUrlPrefixToRemove(
         String proxyUrlPrefixToRemove) {
       this.proxyUrlPrefixToRemove = proxyUrlPrefixToRemove;
@@ -264,6 +274,7 @@ public class ResponseDefinitionBuilder {
     public ResponseDefinition build() {
       return super.build(
           !additionalRequestHeaders.isEmpty() ? new HttpHeaders(additionalRequestHeaders) : null,
+          !removeRequestHeaders.isEmpty() ? removeRequestHeaders : null,
           proxyUrlPrefixToRemove);
     }
   }
@@ -274,11 +285,13 @@ public class ResponseDefinitionBuilder {
   }
 
   public ResponseDefinition build() {
-    return build(null, null);
+    return build(null, null, null);
   }
 
   protected ResponseDefinition build(
-      HttpHeaders additionalProxyRequestHeaders, String proxyUrlPrefixToRemove) {
+      HttpHeaders additionalProxyRequestHeaders,
+      List<String> removeProxyRequestHeaders,
+      String proxyUrlPrefixToRemove) {
     HttpHeaders httpHeaders =
         headers == null || headers.isEmpty() ? null : new HttpHeaders(headers);
     Parameters transformerParameters =
@@ -292,6 +305,7 @@ public class ResponseDefinitionBuilder {
         bodyFileName,
         httpHeaders,
         additionalProxyRequestHeaders,
+        removeProxyRequestHeaders,
         fixedDelayMilliseconds,
         delayDistribution,
         chunkedDribbleDelay,

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,6 +172,13 @@ public class ResponseTemplateTransformer
                 key, proxyHttpHeaders.getHeader(key).firstValue());
           }
         }
+
+        if (responseDefinition.getRemoveProxyRequestHeaders() != null) {
+          for (String key : responseDefinition.getRemoveProxyRequestHeaders()) {
+            newProxyResponseDefBuilder.withRemoveRequestHeader(key);
+          }
+        }
+
         return newProxyResponseDefBuilder.build();
       } else {
         return newResponseDefBuilder.build();

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.github.tomakehurst.wiremock.store.SettingsStore;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import javax.net.ssl.SSLException;
@@ -143,8 +144,16 @@ public class ProxyResponseRenderer implements ResponseRenderer {
   private void addRequestHeaders(
       ImmutableRequest.Builder requestBuilder, ResponseDefinition response) {
     Request originalRequest = response.getOriginalRequest();
+    List<String> removeProxyRequestHeaders =
+        response.getRemoveProxyRequestHeaders() == null
+            ? Collections.emptyList()
+            : response.getRemoveProxyRequestHeaders();
     for (String key : originalRequest.getAllHeaderKeys()) {
-      if (!HttpClient.HOST_HEADER.equalsIgnoreCase(key) || preserveHostHeader) {
+      String lowerCaseKey = key.toLowerCase();
+      if (removeProxyRequestHeaders.contains(lowerCaseKey)) {
+        continue;
+      }
+      if (!HttpClient.HOST_HEADER.equals(lowerCaseKey) || preserveHostHeader) {
         List<String> values = originalRequest.header(key).values();
         requestBuilder.withHeader(key, values);
       } else {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -44,6 +44,7 @@ public class ResponseDefinition {
   private final String bodyFileName;
   private final HttpHeaders headers;
   private final HttpHeaders additionalProxyRequestHeaders;
+  private final List<String> removeProxyRequestHeaders;
   private final Integer fixedDelayMilliseconds;
   private final DelayDistribution delayDistribution;
   private final ChunkedDribbleDelay chunkedDribbleDelay;
@@ -67,6 +68,7 @@ public class ResponseDefinition {
       @JsonProperty("bodyFileName") String bodyFileName,
       @JsonProperty("headers") HttpHeaders headers,
       @JsonProperty("additionalProxyRequestHeaders") HttpHeaders additionalProxyRequestHeaders,
+      @JsonProperty("removeProxyRequestHeaders") List<String> removeProxyRequestHeaders,
       @JsonProperty("fixedDelayMilliseconds") Integer fixedDelayMilliseconds,
       @JsonProperty("delayDistribution") DelayDistribution delayDistribution,
       @JsonProperty("chunkedDribbleDelay") ChunkedDribbleDelay chunkedDribbleDelay,
@@ -83,6 +85,7 @@ public class ResponseDefinition {
         bodyFileName,
         headers,
         additionalProxyRequestHeaders,
+        removeProxyRequestHeaders,
         fixedDelayMilliseconds,
         delayDistribution,
         chunkedDribbleDelay,
@@ -103,6 +106,7 @@ public class ResponseDefinition {
       String bodyFileName,
       HttpHeaders headers,
       HttpHeaders additionalProxyRequestHeaders,
+      List<String> removeProxyRequestHeaders,
       Integer fixedDelayMilliseconds,
       DelayDistribution delayDistribution,
       ChunkedDribbleDelay chunkedDribbleDelay,
@@ -119,6 +123,7 @@ public class ResponseDefinition {
         bodyFileName,
         headers,
         additionalProxyRequestHeaders,
+        removeProxyRequestHeaders,
         fixedDelayMilliseconds,
         delayDistribution,
         chunkedDribbleDelay,
@@ -137,6 +142,7 @@ public class ResponseDefinition {
       String bodyFileName,
       HttpHeaders headers,
       HttpHeaders additionalProxyRequestHeaders,
+      List<String> removeProxyRequestHeaders,
       Integer fixedDelayMilliseconds,
       DelayDistribution delayDistribution,
       ChunkedDribbleDelay chunkedDribbleDelay,
@@ -154,6 +160,7 @@ public class ResponseDefinition {
 
     this.headers = headers;
     this.additionalProxyRequestHeaders = additionalProxyRequestHeaders;
+    this.removeProxyRequestHeaders = removeProxyRequestHeaders;
     this.fixedDelayMilliseconds = fixedDelayMilliseconds;
     this.delayDistribution = delayDistribution;
     this.chunkedDribbleDelay = chunkedDribbleDelay;
@@ -170,6 +177,7 @@ public class ResponseDefinition {
         statusCode,
         null,
         Body.fromString(bodyContent),
+        null,
         null,
         null,
         null,
@@ -198,6 +206,7 @@ public class ResponseDefinition {
         null,
         null,
         null,
+        null,
         Collections.emptyList(),
         Parameters.empty(),
         true);
@@ -208,6 +217,7 @@ public class ResponseDefinition {
         HTTP_OK,
         null,
         Body.none(),
+        null,
         null,
         null,
         null,
@@ -306,6 +316,7 @@ public class ResponseDefinition {
             this.bodyFileName,
             this.headers,
             this.additionalProxyRequestHeaders,
+            this.removeProxyRequestHeaders,
             this.fixedDelayMilliseconds,
             this.delayDistribution,
             this.chunkedDribbleDelay,
@@ -324,6 +335,10 @@ public class ResponseDefinition {
 
   public HttpHeaders getAdditionalProxyRequestHeaders() {
     return additionalProxyRequestHeaders;
+  }
+
+  public List<String> getRemoveProxyRequestHeaders() {
+    return removeProxyRequestHeaders;
   }
 
   public int getStatus() {
@@ -473,6 +488,7 @@ public class ResponseDefinition {
         && Objects.equals(bodyFileName, that.bodyFileName)
         && Objects.equals(headers, that.headers)
         && Objects.equals(additionalProxyRequestHeaders, that.additionalProxyRequestHeaders)
+        && Objects.equals(removeProxyRequestHeaders, that.removeProxyRequestHeaders)
         && Objects.equals(fixedDelayMilliseconds, that.fixedDelayMilliseconds)
         && Objects.equals(delayDistribution, that.delayDistribution)
         && Objects.equals(chunkedDribbleDelay, that.chunkedDribbleDelay)
@@ -494,6 +510,7 @@ public class ResponseDefinition {
         bodyFileName,
         headers,
         additionalProxyRequestHeaders,
+        removeProxyRequestHeaders,
         fixedDelayMilliseconds,
         delayDistribution,
         chunkedDribbleDelay,

--- a/src/main/resources/swagger/schemas/response-definition.yaml
+++ b/src/main/resources/swagger/schemas/response-definition.yaml
@@ -13,6 +13,11 @@ allOf:
       additionalProxyRequestHeaders:
         type: object
         description: Extra request headers to send when proxying to another host.
+      removeProxyRequestHeaders:
+        type: array
+        description: Request headers to remove when proxying to another host.
+        items:
+          type: string
       body:
         type: string
         description: The response body as a string. Only one of body, base64Body, jsonBody or bodyFileName may be specified.

--- a/src/main/resources/swagger/wiremock-admin-api.json
+++ b/src/main/resources/swagger/wiremock-admin-api.json
@@ -208,6 +208,13 @@
                                     "type": "object",
                                     "description": "Extra request headers to send when proxying to another host."
                                   },
+                                  "removeProxyRequestHeaders": {
+                                    "type": "array",
+                                    "description": "Request headers to remove when proxying to another host.",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
                                   "body": {
                                     "type": "string",
                                     "description": "The response body as a string. Only one of body, base64Body, jsonBody or bodyFileName may be specified."
@@ -521,6 +528,13 @@
                             "type": "object",
                             "description": "Extra request headers to send when proxying to another host."
                           },
+                          "removeProxyRequestHeaders": {
+                            "type": "array",
+                            "description": "Request headers to remove when proxying to another host.",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
                           "body": {
                             "type": "string",
                             "description": "The response body as a string. Only one of body, base64Body, jsonBody or bodyFileName may be specified."
@@ -779,6 +793,13 @@
                             "additionalProxyRequestHeaders": {
                               "type": "object",
                               "description": "Extra request headers to send when proxying to another host."
+                            },
+                            "removeProxyRequestHeaders": {
+                              "type": "array",
+                              "description": "Request headers to remove when proxying to another host.",
+                              "items": {
+                                "type": "string"
+                              }
                             },
                             "body": {
                               "type": "string",
@@ -1125,6 +1146,13 @@
                               "type": "object",
                               "description": "Extra request headers to send when proxying to another host."
                             },
+                            "removeProxyRequestHeaders": {
+                              "type": "array",
+                              "description": "Request headers to remove when proxying to another host.",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
                             "body": {
                               "type": "string",
                               "description": "The response body as a string. Only one of body, base64Body, jsonBody or bodyFileName may be specified."
@@ -1400,6 +1428,13 @@
                             "type": "object",
                             "description": "Extra request headers to send when proxying to another host."
                           },
+                          "removeProxyRequestHeaders": {
+                            "type": "array",
+                            "description": "Request headers to remove when proxying to another host.",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
                           "body": {
                             "type": "string",
                             "description": "The response body as a string. Only one of body, base64Body, jsonBody or bodyFileName may be specified."
@@ -1658,6 +1693,13 @@
                             "additionalProxyRequestHeaders": {
                               "type": "object",
                               "description": "Extra request headers to send when proxying to another host."
+                            },
+                            "removeProxyRequestHeaders": {
+                              "type": "array",
+                              "description": "Request headers to remove when proxying to another host.",
+                              "items": {
+                                "type": "string"
+                              }
                             },
                             "body": {
                               "type": "string",
@@ -2084,6 +2126,13 @@
                                   "additionalProxyRequestHeaders": {
                                     "type": "object",
                                     "description": "Extra request headers to send when proxying to another host."
+                                  },
+                                  "removeProxyRequestHeaders": {
+                                    "type": "array",
+                                    "description": "Request headers to remove when proxying to another host.",
+                                    "items": {
+                                      "type": "string"
+                                    }
                                   },
                                   "body": {
                                     "type": "string",
@@ -4145,6 +4194,13 @@
                                     "type": "object",
                                     "description": "Extra request headers to send when proxying to another host."
                                   },
+                                  "removeProxyRequestHeaders": {
+                                    "type": "array",
+                                    "description": "Request headers to remove when proxying to another host.",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
                                   "body": {
                                     "type": "string",
                                     "description": "The response body as a string. Only one of body, base64Body, jsonBody or bodyFileName may be specified."
@@ -4768,6 +4824,13 @@
                                     "type": "object",
                                     "description": "Extra request headers to send when proxying to another host."
                                   },
+                                  "removeProxyRequestHeaders": {
+                                    "type": "array",
+                                    "description": "Request headers to remove when proxying to another host.",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
                                   "body": {
                                     "type": "string",
                                     "description": "The response body as a string. Only one of body, base64Body, jsonBody or bodyFileName may be specified."
@@ -5326,6 +5389,13 @@
                         "additionalProxyRequestHeaders": {
                           "type": "object",
                           "description": "Extra request headers to send when proxying to another host."
+                        },
+                        "removeProxyRequestHeaders": {
+                          "type": "array",
+                          "description": "Request headers to remove when proxying to another host.",
+                          "items": {
+                            "type": "string"
+                          }
                         },
                         "body": {
                           "type": "string",
@@ -6163,6 +6233,13 @@
                         "additionalProxyRequestHeaders": {
                           "type": "object",
                           "description": "Extra request headers to send when proxying to another host."
+                        },
+                        "removeProxyRequestHeaders": {
+                          "type": "array",
+                          "description": "Request headers to remove when proxying to another host.",
+                          "items": {
+                            "type": "string"
+                          }
                         },
                         "body": {
                           "type": "string",

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
@@ -86,6 +86,7 @@ class ResponseDefinitionBuilderTest {
         ResponseDefinitionBuilder.responseDefinition().proxiedFrom("http://my.domain").build();
 
     assertThat(proxyDefinition.getAdditionalProxyRequestHeaders(), nullValue());
+    assertThat(proxyDefinition.getRemoveProxyRequestHeaders(), nullValue());
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), nullValue());
   }
 
@@ -98,6 +99,7 @@ class ResponseDefinitionBuilderTest {
             .build();
 
     assertThat(proxyDefinition.getAdditionalProxyRequestHeaders(), nullValue());
+    assertThat(proxyDefinition.getRemoveProxyRequestHeaders(), nullValue());
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), nullValue());
   }
 
@@ -110,6 +112,7 @@ class ResponseDefinitionBuilderTest {
             .build();
 
     assertThat(proxyDefinition.getAdditionalProxyRequestHeaders(), nullValue());
+    assertThat(proxyDefinition.getRemoveProxyRequestHeaders(), nullValue());
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), nullValue());
   }
 
@@ -119,12 +122,14 @@ class ResponseDefinitionBuilderTest {
         ResponseDefinitionBuilder.responseDefinition()
             .proxiedFrom("http://my.domain")
             .withAdditionalRequestHeader("header", "value")
+            .withRemoveRequestHeader("header")
             .withProxyUrlPrefixToRemove("/remove")
             .build();
 
     assertThat(
         proxyDefinition.getAdditionalProxyRequestHeaders(),
         equalTo(new HttpHeaders(List.of(new HttpHeader("header", "value")))));
+    assertThat(proxyDefinition.getRemoveProxyRequestHeaders(), equalTo(List.of("header")));
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
   }
 
@@ -134,6 +139,7 @@ class ResponseDefinitionBuilderTest {
         ResponseDefinitionBuilder.responseDefinition()
             .proxiedFrom("http://my.domain")
             .withAdditionalRequestHeader("header", "value")
+            .withRemoveRequestHeader("header")
             .withProxyUrlPrefixToRemove("/remove")
             .withJsonBody(Json.read("{}", JsonNode.class))
             .build();
@@ -141,6 +147,7 @@ class ResponseDefinitionBuilderTest {
     assertThat(
         proxyDefinition.getAdditionalProxyRequestHeaders(),
         equalTo(new HttpHeaders(List.of(new HttpHeader("header", "value")))));
+    assertThat(proxyDefinition.getRemoveProxyRequestHeaders(), equalTo(List.of("header")));
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
   }
 
@@ -150,6 +157,7 @@ class ResponseDefinitionBuilderTest {
         ResponseDefinitionBuilder.responseDefinition()
             .proxiedFrom("http://my.domain")
             .withAdditionalRequestHeader("header", "value")
+            .withRemoveRequestHeader("header")
             .withProxyUrlPrefixToRemove("/remove")
             .withBody(new byte[] {0x01})
             .build();
@@ -157,6 +165,7 @@ class ResponseDefinitionBuilderTest {
     assertThat(
         proxyDefinition.getAdditionalProxyRequestHeaders(),
         equalTo(new HttpHeaders(List.of(new HttpHeader("header", "value")))));
+    assertThat(proxyDefinition.getRemoveProxyRequestHeaders(), equalTo(List.of("header")));
     assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,6 +119,7 @@ public class StubResponseRendererTest {
             null,
             "",
             "",
+            null,
             null,
             null,
             fixedDelayMillis,

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2023 Thomas Akehurst
+ * Copyright (C) 2012-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ public class ResponseDefinitionTest {
             null,
             "name.json",
             new HttpHeaders(httpHeader("thing", "thingvalue")),
+            null,
             null,
             1112,
             null,


### PR DESCRIPTION
Along with the ability to add `additionalProxyRequestHeaders`, it may be beneficial to `removeProxyRequestHeaders`. For example, if you want to remove the existing value(s) of a header before additional are added or if there are headers you don't want sent downstream.

## References

- https://github.com/wiremock/wiremock.org/pull/268

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
