### PR TITLE
Add preserveUserAgentProxyHeader to keep User-Agent header

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -94,6 +94,8 @@ public interface Options {
 
   boolean shouldPreserveHostHeader();
 
+  boolean shouldPreserveUserAgentProxyHeader();
+
   String proxyHostHeader();
 
   HttpServerFactory httpServerFactory();

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -101,6 +101,7 @@ public class WireMockConfiguration implements Options {
   private List<CaseInsensitiveKey> matchingHeaders = emptyList();
 
   private boolean preserveHostHeader;
+  private boolean preserveUserAgentProxyHeader;
   private String proxyHostHeader;
   private HttpServerFactory httpServerFactory = new JettyHttpServerFactory();
   private HttpClientFactory httpClientFactory = new ApacheHttpClientFactory();
@@ -401,6 +402,11 @@ public class WireMockConfiguration implements Options {
 
   public WireMockConfiguration preserveHostHeader(boolean preserveHostHeader) {
     this.preserveHostHeader = preserveHostHeader;
+    return this;
+  }
+
+  public WireMockConfiguration preserveUserAgentProxyHeader(boolean preserveUserAgentProxyHeader) {
+    this.preserveUserAgentProxyHeader = preserveUserAgentProxyHeader;
     return this;
   }
 
@@ -709,6 +715,11 @@ public class WireMockConfiguration implements Options {
   @Override
   public boolean shouldPreserveHostHeader() {
     return preserveHostHeader;
+  }
+
+  @Override
+  public boolean shouldPreserveUserAgentProxyHeader() {
+    return preserveUserAgentProxyHeader;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheBackedHttpClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheBackedHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,18 +40,22 @@ import org.apache.hc.core5.http.message.BasicHeader;
 public class ApacheBackedHttpClient implements HttpClient {
 
   private final CloseableHttpClient apacheHttpClient;
+  private final boolean preserveUserAgentProxyHeader;
 
-  public ApacheBackedHttpClient(CloseableHttpClient apacheHttpClient) {
+  public ApacheBackedHttpClient(
+      CloseableHttpClient apacheHttpClient, boolean preserveUserAgentProxyHeader) {
     this.apacheHttpClient = apacheHttpClient;
+    this.preserveUserAgentProxyHeader = preserveUserAgentProxyHeader;
   }
 
   @Override
   public Response execute(Request request) throws IOException {
-    ClassicHttpRequest apacheRequest = createApacheRequest(request);
+    ClassicHttpRequest apacheRequest = createApacheRequest(request, preserveUserAgentProxyHeader);
     return apacheHttpClient.execute(apacheRequest, ApacheBackedHttpClient::toWireMockHttpResponse);
   }
 
-  private static ClassicHttpRequest createApacheRequest(Request request) {
+  private static ClassicHttpRequest createApacheRequest(
+      Request request, boolean preserveUserAgentProxyHeader) {
     ContentType contentType =
         request.contentTypeHeader().isPresent()
             ? ContentType.parse(request.contentTypeHeader().firstValue())
@@ -63,7 +67,10 @@ public class ApacheBackedHttpClient implements HttpClient {
             .setHeaders(
                 request.getHeaders().all().stream()
                     .filter(
-                        header -> !FORBIDDEN_REQUEST_HEADERS.contains(header.key().toLowerCase()))
+                        header ->
+                            !FORBIDDEN_REQUEST_HEADERS.contains(header.key().toLowerCase())
+                                || (preserveUserAgentProxyHeader
+                                    && header.key().equalsIgnoreCase(USER_AGENT)))
                     .flatMap(
                         header ->
                             header.values().stream()

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
@@ -39,6 +39,6 @@ public class ApacheHttpClientFactory implements HttpClientFactory {
             options.getProxyTargetRules(),
             true);
 
-    return new ApacheBackedHttpClient(apacheClient);
+    return new ApacheBackedHttpClient(apacheClient, options.shouldPreserveUserAgentProxyHeader());
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -157,6 +157,11 @@ public class WarConfiguration implements Options {
   }
 
   @Override
+  public boolean shouldPreserveUserAgentProxyHeader() {
+    return false;
+  }
+
+  @Override
   public String proxyHostHeader() {
     return null;
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -65,6 +65,7 @@ public class CommandLineOptions implements Options {
   private static final String MATCH_HEADERS = "match-headers";
   private static final String PROXY_ALL = "proxy-all";
   private static final String PRESERVE_HOST_HEADER = "preserve-host-header";
+  private static final String PRESERVE_USER_AGENT_PROXY_HEADER = "preserve-user-agent-proxy-header";
   private static final String PROXY_VIA = "proxy-via";
   private static final String TIMEOUT = "timeout";
   private static final String PORT = "port";
@@ -211,6 +212,9 @@ public class CommandLineOptions implements Options {
     optionParser.accepts(
         PRESERVE_HOST_HEADER,
         "Will transfer the original host header from the client to the proxied service");
+    optionParser.accepts(
+        PRESERVE_USER_AGENT_PROXY_HEADER,
+        "Will transfer the original User-Agent header from the client to the proxied service");
     optionParser
         .accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests")
         .withRequiredArg();
@@ -670,6 +674,11 @@ public class CommandLineOptions implements Options {
   }
 
   @Override
+  public boolean shouldPreserveUserAgentProxyHeader() {
+    return optionSet.has(PRESERVE_USER_AGENT_PROXY_HEADER);
+  }
+
+  @Override
   public String proxyHostHeader() {
     return optionSet.hasArgument(PROXY_ALL)
         ? URI.create((String) optionSet.valueOf(PROXY_ALL)).getAuthority()
@@ -812,6 +821,7 @@ public class CommandLineOptions implements Options {
     if (proxyUrl() != null) {
       map.put(PROXY_ALL, nullToString(proxyUrl()));
       map.put(PRESERVE_HOST_HEADER, shouldPreserveHostHeader());
+      map.put(PRESERVE_USER_AGENT_PROXY_HEADER, shouldPreserveUserAgentProxyHeader());
     }
 
     BrowserProxySettings browserProxySettings = browserProxySettings();

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
@@ -542,7 +542,7 @@ public class ProxyResponseRendererTest {
                 true,
                 NetworkAddressRules.ALLOW_ALL,
                 true));
-    HttpClient reverseProxyClient = new ApacheBackedHttpClient(reverseProxyApacheClient);
+    HttpClient reverseProxyClient = new ApacheBackedHttpClient(reverseProxyApacheClient, false);
 
     forwardProxyApacheClient =
         spy(
@@ -556,7 +556,7 @@ public class ProxyResponseRendererTest {
                 false,
                 NetworkAddressRules.ALLOW_ALL,
                 true));
-    HttpClient forwardProxyClient = new ApacheBackedHttpClient(forwardProxyApacheClient);
+    HttpClient forwardProxyClient = new ApacheBackedHttpClient(forwardProxyApacheClient, false);
 
     return new ProxyResponseRenderer(
         /* preserveHostHeader= */ false,

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -302,6 +302,18 @@ public class CommandLineOptionsTest {
   }
 
   @Test
+  public void returnPreserveUserAgentProxyHeaderTrueWhenPresent() {
+    CommandLineOptions options = new CommandLineOptions("--preserve-user-agent-proxy-header");
+    assertThat(options.shouldPreserveUserAgentProxyHeader(), is(true));
+  }
+
+  @Test
+  public void returnPreserveUserAgentProxyHeaderFalseWhenNotPresent() {
+    CommandLineOptions options = new CommandLineOptions("--port", "8080");
+    assertThat(options.shouldPreserveUserAgentProxyHeader(), is(false));
+  }
+
+  @Test
   public void returnsCorrectlyParsedNumberOfThreads() {
     CommandLineOptions options = new CommandLineOptions("--container-threads", "300");
     assertThat(options.containerThreads(), is(300));

--- a/src/test/java/ignored/Examples.java
+++ b/src/test/java/ignored/Examples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2023 Thomas Akehurst
+ * Copyright (C) 2012-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -472,6 +472,9 @@ public class Examples extends AcceptanceTestBase {
         // Override the Host header sent when reverse proxying to another system (this and the
         // previous parameter are mutually exclusive)
         .proxyHostHeader("my.otherdomain.com")
+
+        // Send the User-Agent header in the original request onwards to the system being proxied to
+        .preserveUserAgentProxyHeader(false)
 
         // When reverse proxying, also route via the specified forward proxy (useful inside
         // corporate firewalls)


### PR DESCRIPTION
On recent Wiremock versions the User-Agent is not preserved from the original request as in older versions. This PR adds the option to preserve it, it is based on the suggestion at this conversation: https://community.wiremock.io/t/16656487/hi-all-i-m-still-trying-to-find-a-way-to-keep-the-user-agent#c0f08603-a911-4754-a427-547c914ff259

## References

- [Issue reported and suggestion of PR](https://community.wiremock.io/t/16656487/hi-all-i-m-still-trying-to-find-a-way-to-keep-the-user-agent#c0f08603-a911-4754-a427-547c914ff259)

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
