### PR TITLE
Make it easier to fix issue with file's path

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2023 Thomas Akehurst
+ * Copyright (C) 2012-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,7 +157,9 @@ public abstract class AbstractFileSource implements FileSource {
         throw new NotAuthorisedException(
             "Access to file "
                 + path
-                + " is not permitted. An absolute path from the filesystem root might be specified");
+                + " is not permitted. An absolute path from the filesystem root might be specified. "
+                + "Your file must be in "
+                + rootDirectory.getAbsolutePath());
       }
     } catch (IOException ioe) {
       throw new NotAuthorisedException("File " + path + " cannot be accessed", ioe);


### PR DESCRIPTION
Specify which directory the file must be within when rejecting it
because it is not in that directory.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
