### PR TITLE
Fix publications by excluding testFixturesApi components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,7 @@ allprojects {
     mavenCentral()
   }
 
-  version = '3.5.1'
+  version = '3.5.2-SNAPSHOT'
 
   compileJava {
     options.encoding = 'UTF-8'
@@ -361,6 +361,9 @@ publishing {
       }
     }
   }
+
+  components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) { skip() }
+  components.java.withVariantsFromConfiguration(configurations.testFixturesRuntimeElements) { skip() }
 
   getComponents().withType(AdhocComponentWithVariants).each { c ->
     c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements) {


### PR DESCRIPTION
Fix publications by excluding testFixturesApi components. Those cause an invalid POM file being generated:

```
[WARNING] The POM for org.wiremock:wiremock:jar:3.5.1 is invalid, transitive dependencies (if any) will not be available: 3 problems were encountered while building the effective model for org.wiremock:wiremock:3.5.1
```

Verified locally with `./gradlew localRelease`

## References

Closes https://github.com/wiremock/wiremock/issues/2660

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [X] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
