### PR TITLE
Content-Type Header for Multipart-Requests should be checked case-insensitive

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -289,7 +289,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
   @Override
   public boolean isMultipart() {
     String header = getHeader("Content-Type");
-    return (header != null && header.contains("multipart/"));
+    return (header != null && header.matches("(?i)^multipart/.*"));
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -289,7 +289,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
   @Override
   public boolean isMultipart() {
     String header = getHeader("Content-Type");
-    return (header != null && header.matches("(?i)^multipart/.*"));
+    return (header != null && header.matches("(?i)^\\s*multipart/.*"));
   }
 
   @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
@@ -181,13 +181,10 @@ public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
   void acceptsAMultipartRequestWithCamelcasedContentTypeInformation() throws Exception {
     stubFor(
         post("/multipart-camelcased-content-type")
-            .withMultipartRequestBody(aMultipart()
-                .withName("field1")
-                .withHeader("Content-Type", equalTo("text/plain"))
-                .withBody(containing("hello")))
-            .withMultipartRequestBody(aMultipart()
-                .withName("field2")
-                .withBody(containing("world")))
+            .withMultipartRequestBody(
+                aMultipart().withName("field1").withBody(containing("hello")))
+            .withMultipartRequestBody(
+                aMultipart().withName("field2").withBody(containing("world")))
             .willReturn(ok()));
 
     final URL url = new URL(wireMockServer.baseUrl() + "/multipart-camelcased-content-type");
@@ -203,7 +200,6 @@ public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
     try (final OutputStream contentStream = connection.getOutputStream()) {
       contentStream.write(("--" + boundary + "\r\n" +
           "Content-Disposition: form-data; name=\"field1\"\r\n" +
-          "Content-Type: text/plain\r\n" +
           "\r\n" +
           "hello\r\n" +
           "--" + boundary + "\r\n" +

--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
@@ -26,6 +26,10 @@ import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.http.HttpClientFactory;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.UUID;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.ClassicHttpRequest;
@@ -36,11 +40,6 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.UUID;
 
 public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
 
@@ -181,10 +180,8 @@ public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
   void acceptsAMultipartRequestWithCamelcasedContentTypeInformation() throws Exception {
     stubFor(
         post("/multipart-camelcased-content-type")
-            .withMultipartRequestBody(
-                aMultipart().withName("field1").withBody(containing("hello")))
-            .withMultipartRequestBody(
-                aMultipart().withName("field2").withBody(containing("world")))
+            .withMultipartRequestBody(aMultipart().withName("field1").withBody(containing("hello")))
+            .withMultipartRequestBody(aMultipart().withName("field2").withBody(containing("world")))
             .willReturn(ok()));
 
     final URL url = new URL(wireMockServer.baseUrl() + "/multipart-camelcased-content-type");
@@ -193,14 +190,16 @@ public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
 
     // Test without leading Spaces
     HttpURLConnection connection = prepareUrlConnectionForCamelcasedContentTypeInformation(url);
-    connection.setRequestProperty("Content-Type", "Multipart/Form-Data; boundary=\"" + boundary + "\"");
+    connection.setRequestProperty(
+        "Content-Type", "Multipart/Form-Data; boundary=\"" + boundary + "\"");
     try (final OutputStream contentStream = connection.getOutputStream()) {
       contentStream.write(getRequestBodyForCamelasedContentTypeInformationWithBoundary(boundary));
     }
     assertThat(connection.getResponseCode(), is(200));
   }
 
-  private HttpURLConnection prepareUrlConnectionForCamelcasedContentTypeInformation(URL url) throws Exception {
+  private HttpURLConnection prepareUrlConnectionForCamelcasedContentTypeInformation(URL url)
+      throws Exception {
     final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
     connection.setDoInput(true);
     connection.setDoOutput(true);
@@ -211,25 +210,31 @@ public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
   }
 
   private byte[] getRequestBodyForCamelasedContentTypeInformationWithBoundary(String boundary) {
-    return ("--" + boundary + "\r\n" +
-        "Content-Disposition: form-data; name=\"field1\"\r\n" +
-        "\r\n" +
-        "hello\r\n" +
-        "--" + boundary + "\r\n" +
-        "Content-Disposition: form-data; name=\"field2\"\r\n" +
-        "\r\n" +
-        "world\r\n" +
-        "--" + boundary + "--").getBytes();
+    return ("--"
+            + boundary
+            + "\r\n"
+            + "Content-Disposition: form-data; name=\"field1\"\r\n"
+            + "\r\n"
+            + "hello\r\n"
+            + "--"
+            + boundary
+            + "\r\n"
+            + "Content-Disposition: form-data; name=\"field2\"\r\n"
+            + "\r\n"
+            + "world\r\n"
+            + "--"
+            + boundary
+            + "--")
+        .getBytes();
   }
 
   @Test
-  void acceptsAMultipartRequestWithCamelcasedContentTypeInformationPrefixedWithSpaces() throws Exception {
+  void acceptsAMultipartRequestWithCamelcasedContentTypeInformationPrefixedWithSpaces()
+      throws Exception {
     stubFor(
         post("/multipart-camelcased-content-type")
-            .withMultipartRequestBody(
-                aMultipart().withName("field1").withBody(containing("hello")))
-            .withMultipartRequestBody(
-                aMultipart().withName("field2").withBody(containing("world")))
+            .withMultipartRequestBody(aMultipart().withName("field1").withBody(containing("hello")))
+            .withMultipartRequestBody(aMultipart().withName("field2").withBody(containing("world")))
             .willReturn(ok()));
 
     final URL url = new URL(wireMockServer.baseUrl() + "/multipart-camelcased-content-type");
@@ -238,7 +243,8 @@ public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
 
     // Test without leading Spaces
     HttpURLConnection connection = prepareUrlConnectionForCamelcasedContentTypeInformation(url);
-    connection.setRequestProperty("Content-Type", "    Multipart/Form-Data; boundary=\"" + boundary + "\"");
+    connection.setRequestProperty(
+        "Content-Type", "    Multipart/Form-Data; boundary=\"" + boundary + "\"");
     try (final OutputStream contentStream = connection.getOutputStream()) {
       contentStream.write(getRequestBodyForCamelasedContentTypeInformationWithBoundary(boundary));
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
@@ -196,7 +196,7 @@ public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
     connection.setRequestProperty("Accept", "*/*");
 
     final String boundary = "uuid:" + UUID.randomUUID();
-    connection.setRequestProperty("Content-Type", "Multipart/Form-Data; boundary=\"" + boundary + "\"");
+    connection.setRequestProperty("Content-Type", "   Multipart/Form-Data; boundary=\"" + boundary + "\"");
     try (final OutputStream contentStream = connection.getOutputStream()) {
       contentStream.write(("--" + boundary + "\r\n" +
           "Content-Disposition: form-data; name=\"field1\"\r\n" +


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

When testing SOAP-Requests with MTOM enabled the Standard SAAJ Implementation sends a HTTP-Header `Content-Type: Multipart/Related; boundary=...`. This leads to a Failure on Wiremock Multipart Behaviour because it only has checked against lowercased `multipart/`.

Instead it checks against a case-insensitive Regular-Expression `^multipart/.*`.

Can this be also merged to the Java-8 related Versions?

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
