### PR TITLE
WireMockStaticRule Deprecated(forRemoval = true)

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/archunit/JUnit4DetectionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/archunit/JUnit4DetectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Thomas Akehurst
+ * Copyright (C) 2021-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,8 +48,10 @@ import org.junit.runner.RunWith;
 @AnalyzeClasses(
     packagesOf = WireMockServer.class,
     importOptions = {ImportOption.DoNotIncludeArchives.class, ImportOption.DoNotIncludeJars.class})
+@SuppressWarnings({"removal"})
 class JUnit4DetectionTest {
 
+  @SuppressWarnings({"removal"})
   private static final List<Class<?>> excluded =
       Stream.of(
               WireMockClassRule.class,

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockStaticRule.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockStaticRule.java
@@ -26,7 +26,7 @@ import org.junit.runners.model.Statement;
  * @deprecated JUnit disallows this approach from version 4.11. Use {@link WireMockClassRule}
  *     instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class WireMockStaticRule implements MethodRule {
 
   private final WireMockServer wireMockServer;


### PR DESCRIPTION
Delete WireMockStaticRule