### PR TITLE
Near miss takes custom matchers into account

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -127,7 +127,8 @@ public class WireMockApp implements StubServer, Admin {
             extensions.ofType(ResponseDefinitionTransformerV2.class),
             stores.getFilesBlobStore(),
             List.copyOf(extensions.ofType(StubLifecycleListener.class).values()));
-    nearMissCalculator = new NearMissCalculator(stubMappings, requestJournal, scenarios);
+    nearMissCalculator =
+        new NearMissCalculator(stubMappings, requestJournal, scenarios, customMatchers);
     recorder =
         new Recorder(this, extensions, stores.getFilesBlobStore(), stores.getRecorderStateStore());
     globalSettingsListeners = List.copyOf(extensions.ofType(GlobalSettingsListener.class).values());
@@ -173,7 +174,8 @@ public class WireMockApp implements StubServer, Admin {
             stores.getFilesBlobStore(),
             Collections.emptyList());
     this.container = container;
-    nearMissCalculator = new NearMissCalculator(stubMappings, requestJournal, scenarios);
+    nearMissCalculator =
+        new NearMissCalculator(stubMappings, requestJournal, scenarios, requestMatchers);
     recorder =
         new Recorder(this, extensions, stores.getFilesBlobStore(), stores.getRecorderStateStore());
     globalSettingsListeners = Collections.emptyList();


### PR DESCRIPTION
Currently the near miss calculator does not apply custom matchers; instead it assumes they did not match and applies a distance of 1.

This means that just having a custom matcher immediately distorts the distance dramatically, even if it matches, but also if it is a partial match (distance < 1).

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
