### PR TITLE
Fix custom matcher skewing match result distances

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -252,7 +252,10 @@ public class RequestPattern implements NamedValueMatcher<Request> {
       MatchResult customMatchResult =
           requestMatcher.match(request, customMatcherDefinition.getParameters());
 
-      return MatchResult.aggregate(standardMatchResult, customMatchResult);
+      return new WeightedAggregateMatchResult(
+          List.of(
+              new WeightedMatchResult(standardMatchResult, 100.0),
+              new WeightedMatchResult(customMatchResult, 1.0)));
     }
 
     return standardMatchResult;


### PR DESCRIPTION
Fix for [matcher distance short-circuit biases](https://github.com/wiremock/wiremock/issues/2677) that causes a stub mapping's custom matcher a skew match result distances in unexpected ways.

## References

https://github.com/wiremock/wiremock/issues/2677

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
