### PR TITLE
Added null checks in getting server instance for issue 2718

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/admin/model/ServeEventQuery.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/model/ServeEventQuery.java
@@ -25,6 +25,7 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Predicate;
 
@@ -96,7 +97,8 @@ public class ServeEventQuery {
         stubMappingId != null
             ? serveEvent ->
                 serveEvent.getWasMatched()
-                    && serveEvent.getStubMapping().getId().equals(stubMappingId)
+                    && Objects.nonNull(serveEvent.getStubMapping().getId())
+                        && serveEvent.getStubMapping().getId().equals(stubMappingId)
             : serveEvent -> true;
 
     return events.stream().filter(matchPredicate).filter(stubPredicate).collect(toList());


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- Added null checks in getting server instance for issue 2718
- Added null check for `serveEvent.getStubMapping().getId()` as Id should not be null in comparing with `stubMappingId`


## References

#2718 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
