### PR TITLE
Allow commons-fileupload to load commons-io as a transitive dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,9 +96,7 @@ dependencies {
     exclude group: 'org.apache.commons', module: 'commons-lang3'
   }
 
-  api 'commons-fileupload:commons-fileupload:1.5',  {
-    exclude group: 'commons-io', module: 'commons-io'
-  }
+  api 'commons-fileupload:commons-fileupload:1.5'
 
   api 'com.networknt:json-schema-validator:1.4.0'
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR is a fix for #2688 where `commons-fileupload` was not loading `commons-io` as a transitive dependency.  Now we have removed our dependency on `commons-io` we can now allow `commons-fileupload` to pull it in as a transitive dependency

## References
https://github.com/wiremock/wiremock/issues/2688

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
