### PR TITLE
Support sub events on partial matchers

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchResult.java
@@ -49,7 +49,15 @@ public abstract class MatchResult implements Comparable<MatchResult> {
 
   @JsonCreator
   public static MatchResult partialMatch(@JsonProperty("distance") double distance) {
-    return new EagerMatchResult(distance);
+    return partialMatch(distance, List.of());
+  }
+
+  public static MatchResult partialMatch(double distance, SubEvent... subEvents) {
+    return partialMatch(distance, List.of(subEvents));
+  }
+
+  public static MatchResult partialMatch(double distance, List<SubEvent> subEvents) {
+    return new EagerMatchResult(distance, subEvents);
   }
 
   public static MatchResult exactMatch(SubEvent... subEvents) {


### PR DESCRIPTION
Currently partial matches cannot have sub events. This allows them to.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
