### PR TITLE
Disabled DNS filtering when no custom proxy security rules are set

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/DefaultNetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/DefaultNetworkAddressRules.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL;
+import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL_RANGES;
 import static com.github.tomakehurst.wiremock.common.NetworkAddressUtils.isValidInet4Address;
 import static java.util.stream.Collectors.toSet;
 
@@ -37,7 +37,7 @@ public class DefaultNetworkAddressRules implements NetworkAddressRules {
                     networkAddressRange ->
                         !(networkAddressRange instanceof NetworkAddressRange.DomainNameWildcard))
                 .collect(toSet()),
-            Set.of(ALL));
+            ALL_RANGES);
     this.allowedHostPatterns =
         defaultIfEmpty(
             allowed.stream()
@@ -45,7 +45,7 @@ public class DefaultNetworkAddressRules implements NetworkAddressRules {
                     networkAddressRange ->
                         (networkAddressRange instanceof NetworkAddressRange.DomainNameWildcard))
                 .collect(toSet()),
-            Set.of(ALL));
+            ALL_RANGES);
     this.denied =
         denied.stream()
             .filter(
@@ -83,8 +83,8 @@ public class DefaultNetworkAddressRules implements NetworkAddressRules {
 
   @Override
   public boolean isAllowedAll() {
-    return allowed.equals(Set.of(ALL))
-        && allowedHostPatterns.equals(Set.of(ALL))
+    return allowed.equals(ALL_RANGES)
+        && allowedHostPatterns.equals(ALL_RANGES)
         && denied.isEmpty()
         && deniedHostPatterns.isEmpty();
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/DefaultNetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/DefaultNetworkAddressRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Thomas Akehurst
+ * Copyright (C) 2022-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,5 +79,13 @@ public class DefaultNetworkAddressRules implements NetworkAddressRules {
       return allowedHostPatterns.stream().anyMatch(rule -> rule.isIncluded(testValue))
           && deniedHostPatterns.stream().noneMatch(rule -> rule.isIncluded(testValue));
     }
+  }
+
+  @Override
+  public boolean isAllowedAll() {
+    return allowed.equals(Set.of(ALL))
+        && allowedHostPatterns.equals(Set.of(ALL))
+        && denied.equals(Set.of())
+        && deniedHostPatterns.equals(Set.of());
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/DefaultNetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/DefaultNetworkAddressRules.java
@@ -85,7 +85,7 @@ public class DefaultNetworkAddressRules implements NetworkAddressRules {
   public boolean isAllowedAll() {
     return allowed.equals(Set.of(ALL))
         && allowedHostPatterns.equals(Set.of(ALL))
-        && denied.equals(Set.of())
-        && deniedHostPatterns.equals(Set.of());
+        && denied.isEmpty()
+        && deniedHostPatterns.isEmpty();
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRange.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Thomas Akehurst
+ * Copyright (C) 2022-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,13 @@ import static com.github.tomakehurst.wiremock.common.NetworkAddressUtils.isValid
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public abstract class NetworkAddressRange {
 
   public static final NetworkAddressRange ALL = new All();
+  public static final Set<NetworkAddressRange> ALL_RANGES = Set.of(ALL);
 
   private static final Pattern SINGLE_IP =
       Pattern.compile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -15,14 +15,14 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL;
+import static com.github.tomakehurst.wiremock.common.NetworkAddressRange.ALL_RANGES;
 import static java.util.Collections.emptySet;
 
 import java.util.HashSet;
 import java.util.Set;
 
 public interface NetworkAddressRules {
-  NetworkAddressRules ALLOW_ALL = new DefaultNetworkAddressRules(Set.of(ALL), emptySet());
+  NetworkAddressRules ALLOW_ALL = new DefaultNetworkAddressRules(ALL_RANGES, emptySet());
 
   static Builder builder() {
     return new Builder();
@@ -49,7 +49,7 @@ public interface NetworkAddressRules {
     public NetworkAddressRules build() {
       Set<NetworkAddressRange> allowedRanges = allowed;
       if (allowedRanges.isEmpty()) {
-        allowedRanges = Set.of(ALL);
+        allowedRanges = ALL_RANGES;
       }
       return new DefaultNetworkAddressRules(Set.copyOf(allowedRanges), Set.copyOf(denied));
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/NetworkAddressRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ public interface NetworkAddressRules {
   }
 
   boolean isAllowed(String testValue);
+
+  boolean isAllowedAll();
 
   public static class Builder {
     private final Set<NetworkAddressRange> allowed = new HashSet<>();

--- a/src/main/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolver.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,8 +46,14 @@ public class NetworkAddressRulesAdheringDnsResolver implements DnsResolver {
       throw new ProhibitedNetworkAddressException();
     }
 
+    final InetAddress[] resolved = delegate.resolve(host);
+
+    if (networkAddressRules.isAllowedAll()) {
+      return resolved;
+    }
+
     final InetAddress[] resolvedIpv4 =
-        Arrays.stream(delegate.resolve(host))
+        Arrays.stream(resolved)
             .filter(inetAddress -> inetAddress instanceof Inet4Address)
             .toArray(InetAddress[]::new);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolverTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/NetworkAddressRulesAdheringDnsResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -254,6 +254,18 @@ public class NetworkAddressRulesAdheringDnsResolverTest {
         new NetworkAddressRulesAdheringDnsResolver(dns, rules);
 
     assertThat(resolver.resolve("1.example.com")).isEqualTo(dns.resolve("10.1.1.1"));
+  }
+
+  @Test
+  void resolveIpv4AndIpv6AddressesWithoutCustomRules() throws UnknownHostException {
+    register("1.example.com", "10.1.1.1", "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+
+    NetworkAddressRules rules = NetworkAddressRules.builder().build();
+
+    NetworkAddressRulesAdheringDnsResolver resolver =
+        new NetworkAddressRulesAdheringDnsResolver(dns, rules);
+
+    assertThat(resolver.resolve("1.example.com")).isEqualTo(dns.resolve("1.example.com"));
   }
 
   private void register(String host, String... ipAddresses) throws UnknownHostException {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

attempt to fix https://github.com/wiremock/wiremock/issues/2736

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)