### PR TITLE
Move template benchmark into benchmarks

### DIFF
--- a/src/test/java/benchmarks/HandlebarsOptimizedTemplateBenchmark.java
+++ b/src/test/java/benchmarks/HandlebarsOptimizedTemplateBenchmark.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package benchmarks;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static com.github.tomakehurst.wiremock.stubbing.ServeEventFactory.newPostMatchServeEvent;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.matching.MockRequest;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import com.github.tomakehurst.wiremock.testsupport.ExtensionFactoryUtils;
+import org.openjdk.jmh.annotations.*;
+
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 2)
+@Fork(1)
+@Measurement(iterations = 5)
+public class HandlebarsOptimizedTemplateBenchmark {
+
+  @State(Scope.Benchmark)
+  public static class HandlebarsOptimizedTemplateBenchmarkState {
+    private ResponseTemplateTransformer transformer;
+
+    @Setup
+    public void setup() {
+      transformer = ExtensionFactoryUtils.buildTemplateTransformer(true);
+    }
+  }
+
+  @Benchmark
+  @Threads(50)
+  public boolean transform(HandlebarsOptimizedTemplateBenchmarkState state) {
+
+    String result =
+        transform(
+            "{{#each (range 100000 199999) as |index|}}Line {{index}}\n{{/each}}",
+            state.transformer);
+
+    boolean hasCorrectStart = result.startsWith("Line 100000\nLine 100001\nLine 100002\n");
+    boolean hasCorrectLength = result.length() == 1_200_000;
+    return hasCorrectStart && hasCorrectLength;
+  }
+
+  private String transform(String responseBodyTemplate, ResponseTemplateTransformer transformer) {
+    final ResponseDefinitionBuilder responseDefinitionBuilder =
+        aResponse().withBody(responseBodyTemplate);
+    final StubMapping stub = get("/").willReturn(responseDefinitionBuilder).build();
+    final MockRequest request = mockRequest();
+    ServeEvent serveEvent = newPostMatchServeEvent(request, responseDefinitionBuilder, stub);
+    return transformer.transform(serveEvent).getBody();
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,6 @@ import static com.github.tomakehurst.wiremock.stubbing.ServeEventFactory.newPost
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.lessThan;
 
 import com.github.jknack.handlebars.Helper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
@@ -36,8 +34,6 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEventFactory;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.ExtensionFactoryUtils;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import java.time.Duration;
-import java.time.Instant;
 import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAdjusters;
@@ -1032,18 +1028,6 @@ public class ResponseTemplateTransformerTest {
     String result = transform("{{date (parseDate '2021' format='yyyy') format='yyyy-MM'}}");
     String expected = YearMonth.of(2021, 1).toString();
     assertThat(result, is(expected));
-  }
-
-  @Test
-  public void canHandleALargeTemplateReasonablyFast() {
-    String template = "{{#each (range 100000 199999) as |index|}}Line {{index}}\n{{/each}}";
-    Instant start = Instant.now();
-    String result = transform(template);
-    Duration timeTaken = Duration.between(start, Instant.now());
-
-    assertThat(result.substring(0, 100), startsWith("Line 100000\nLine 100001\nLine 100002\n"));
-    assertThat(result.length(), equalTo(1_200_000));
-    assertThat(timeTaken, lessThan(Duration.ofSeconds(5)));
   }
 
   private Integer transformToInt(String responseBodyTemplate) {


### PR DESCRIPTION
It's a benchmark so it should be in benchmarks

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
