### PR TITLE
removeEventsMatching supports custom matchers

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -583,4 +583,9 @@ public class RequestPattern implements NamedValueMatcher<Request> {
   public static Predicate<ServeEvent> withRequestMatching(final RequestPattern pattern) {
     return serveEvent -> pattern.match(serveEvent.getRequest()).isExactMatch();
   }
+
+  public static Predicate<ServeEvent> withRequestMatching(
+      final RequestPattern pattern, final Map<String, RequestMatcherExtension> customMatchers) {
+    return serveEvent -> pattern.match(serveEvent.getRequest(), customMatchers).isExactMatch();
+  }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/AbstractRequestJournal.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/AbstractRequestJournal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ public abstract class AbstractRequestJournal implements RequestJournal {
 
   @Override
   public List<ServeEvent> removeEventsMatching(RequestPattern requestPattern) {
-    return removeServeEvents(withRequestMatching(requestPattern));
+    return removeServeEvents(withRequestMatching(requestPattern, customMatchers));
   }
 
   @Override


### PR DESCRIPTION
I can't think of any reason why this wouldn't?

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
