### PR TITLE
feat: provide summary of HttpHeaders to be used in assertions (refs #2654)

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.http;
 
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.joining;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -132,5 +133,22 @@ public class HttpHeaders {
 
   private CaseInsensitiveKey caseInsensitive(String key) {
     return new CaseInsensitiveKey(key);
+  }
+
+  public String summary() {
+    Map<String, List<String>> sortedHeaders = new TreeMap<>();
+    this.headers
+        .entries()
+        .forEach(
+            e -> {
+              String key = e.getKey().value();
+              if (!sortedHeaders.containsKey(key)) {
+                sortedHeaders.put(key, new ArrayList<>());
+              }
+              sortedHeaders.get(key).add(e.getValue());
+            });
+    return sortedHeaders.entrySet().stream()
+        .map(e -> e.getKey() + ": [" + e.getValue().stream().sorted().collect(joining(", ")) + "]")
+        .collect(joining("\n"));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeadersTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Thomas Akehurst
+ * Copyright (C) 2012-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 import com.github.tomakehurst.wiremock.common.Json;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class HttpHeadersTest {
@@ -31,6 +32,8 @@ public class HttpHeadersTest {
     HttpHeader header = httpHeaders.getHeader("Test-Header");
 
     assertThat(header.isPresent(), is(false));
+
+    Assertions.assertThat(httpHeaders.summary()).isEqualTo("");
   }
 
   @Test
@@ -41,6 +44,8 @@ public class HttpHeadersTest {
     assertThat(header.isPresent(), is(true));
     assertThat(header.key(), is("Test-Header"));
     assertThat(header.containsValue("value2"), is(true));
+
+    Assertions.assertThat(httpHeaders.summary()).isEqualTo("Test-Header: [value1, value2]");
   }
 
   @SuppressWarnings("unchecked")
@@ -112,6 +117,9 @@ public class HttpHeadersTest {
     assertThat(header.values().size(), is(2));
 
     assertThat(headers.size(), is(2));
+
+    Assertions.assertThat(headers.summary())
+        .isEqualTo("Header-1: [value-1, value-2]\n" + "Header-2: [value-3, value-4]");
   }
 
   @Test
@@ -123,6 +131,9 @@ public class HttpHeadersTest {
 
     String json = Json.write(headers);
     assertThat("Actual: " + json, json, equalToJson(MULTI_VALUE_HEADER));
+
+    Assertions.assertThat(headers.summary())
+        .isEqualTo("Header-1: [value-1, value-2]\n" + "Header-2: [value-3, value-4]");
   }
 
   @Test


### PR DESCRIPTION
I want a compact summary of the headers that I can use in assertions.

I see there is a test case that serializes to JSON and asserts on that. I think that is a bit too verbose and not as readable as this alternative.

See motivation in the similar PR: #2658

## References

- #2654
- #2658

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
