### PR TITLE
Additional tests for new helpers and Store implementations

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ArrayAddHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ArrayAddHelper.java
@@ -46,6 +46,10 @@ public class ArrayAddHelper extends AbstractArrayHelper {
     }
 
     if (position != null) {
+      if (position < 0 || position > mutableList.size()) {
+        return handleError(
+            "position must be greater than or equal to 0 and less than or equal to the size of the list");
+      }
       mutableList.add(position, newValue);
     } else {
       mutableList.add(newValue);

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ArrayRemoveHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ArrayRemoveHelper.java
@@ -35,6 +35,10 @@ public class ArrayRemoveHelper extends AbstractArrayHelper {
 
     final Integer positionToRemove = getFirstNonNull(position, list.size() - 1);
     final ArrayList<Object> mutableList = new ArrayList<>(list);
+    if (position != null && (position < 0 || position > mutableList.size())) {
+      return handleError(
+          "position must be greater than or equal to 0 and less than or equal to the size of the list");
+    }
     mutableList.remove((int) positionToRemove);
 
     return mutableList;

--- a/src/test/java/com/github/tomakehurst/wiremock/CustomMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CustomMatchingAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 Thomas Akehurst
+ * Copyright (C) 2015-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,7 +116,9 @@ public class CustomMatchingAcceptanceTest {
   public void customMatcherDefinitionCanBeCombinedWithStandardMatchers() {
     wm.register(
         get(urlPathMatching("/the/.*/one"))
-            .andMatching(new CustomMatcherDefinition("path-contains-param", Parameters.one("path", "correct")))
+            .andMatching(
+                new CustomMatcherDefinition(
+                    "path-contains-param", Parameters.one("path", "correct")))
             .willReturn(ok()));
 
     assertThat(client.get("/the/correct/one").statusCode(), is(200));

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -1110,9 +1110,32 @@ public class ResponseTemplateTransformerTest {
   }
 
   @Test
-  void valHelperDefaultsNullValue() {
+  void valHelperReturnsDefaultsNullValue() {
     assertThat(transform("{{val request.query.nonexist or='123'}}"), is("123"));
+    assertThat(transform("{{val request.query.nonexist default='123'}}"), is("123"));
+  }
+
+  @Test
+  void valHelperReturnsValueIfNotNullValue() {
     assertThat(transform("{{val 'exists' or='123'}}"), is("exists"));
+    assertThat(transform("{{val 'exists' default='123'}}"), is("exists"));
+    assertThat(transform("{{val (array 1 2 3) default='123'}}"), is("[1, 2, 3]"));
+  }
+
+  @Test
+  void valHelperCanAssignValueToNamedVariable() {
+    assertThat(
+        transform("{{val 'value for myVar' assign='myVar'}}{{myVar}}"), is("value for myVar"));
+    assertThat(transform("{{val 12 assign='myVar'}}{{myVar}}"), is("12"));
+    assertThat(transform("{{val (array 1 2 3) assign='myVar'}}{{myVar}}"), is("[1, 2, 3]"));
+    assertThat(transform("{{val (array 1 2 3) assign='myVar'}}{{join '*' myVar}}"), is("1*2*3"));
+  }
+
+  @Test
+  void valHelperCanAssignValueToNamedVariableAndMaintainsType() {
+    assertThat(
+        transform("{{val 10 assign='myVar'}}{{#lt myVar 20}}Less Than{{else}}More Than{{/lt}}"),
+        is("Less Than"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -863,13 +863,82 @@ public class ResponseTemplateTransformerTest {
   }
 
   @Test
-  void addsArrayItem() {
+  void addsArrayItemWthSpecifiedIntegerPosition() {
     assertThat(transform("{{arrayAdd (array 1 'three') 2 position=1}}"), is("[1, 2, three]"));
   }
 
   @Test
-  void deletesArrayItem() {
+  void addsArrayItemWthSpecifiedStartPosition() {
+    assertThat(transform("{{arrayAdd (array 1 'three') 2 position='start'}}"), is("[2, 1, three]"));
+  }
+
+  @Test
+  void addsArrayItemWthSpecifiedEndPosition() {
+    assertThat(transform("{{arrayAdd (array 1 'three') 2 position='end'}}"), is("[1, three, 2]"));
+  }
+
+  @Test
+  void addsArrayItemWithNoPositionAddsToEnd() {
+    assertThat(transform("{{arrayAdd (array 1 'three') 2}}"), is("[1, three, 2]"));
+  }
+
+  @Test
+  void addsArrayItemWithNegativePositionThrowsAnError() {
+    assertThat(
+        transform("{{arrayAdd (array 1 'three') 2 position=-2}}"),
+        is(
+            "[ERROR: position must be greater than or equal to 0 and less than or equal to the size of the list]"));
+  }
+
+  @Test
+  void addsArrayItemWithPositionGreaterThanTheArrayLengthThrowsAnError() {
+    assertThat(
+        transform("{{arrayAdd (array 1 'three') 2 position=3}}"),
+        is(
+            "[ERROR: position must be greater than or equal to 0 and less than or equal to the size of the list]"));
+  }
+
+  @Test
+  void addsArrayItemWithMissingValueToAdd() {
+    assertThat(
+        transform("{{arrayAdd (array 1 'three') position=1}}"),
+        is("[ERROR: Missing required parameter: additional value to add to list]"));
+  }
+
+  @Test
+  void deletesArrayItemWthSpecifiedIntegerPosition() {
     assertThat(transform("{{arrayRemove (array 1 2 'three') position=1}}"), is("[1, three]"));
+  }
+
+  @Test
+  void deletesArrayItemWthSpecifiedStartPosition() {
+    assertThat(transform("{{arrayRemove (array 1 2 'three') position='start'}}"), is("[2, three]"));
+  }
+
+  @Test
+  void deletesArrayItemWthSpecifiedEndPosition() {
+    assertThat(transform("{{arrayRemove (array 1 2 'three') position='end'}}"), is("[1, 2]"));
+  }
+
+  @Test
+  void deletesArrayItemWithNoPositionRemovesFromEnd() {
+    assertThat(transform("{{arrayRemove (array 1 2 'three') }}"), is("[1, 2]"));
+  }
+
+  @Test
+  void deletesArrayItemWithNegativePositionThrowsAnError() {
+    assertThat(
+        transform("{{arrayRemove (array 1 'three') position=-2}}"),
+        is(
+            "[ERROR: position must be greater than or equal to 0 and less than or equal to the size of the list]"));
+  }
+
+  @Test
+  void deletesArrayItemWithPositionGreaterThanTheArrayLengthThrowsAnError() {
+    assertThat(
+        transform("{{arrayRemove (array 1 'three') position=3}}"),
+        is(
+            "[ERROR: position must be greater than or equal to 0 and less than or equal to the size of the list]"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -1126,6 +1126,12 @@ public class ResponseTemplateTransformerTest {
   void valHelperCanAssignValueToNamedVariable() {
     assertThat(
         transform("{{val 'value for myVar' assign='myVar'}}{{myVar}}"), is("value for myVar"));
+    assertThat(
+        transform("{{val null or='other value for myVar' assign='myVar'}}{{myVar}}"),
+        is("other value for myVar"));
+    assertThat(
+        transform("{{val null default='other value for myVar' assign='myVar'}}{{myVar}}"),
+        is("other value for myVar"));
     assertThat(transform("{{val 12 assign='myVar'}}{{myVar}}"), is("12"));
     assertThat(transform("{{val (array 1 2 3) assign='myVar'}}{{myVar}}"), is("[1, 2, 3]"));
     assertThat(transform("{{val (array 1 2 3) assign='myVar'}}{{join '*' myVar}}"), is("1*2*3"));

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -1117,6 +1117,8 @@ public class ResponseTemplateTransformerTest {
 
   @Test
   void valHelperReturnsValueIfNotNullValue() {
+    assertThat(transform("{{val 'exists'}}"), is("exists"));
+    assertThat(transform("{{val null}}"), is(""));
     assertThat(transform("{{val 'exists' or='123'}}"), is("exists"));
     assertThat(transform("{{val 'exists' default='123'}}"), is("exists"));
     assertThat(transform("{{val (array 1 2 3) default='123'}}"), is("[1, 2, 3]"));

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ValHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ValHelperTest.java
@@ -53,6 +53,9 @@ public class ValHelperTest extends HandlebarsHelperTestBase {
   void returnsTheValueWhenNotNullAndDefaultIsSpecified() throws Exception {
     assertThat(
         renderHelperValue(helper, "some value", Map.of("or", "other value")), is("some value"));
+    assertThat(
+        renderHelperValue(helper, "some value", Map.of("default", "other value")),
+        is("some value"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStoreTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStoreTest.java
@@ -70,7 +70,7 @@ public class InMemoryObjectStoreTest {
   }
 
   @Test
-  void sizeLimitRemainsConsistenWhenItemRemoved() {
+  void sizeLimitRemainsConsistentWhenItemRemoved() {
     InMemoryObjectStore store = new InMemoryObjectStore(3);
 
     store.put("one", "1");
@@ -86,4 +86,18 @@ public class InMemoryObjectStoreTest {
     assertThat(store.getAllKeys().count(), is(3L));
     assertThat(store.getAllKeys().collect(toList()), hasItems("three", "four", "five"));
   }
+  
+  @Test
+  void clearRemovesAllItems() {
+    InMemoryObjectStore store = new InMemoryObjectStore(3);
+
+    store.put("one", "1");
+    store.put("two", "2");
+    store.put("three", "3");
+
+    store.clear();
+
+    assertThat(store.getAllKeys().count(), is(0L));
+  }
+
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStoreTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStoreTest.java
@@ -86,7 +86,7 @@ public class InMemoryObjectStoreTest {
     assertThat(store.getAllKeys().count(), is(3L));
     assertThat(store.getAllKeys().collect(toList()), hasItems("three", "four", "five"));
   }
-  
+
   @Test
   void clearRemovesAllItems() {
     InMemoryObjectStore store = new InMemoryObjectStore(3);
@@ -99,5 +99,4 @@ public class InMemoryObjectStoreTest {
 
     assertThat(store.getAllKeys().count(), is(0L));
   }
-
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/store/files/FileSourceJsonObjectStoreTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/files/FileSourceJsonObjectStoreTest.java
@@ -137,4 +137,49 @@ public class FileSourceJsonObjectStoreTest {
 
     assertThat(store.get("count").get(), is(101));
   }
+  
+  @Test
+  void getAllKeysReturnsTheCorrectKeys() {
+    store.put("the_key", "Store this");
+    store.put("that_key", "Store that");
+
+    assertThat(store.getAllKeys().count(), is(2L));
+    assertThat(store.getAllKeys().anyMatch("the_key.json"::equals), is(true));
+    assertThat(store.getAllKeys().anyMatch("that_key.json"::equals), is(true));
+  }
+
+  @Test
+  void remove() {
+    store.put("the_key", "Store this");
+    store.put("that_key", "Store that");
+
+    assertThat(store.getAllKeys().count(), is(2L));
+    assertThat(store.getAllKeys().anyMatch("the_key.json"::equals), is(true));
+    assertThat(store.getAllKeys().anyMatch("that_key.json"::equals), is(true));
+    
+    store.remove("the_key");
+    
+    assertThat(store.getAllKeys().count(), is(1L));
+    assertThat(store.getAllKeys().anyMatch("the_key.json"::equals), is(false));
+    assertThat(store.getAllKeys().anyMatch("that_key.json"::equals), is(true));
+  }
+  
+  @Test
+  void clear() {
+    store.put("the_key", "Store this");
+    store.put("that_key", "Store that");
+
+    assertThat(store.getAllKeys().count(), is(2L));
+    assertThat(store.getAllKeys().anyMatch("the_key.json"::equals), is(true));
+    assertThat(store.getAllKeys().anyMatch("that_key.json"::equals), is(true));
+
+    store.clear();
+
+    assertThat(store.getAllKeys().count(), is(0L));
+  }
+
+  @Test
+  void getPath() {
+    assertThat(store.getPath(), is(storeDir.toFile().getAbsolutePath()));
+  }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/store/files/FileSourceJsonObjectStoreTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/files/FileSourceJsonObjectStoreTest.java
@@ -137,7 +137,7 @@ public class FileSourceJsonObjectStoreTest {
 
     assertThat(store.get("count").get(), is(101));
   }
-  
+
   @Test
   void getAllKeysReturnsTheCorrectKeys() {
     store.put("the_key", "Store this");
@@ -156,14 +156,14 @@ public class FileSourceJsonObjectStoreTest {
     assertThat(store.getAllKeys().count(), is(2L));
     assertThat(store.getAllKeys().anyMatch("the_key.json"::equals), is(true));
     assertThat(store.getAllKeys().anyMatch("that_key.json"::equals), is(true));
-    
+
     store.remove("the_key");
-    
+
     assertThat(store.getAllKeys().count(), is(1L));
     assertThat(store.getAllKeys().anyMatch("the_key.json"::equals), is(false));
     assertThat(store.getAllKeys().anyMatch("that_key.json"::equals), is(true));
   }
-  
+
   @Test
   void clear() {
     store.put("the_key", "Store this");


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR adds new tests for the new helpers going into the `3.6.0` release along with padding out the tests for the new Stores implemetations.

The only new bit of functionality going into this PR is for the new `arrayAdd` and `arrayRemove` helpers where we now check for out of bounds `position` parameters

Docs will be updated in a separate PR

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
