### PR TITLE
fix: handlebars math helper handles large negative integers

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/MathsHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/MathsHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,11 +88,12 @@ public class MathsHelper extends HandlebarsHelper<Object> {
     }
 
     if (value.scale() == 0) {
-      if (value.longValue() <= Integer.MAX_VALUE) {
+      long longValue = value.longValue();
+      if (longValue <= Integer.MAX_VALUE && longValue >= Integer.MIN_VALUE) {
         return value.intValue();
       }
 
-      return value.longValue();
+      return longValue;
     }
 
     return value.doubleValue();

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/MathsHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/MathsHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,5 +109,10 @@ public class MathsHelperTest extends HandlebarsHelperTestBase {
     assertThat(
         renderHelperValue(helper, new RenderableDate(date, "epoch", null), "+", 0),
         is(1663258226792L));
+  }
+
+  @Test
+  void handlesLargeNegativeIntegerResults() throws Exception {
+    assertThat(renderHelperValue(helper, Long.MIN_VALUE, "+", 1), is(Long.MIN_VALUE + 1));
   }
 }


### PR DESCRIPTION
Currently, when the result of the handlebars math helper is a negative number less than `java.lang.Integer.MIN_VALUE`, it's incorrectly coerced into a `java.lang.Integer`. This PR fixes that.

## References

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)