### PR TITLE
Fix matching of multiple expected zoned date/time values with multiple actual local ones

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractDateTimeMatchResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractDateTimeMatchResult.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.matching;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
@@ -79,6 +80,8 @@ public abstract class AbstractDateTimeMatchResult extends MatchResult {
       distance = calculateDistance(localExpected, localActual);
     } else if (isLocal && zonedActual != null) {
       distance = calculateDistance(localExpected, zonedActual.toLocalDateTime());
+    } else if (isZoned && localActual != null) {
+      distance = calculateDistance(zonedExpected, localActual.atZone(ZoneId.systemDefault()));
     }
 
     return distance;


### PR DESCRIPTION
Right now, Wiremock doesn't support matching multiple expected zoned date/time values with multiple actual local ones.

In other words, given the matchers below:
```
"request": {
  "method": "GET",
  "urlPath": "/resource",
  "queryParameters": {
    "date": {
      "hasExactly": [
        {
          "equalToDateTime": "now",
          "truncateExpected": "first hour of day",
          "actualFormat": "yyyy-MM-dd"
        },
        {
          "equalToDateTime": "now",
          "expectedOffset": 1,
          "expectedOffsetUnit": "days",
          "truncateExpected": "first hour of day",
          "actualFormat": "yyyy-MM-dd"
        }
      ]
    }
  }
}
```
Then a GET request to the URL below should match (assuming the date is March 27th 2024):
```
/resource?date=2024-03-27&date=2024-03-28
```

Instead, we get a "request was not matched" message.

If we remove `hasExactly` then GET requests to the two following URIs do match with the resulting two individual matchers:
```
/resource?date=2024-03-27
/resource?date=2024-03-28
```
But when we combine the two matchers with `hasExactly` and send the multi-value parameter GET request described above then we get a mismatch.
 
This PR add supports for the above scenario and also adds two test cases which fail with the current implementation.

## References
An older, related PR: https://github.com/wiremock/wiremock/pull/1925

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)