### PR TITLE
feat: provide summary of Cookies, Query and Form to be used in assertions (refs #2654)

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapper.java
@@ -178,7 +178,7 @@ public class RequestWrapper implements Request {
   }
 
   @Override
-  public Map<String, Cookie> getCookies() {
+  public MultiValues<Cookie> getCookies() {
     Map<String, Cookie> cookieMap = new HashMap<>();
     for (Map.Entry<String, Cookie> entry : delegate.getCookies().entrySet()) {
       Cookie newCookie =
@@ -193,7 +193,7 @@ public class RequestWrapper implements Request {
 
     cookieMap.putAll(additionalCookies);
 
-    return Collections.unmodifiableMap(cookieMap);
+    return new MultiValues<>(cookieMap);
   }
 
   @Override
@@ -207,7 +207,7 @@ public class RequestWrapper implements Request {
   }
 
   @Override
-  public Map<String, FormParameter> formParameters() {
+  public MultiValues<FormParameter> formParameters() {
     return delegate.formParameters();
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,12 +148,12 @@ public class ImmutableRequest implements Request {
   }
 
   @Override
-  public Map<String, FormParameter> formParameters() {
-    return Collections.emptyMap();
+  public MultiValues<FormParameter> formParameters() {
+    return new MultiValues<FormParameter>();
   }
 
   @Override
-  public Map<String, Cookie> getCookies() {
+  public MultiValues<Cookie> getCookies() {
     return null;
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/MultiValues.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/MultiValues.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http;
+
+import static java.util.stream.Collectors.joining;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+public class MultiValues<T extends MultiValue> implements Map<String, T> {
+
+  private Map<String, T> map = new HashMap<>();
+
+  public MultiValues() {}
+
+  public MultiValues(Map<String, T> items) {
+    if (items == null) this.map = Collections.unmodifiableMap(new HashMap<>());
+    else this.map = Collections.unmodifiableMap(items);
+  }
+
+  @Override
+  public int size() {
+    return map.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return map.isEmpty();
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return map.containsKey(key);
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return map.containsValue(value);
+  }
+
+  @Override
+  public T get(Object key) {
+    return map.get(key);
+  }
+
+  @Override
+  public T put(String key, T value) {
+    return map.put(key, value);
+  }
+
+  @Override
+  public void clear() {
+    map.clear();
+  }
+
+  @Override
+  public Set<String> keySet() {
+    return map.keySet();
+  }
+
+  @Override
+  public Collection<T> values() {
+    return map.values();
+  }
+
+  @Override
+  public T remove(Object key) {
+    return map.remove(key);
+  }
+
+  @Override
+  public void putAll(Map<? extends String, ? extends T> m) {
+    map.putAll(m);
+  }
+
+  @Override
+  public Set<Entry<String, T>> entrySet() {
+    return this.map.entrySet();
+  }
+
+  public Object getMap() {
+    return this.map;
+  }
+
+  /**
+   * Provides a sorted, deterministic, summary of the contents. Intended to be asserted on in test
+   * cases to provide a clear overview of the content.
+   */
+  public String summary() {
+    Map<String, List<String>> sorted = new TreeMap<>();
+    this.map
+        .entrySet()
+        .forEach(
+            e -> {
+              String key = e.getKey();
+              if (!sorted.containsKey(key)) {
+                sorted.put(key, new ArrayList<>());
+              }
+              for (String value : e.getValue().getValues()) {
+                sorted.get(key).add(value);
+              }
+            });
+    return sorted.entrySet().stream()
+        .map(e -> e.getKey() + ": [" + e.getValue().stream().sorted().collect(joining(", ")) + "]")
+        .collect(joining("\n"));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(map);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+    MultiValues<?> other = (MultiValues<?>) obj;
+    return Objects.equals(map, other.map);
+  }
+
+  @Override
+  public String toString() {
+    return "MultiValues [map=" + map + "]";
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.github.tomakehurst.wiremock.http;
 
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -62,9 +61,9 @@ public interface Request {
 
   FormParameter formParameter(String key);
 
-  Map<String, FormParameter> formParameters();
+  MultiValues<FormParameter> formParameters();
 
-  Map<String, Cookie> getCookies();
+  MultiValues<Cookie> getCookies();
 
   byte[] getBody();
 

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -234,7 +234,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
   }
 
   @Override
-  public Map<String, Cookie> getCookies() {
+  public MultiValues<Cookie> getCookies() {
     ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
 
     jakarta.servlet.http.Cookie[] cookies =
@@ -243,8 +243,9 @@ public class WireMockHttpServletRequestAdapter implements Request {
       builder.put(cookie.getName(), cookie.getValue());
     }
 
-    return Maps.transformValues(
-        builder.build().asMap(), input -> new Cookie(null, List.copyOf(input)));
+    return new MultiValues<>(
+        Maps.transformValues(
+            builder.build().asMap(), input -> new Cookie(null, List.copyOf(input))));
   }
 
   @Override
@@ -259,8 +260,8 @@ public class WireMockHttpServletRequestAdapter implements Request {
   }
 
   @Override
-  public Map<String, FormParameter> formParameters() {
-    return cachedFormParameters;
+  public MultiValues<FormParameter> formParameters() {
+    return new MultiValues<FormParameter>(cachedFormParameters);
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -227,8 +227,8 @@ public class LoggedRequest implements Request {
   }
 
   @Override
-  public Map<String, Cookie> getCookies() {
-    return cookies;
+  public MultiValues<Cookie> getCookies() {
+    return new MultiValues<>(cookies);
   }
 
   @Override
@@ -265,18 +265,18 @@ public class LoggedRequest implements Request {
   }
 
   @Override
-  public Map<String, FormParameter> formParameters() {
-    return formParameters;
+  public MultiValues<FormParameter> formParameters() {
+    return new MultiValues<FormParameter>(formParameters);
   }
 
   @JsonProperty("formParams")
-  public Map<String, FormParameter> getFormParameters() {
-    return formParameters;
+  public MultiValues<FormParameter> getFormParameters() {
+    return new MultiValues<FormParameter>(formParameters);
   }
 
   @JsonProperty("queryParams")
-  public Map<String, QueryParameter> getQueryParams() {
-    return queryParams;
+  public MultiValues<QueryParameter> getQueryParams() {
+    return new MultiValues<QueryParameter>(queryParams);
   }
 
   public HttpHeaders getHeaders() {

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/diff/EmptyToStringRequestWrapper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/diff/EmptyToStringRequestWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Thomas Akehurst
+ * Copyright (C) 2018-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package com.github.tomakehurst.wiremock.verification.diff;
 
 import com.github.tomakehurst.wiremock.http.*;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -95,8 +94,8 @@ public class EmptyToStringRequestWrapper implements Request {
   }
 
   @Override
-  public Map<String, Cookie> getCookies() {
-    return target.getCookies();
+  public MultiValues<Cookie> getCookies() {
+    return new MultiValues<>(target.getCookies());
   }
 
   @Override
@@ -110,7 +109,7 @@ public class EmptyToStringRequestWrapper implements Request {
   }
 
   @Override
-  public Map<String, FormParameter> formParameters() {
+  public MultiValues<FormParameter> formParameters() {
     return target.formParameters();
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/MultiValuesMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultiValuesMatchingAcceptanceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2016-2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.common.ContentTypes.COOKIE;
+import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import java.util.Arrays;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MultiValuesMatchingAcceptanceTest extends AcceptanceTestBase {
+  private static final String EXPECTED = "param1: [value1, value2]\n" + "param2: [value1]";
+  private WireMockTestClient client;
+
+  @BeforeEach
+  public void init() {
+    WireMock.reset();
+    stubFor(get(WireMock.anyUrl()).willReturn(WireMock.ok()));
+    client = new WireMockTestClient(wireMockServer.port());
+  }
+
+  @Test
+  public void formRequests() {
+    client.post(
+        "/form",
+        new UrlEncodedFormEntity(
+            Arrays.asList(
+                new BasicNameValuePair("param1", "value1"),
+                new BasicNameValuePair("param1", "value2"),
+                new BasicNameValuePair("param2", "value1"))));
+
+    assertThat(findAll(anyRequestedFor(WireMock.anyUrl())).get(0).getFormParameters().summary())
+        .isEqualTo(EXPECTED);
+  }
+
+  @Test
+  public void cookies() {
+    client.get("/cookie", withHeader(COOKIE, "param1=value1; param1=value2; param2=value1"));
+
+    assertThat(findAll(anyRequestedFor(WireMock.anyUrl())).get(0).getCookies().summary())
+        .isEqualTo(EXPECTED);
+  }
+
+  @Test
+  public void queries() {
+    client.get("/queries?param1=value1&param1=value2&param2=value1");
+
+    assertThat(findAll(anyRequestedFor(WireMock.anyUrl())).get(0).getQueryParams().summary())
+        .isEqualTo(EXPECTED);
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/http/MultiValuesTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/MultiValuesTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.github.tomakehurst.wiremock.common.Json;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MultiValuesTest {
+
+  @Test
+  public void summary_0_cookies() {
+    MultiValues<Cookie> cookies = new MultiValues<>(new HashMap<>());
+
+    assertThat(cookies.summary()).isEqualTo("");
+  }
+
+  @Test
+  public void serialization() {
+    MultiValues<Cookie> originalCookies =
+        new MultiValues<>(
+            Map.of(
+                "cookie1",
+                new Cookie(
+                    Arrays.asList(
+                        "cookie1_value1",
+                        "cookie1_value2",
+                        "cookie1_value3",
+                        "cookie1_value4",
+                        "cookie1_value5"))));
+
+    String expectedJsonString =
+        "{\n"
+            + "  \"cookie1\" : [ \"cookie1_value1\", \"cookie1_value2\", \"cookie1_value3\", \"cookie1_value4\", \"cookie1_value5\" ]\n"
+            + "}";
+    assertThat(Json.write(originalCookies)).isEqualToIgnoringWhitespace(expectedJsonString);
+
+    assertThat(
+            Json.write(Json.read(expectedJsonString, new TypeReference<MultiValues<Cookie>>() {})))
+        .isEqualToIgnoringWhitespace(expectedJsonString);
+  }
+
+  @Test
+  public void summary_1_cookie_1_value() {
+    MultiValues<Cookie> cookies =
+        new MultiValues<>(Map.of("cookie1", new Cookie(Arrays.asList("cookie1_value1"))));
+
+    assertThat(cookies.summary()).isEqualTo("cookie1: [cookie1_value1]");
+  }
+
+  @Test
+  public void summary_1_cookie_5_value() {
+    MultiValues<Cookie> cookies =
+        new MultiValues<>(
+            Map.of(
+                "cookie1",
+                new Cookie(
+                    Arrays.asList(
+                        "cookie1_value1",
+                        "cookie1_value2",
+                        "cookie1_value3",
+                        "cookie1_value4",
+                        "cookie1_value5"))));
+
+    assertThat(cookies.summary())
+        .isEqualTo(
+            "cookie1: [cookie1_value1, cookie1_value2, cookie1_value3, cookie1_value4, cookie1_value5]");
+  }
+
+  @Test
+  public void summary_2_cookies_2_values() {
+    MultiValues<Cookie> cookies =
+        new MultiValues<>(
+            Map.of(
+                "cookie1",
+                new Cookie(Arrays.asList("cookie1_value1", "cookie1_value2")),
+                "cookie2",
+                new Cookie(Arrays.asList("cookie2_value1", "cookie2_value2"))));
+
+    assertThat(cookies.summary())
+        .isEqualTo(
+            "cookie1: [cookie1_value1, cookie1_value2]\n"
+                + "cookie2: [cookie2_value1, cookie2_value2]");
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
@@ -215,8 +215,8 @@ public class MockRequest implements Request {
   }
 
   @Override
-  public Map<String, Cookie> getCookies() {
-    return cookies;
+  public MultiValues<Cookie> getCookies() {
+    return new MultiValues<>(cookies);
   }
 
   @Override
@@ -231,8 +231,8 @@ public class MockRequest implements Request {
   }
 
   @Override
-  public Map<String, FormParameter> formParameters() {
-    return formParameters;
+  public MultiValues<FormParameter> formParameters() {
+    return new MultiValues<FormParameter>(formParameters);
   }
 
   @Override

--- a/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
+++ b/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
@@ -29,7 +29,7 @@ public class MockRequestBuilder {
   private RequestMethod method = GET;
   private String clientIp = "x.x.x.x";
   private List<HttpHeader> individualHeaders = new ArrayList<>();
-  private Map<String, Cookie> cookies = new HashMap<>();
+  private MultiValues<Cookie> cookies = new MultiValues<>();
   private List<QueryParameter> queryParameters = new ArrayList<>();
 
   private List<FormParameter> formParameters = new ArrayList<>();


### PR DESCRIPTION
I want to assert on cookies, query and form in a compact, consistent and readable way that simplifies my test cases and makes them easier to maintain. I want clear errors when those test cases fail.

With this change I can do my assertions i a compact, consistent and readable way:

```java
    assertThat(findAll(anyRequestedFor(anyUrl())).get(0).getFormParameters().summary())
        .isEqualTo("...");

    assertThat(findAll(anyRequestedFor(anyUrl())).get(0).getCookies().summary())
        .isEqualTo("...");

    assertThat(findAll(anyRequestedFor(anyUrl())).get(0).getQueryParams().summary())
        .isEqualTo("...");
```

When they fail, the asserted string is changed which will give a clear error with a diff of how the string looked before and how it looks now.

## References

- #2654
- #2655
- #2657

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
