### PR TITLE
Added toggles for plain text and TLS HTTP/2

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -52,6 +52,10 @@ public interface Options {
 
   boolean getHttpDisabled();
 
+  boolean getHttp2PlainEnabled();
+
+  boolean getHttp2TlsEnabled();
+
   HttpsSettings httpsSettings();
 
   JettySettings jettySettings();

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -65,6 +65,8 @@ public class WireMockConfiguration implements Options {
   private boolean disableOptimizeXmlFactoriesLoading = false;
   private int portNumber = DEFAULT_PORT;
   private boolean httpDisabled = false;
+  private boolean http2PlainEnabled = true;
+  private boolean http2TlsEnabled = true;
   private String bindAddress = DEFAULT_BIND_ADDRESS;
 
   private int containerThreads = DEFAULT_CONTAINER_THREADS;
@@ -193,6 +195,16 @@ public class WireMockConfiguration implements Options {
 
   public WireMockConfiguration httpDisabled(boolean httpDisabled) {
     this.httpDisabled = httpDisabled;
+    return this;
+  }
+
+  public WireMockConfiguration http2PlainEnabled(boolean enabled) {
+    this.http2PlainEnabled = enabled;
+    return this;
+  }
+
+  public WireMockConfiguration http2TlsEnabled(boolean enabled) {
+    this.http2TlsEnabled = enabled;
     return this;
   }
 
@@ -570,6 +582,16 @@ public class WireMockConfiguration implements Options {
   @Override
   public boolean getHttpDisabled() {
     return httpDisabled;
+  }
+
+  @Override
+  public boolean getHttp2PlainEnabled() {
+    return http2PlainEnabled;
+  }
+
+  @Override
+  public boolean getHttp2TlsEnabled() {
+    return http2TlsEnabled;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServer.java
@@ -46,6 +46,8 @@ public abstract class JettyHttpServer implements HttpServer {
   protected static final String[] GZIPPABLE_METHODS =
       new String[] {"POST", "PUT", "PATCH", "DELETE"};
 
+  protected final Options options;
+
   protected final Server jettyServer;
   protected final ServerConnector httpConnector;
   protected final ServerConnector httpsConnector;
@@ -56,6 +58,8 @@ public abstract class JettyHttpServer implements HttpServer {
       Options options,
       AdminRequestHandler adminRequestHandler,
       StubRequestHandler stubRequestHandler) {
+    this.options = options;
+
     if (!options.getDisableStrictHttpHeaders()
         && Boolean.FALSE.equals(STRICT_HTTP_HEADERS_APPLIED.get())) {
       System.setProperty("org.eclipse.jetty.http.HttpGenerator.STRICT", String.valueOf(true));

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty11/SslContexts.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty11/SslContexts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Thomas Akehurst
+ * Copyright (C) 2019-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,15 @@ public class SslContexts {
     sslContextFactory.setKeyManagerPassword(httpsSettings.keyManagerPassword());
     setupClientAuth(sslContextFactory, httpsSettings);
     sslContextFactory.setCipherComparator(HTTP2Cipher.COMPARATOR);
+    return sslContextFactory;
+  }
+
+  public static SslContextFactory.Server buildHttp1_1SslContextFactory(
+      HttpsSettings httpsSettings) {
+    SslContextFactory.Server sslContextFactory =
+        SslContexts.defaultSslContextFactory(httpsSettings.keyStore());
+    sslContextFactory.setKeyManagerPassword(httpsSettings.keyManagerPassword());
+    setupClientAuth(sslContextFactory, httpsSettings);
     return sslContextFactory;
   }
 
@@ -118,7 +127,10 @@ public class SslContexts {
   }
 
   private static X509KeyStore buildKeyStore(KeyStoreSettings browserProxyCaKeyStore)
-      throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException,
+      throws KeyStoreException,
+          IOException,
+          NoSuchAlgorithmException,
+          CertificateException,
           CertificateGenerationUnsupportedException {
     final CertificateAuthority certificateAuthority =
         CertificateAuthority.generateCertificateAuthority();

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,16 @@ public class WarConfiguration implements Options {
   @Override
   public boolean getHttpDisabled() {
     return false;
+  }
+
+  @Override
+  public boolean getHttp2PlainEnabled() {
+    return true;
+  }
+
+  @Override
+  public boolean getHttp2TlsEnabled() {
+    return true;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -527,6 +527,16 @@ public class CommandLineOptions implements Options {
   @Override
   public boolean getHttpDisabled() {
     return optionSet.has(DISABLE_HTTP);
+  }
+
+  @Override
+  public boolean getHttp2PlainEnabled() {
+    return true;
+  }
+
+  @Override
+  public boolean getHttp2TlsEnabled() {
+    return true;
   }
 
   public void setActualHttpPort(int port) {

--- a/src/test/java/com/github/tomakehurst/wiremock/jetty11/Http2AcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/jetty11/Http2AcceptanceTest.java
@@ -47,6 +47,7 @@ public class Http2AcceptanceTest {
     wm.stubFor(get("/thing").willReturn(ok("HTTP/2 response")));
 
     ContentResponse response = client.GET(wm.getRuntimeInfo().getHttpsBaseUrl() + "/thing");
+    assertThat(response.getVersion(), is(HTTP_2));
     assertThat(response.getStatus(), is(200));
   }
 
@@ -56,7 +57,7 @@ public class Http2AcceptanceTest {
 
     wm.stubFor(get("/thing").willReturn(ok("HTTP/2 response")));
 
-    ContentResponse response = client.GET(wm.url("/thing"));
+    ContentResponse response = client.GET(wm.getRuntimeInfo().getHttpBaseUrl() + "/thing");
     assertThat(response.getVersion(), is(HTTP_2));
     assertThat(response.getStatus(), is(200));
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/jetty11/Http2DisabledAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/jetty11/Http2DisabledAcceptanceTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty11;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.Socket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class Http2DisabledAcceptanceTest {
+
+  @RegisterExtension
+  public WireMockExtension wm =
+      WireMockExtension.newInstance()
+          .options(
+              wireMockConfig()
+                  .dynamicPort()
+                  .dynamicHttpsPort()
+                  .http2PlainEnabled(false)
+                  .http2TlsEnabled(false))
+          .build();
+
+  HttpClient client;
+
+  @BeforeEach
+  void init() throws Exception {
+    client = HttpClient.newBuilder().sslContext(trustEverything()).build();
+  }
+
+  @Test
+  public void usesHttp1_1OverPlainText() throws Exception {
+    wm.stubFor(get("/thing").willReturn(ok("HTTP/2 response")));
+
+    URI uri = URI.create(wm.getRuntimeInfo().getHttpBaseUrl() + "/thing");
+
+    HttpResponse<String> response =
+        client.send(HttpRequest.newBuilder(uri).build(), HttpResponse.BodyHandlers.ofString());
+    assertThat(response.version(), is(HTTP_1_1));
+    assertThat(response.statusCode(), is(200));
+  }
+
+  @Test
+  void usesHttp1_1OverTls() throws Exception {
+    wm.stubFor(get("/thing").willReturn(ok("HTTP/2 response")));
+
+    URI uri = URI.create(wm.getRuntimeInfo().getHttpsBaseUrl() + "/thing");
+
+    HttpResponse<String> response =
+        client.send(HttpRequest.newBuilder(uri).build(), HttpResponse.BodyHandlers.ofString());
+    assertThat(response.version(), is(HTTP_1_1));
+    assertThat(response.statusCode(), is(200));
+  }
+
+  private SSLContext trustEverything() throws Exception {
+    X509ExtendedTrustManager trustManager =
+        new X509ExtendedTrustManager() {
+          @Override
+          public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[] {};
+          }
+
+          @Override
+          public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+          @Override
+          public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+
+          @Override
+          public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) {}
+
+          @Override
+          public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) {}
+
+          @Override
+          public void checkClientTrusted(
+              X509Certificate[] chain, String authType, SSLEngine engine) {}
+
+          @Override
+          public void checkServerTrusted(
+              X509Certificate[] chain, String authType, SSLEngine engine) {}
+        };
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(null, new TrustManager[] {trustManager}, new SecureRandom());
+
+    return sslContext;
+  }
+}

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2AcceptanceTest.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2AcceptanceTest.java
@@ -61,7 +61,7 @@ public class Http2AcceptanceTest {
 
     wm.stubFor(get("/thing").willReturn(ok("HTTP/2 response")));
 
-    ContentResponse response = client.GET(wm.url("/thing"));
+    ContentResponse response = client.GET(wm.getRuntimeInfo().getHttpBaseUrl() + "/thing");
     assertThat(response.getVersion(), is(HTTP_2));
     assertThat(response.getStatus(), is(200));
   }

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2DisabledAcceptanceTest.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2DisabledAcceptanceTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.Socket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class Http2DisabledAcceptanceTest {
+
+  @RegisterExtension
+  public WireMockExtension wm =
+      WireMockExtension.newInstance()
+          .options(
+              wireMockConfig()
+                  .dynamicPort()
+                  .dynamicHttpsPort()
+                  .http2PlainEnabled(false)
+                  .http2TlsEnabled(false)
+                  .httpServerFactory(new Jetty12HttpServerFactory()))
+          .build();
+
+  HttpClient client;
+
+  @BeforeEach
+  void init() throws Exception {
+    client = HttpClient.newBuilder().sslContext(trustEverything()).build();
+  }
+
+  @Test
+  public void usesHttp1_1OverPlainText() throws Exception {
+    wm.stubFor(get("/thing").willReturn(ok("HTTP/2 response")));
+
+    URI uri = URI.create(wm.getRuntimeInfo().getHttpBaseUrl() + "/thing");
+
+    HttpResponse<String> response =
+        client.send(HttpRequest.newBuilder(uri).build(), HttpResponse.BodyHandlers.ofString());
+    assertThat(response.version(), is(HTTP_1_1));
+    assertThat(response.statusCode(), is(200));
+  }
+
+  @Test
+  void usesHttp1_1OverTls() throws Exception {
+    wm.stubFor(get("/thing").willReturn(ok("HTTP/2 response")));
+
+    URI uri = URI.create(wm.getRuntimeInfo().getHttpsBaseUrl() + "/thing");
+
+    HttpResponse<String> response =
+        client.send(HttpRequest.newBuilder(uri).build(), HttpResponse.BodyHandlers.ofString());
+    assertThat(response.version(), is(HTTP_1_1));
+    assertThat(response.statusCode(), is(200));
+  }
+
+  private SSLContext trustEverything() throws Exception {
+    X509ExtendedTrustManager trustManager =
+        new X509ExtendedTrustManager() {
+          @Override
+          public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[] {};
+          }
+
+          @Override
+          public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+          @Override
+          public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+
+          @Override
+          public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) {}
+
+          @Override
+          public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) {}
+
+          @Override
+          public void checkClientTrusted(
+              X509Certificate[] chain, String authType, SSLEngine engine) {}
+
+          @Override
+          public void checkServerTrusted(
+              X509Certificate[] chain, String authType, SSLEngine engine) {}
+        };
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(null, new TrustManager[] {trustManager}, new SecureRandom());
+
+    return sslContext;
+  }
+}


### PR DESCRIPTION
Support enabling/disabling of HTTP/2 separate on plain text and TLS.

It remains enabled by default for both.