### PR TITLE
Add support for request matching with dynamic year and dynamic year/month values

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/DateTimeParser.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/DateTimeParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,6 +111,22 @@ public class DateTimeParser {
   public LocalDate parseLocalDate(String dateTimeString) {
     if (dateTimeFormatter != null) {
       return LocalDate.parse(dateTimeString, dateTimeFormatter);
+    }
+
+    return null;
+  }
+
+  public YearMonth parseYearMonth(String dateTimeString) {
+    if (dateTimeFormatter != null) {
+      return YearMonth.parse(dateTimeString, dateTimeFormatter);
+    }
+
+    return null;
+  }
+
+  public Year parseYear(String dateTimeString) {
+    if (dateTimeFormatter != null) {
+      return Year.parse(dateTimeString, dateTimeFormatter);
     }
 
     return null;

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractDateTimePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractDateTimePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,7 @@ import com.github.tomakehurst.wiremock.common.DateTimeOffset;
 import com.github.tomakehurst.wiremock.common.DateTimeParser;
 import com.github.tomakehurst.wiremock.common.DateTimeTruncation;
 import com.github.tomakehurst.wiremock.common.DateTimeUnit;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 
@@ -271,7 +269,21 @@ public abstract class AbstractDateTimePattern extends StringValuePattern {
                 : LocalDate.parse(dateTimeString))
             .atStartOfDay();
       } catch (DateTimeParseException ignored2) {
-        return null;
+        try {
+          return (parser != null
+                  ? parser.parseYearMonth(dateTimeString)
+                  : YearMonth.parse(dateTimeString))
+              .atDay(1)
+              .atStartOfDay();
+        } catch (DateTimeParseException ignored3) {
+          try {
+            return (parser != null ? parser.parseYear(dateTimeString) : Year.parse(dateTimeString))
+                .atDay(1)
+                .atStartOfDay();
+          } catch (DateTimeParseException ignored4) {
+            return null;
+          }
+        }
       }
     }
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeParserTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/DateTimeParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,7 @@ package com.github.tomakehurst.wiremock.common;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.Test;
 
@@ -58,6 +56,18 @@ public class DateTimeParserTest {
   public void parsesLocalDateFromFormatString() {
     DateTimeParser parser = DateTimeParser.forFormat("dd/MM/yyyy");
     assertThat(parser.parseLocalDate("23/06/2021"), is(LocalDate.parse("2021-06-23")));
+  }
+
+  @Test
+  public void parsesYearMonthFromFormatString() {
+    DateTimeParser parser = DateTimeParser.forFormat("MM/yyyy");
+    assertThat(parser.parseYearMonth("06/2021"), is(YearMonth.parse("2021-06")));
+  }
+
+  @Test
+  public void parsesYearFromFormatString() {
+    DateTimeParser parser = DateTimeParser.forFormat("yy");
+    assertThat(parser.parseYear("21"), is(Year.parse("2021")));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToDateTimePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToDateTimePatternTest.java
@@ -31,10 +31,8 @@ import com.github.tomakehurst.wiremock.common.DateTimeTruncation;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.http.MultiValue;
 import com.google.common.collect.Lists;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.Test;
 
 public class EqualToDateTimePatternTest {
@@ -80,6 +78,62 @@ public class EqualToDateTimePatternTest {
 
     String good = localExpected;
     String bad = LocalDateTime.parse(localExpected).minusSeconds(1).toString();
+
+    assertTrue(matcher.match(good).isExactMatch());
+    assertFalse(matcher.match(bad).isExactMatch());
+  }
+
+  @Test
+  public void matchesNowToYearMonth() {
+    YearMonth currentYearMonth = YearMonth.now();
+    YearMonth previousYearMonth = currentYearMonth.minusMonths(1);
+    StringValuePattern matcher =
+        WireMock.isNow().truncateExpected(DateTimeTruncation.FIRST_DAY_OF_MONTH);
+
+    String good = currentYearMonth.toString();
+    String bad = previousYearMonth.toString();
+
+    assertTrue(matcher.match(good).isExactMatch());
+    assertFalse(matcher.match(bad).isExactMatch());
+  }
+
+  @Test
+  public void matchesNowToYearMonthInCustomFormat() {
+    YearMonth currentYearMonth = YearMonth.now();
+    StringValuePattern matcher =
+        WireMock.isNow()
+            .truncateExpected(DateTimeTruncation.FIRST_DAY_OF_MONTH)
+            .actualFormat("MM/yyyy");
+
+    String good = currentYearMonth.format(DateTimeFormatter.ofPattern("MM/yyyy"));
+    String bad = currentYearMonth.toString();
+
+    assertTrue(matcher.match(good).isExactMatch());
+    assertFalse(matcher.match(bad).isExactMatch());
+  }
+
+  @Test
+  public void matchesNowToYear() {
+    Year currentYear = Year.now();
+    Year previousYear = currentYear.minusYears(1);
+    StringValuePattern matcher =
+        WireMock.isNow().truncateExpected(DateTimeTruncation.FIRST_DAY_OF_YEAR);
+
+    String good = currentYear.toString();
+    String bad = previousYear.toString();
+
+    assertTrue(matcher.match(good).isExactMatch());
+    assertFalse(matcher.match(bad).isExactMatch());
+  }
+
+  @Test
+  public void matchesNowToYearInCustomFormat() {
+    Year currentYear = Year.now();
+    StringValuePattern matcher =
+        WireMock.isNow().truncateExpected(DateTimeTruncation.FIRST_DAY_OF_YEAR).actualFormat("yy");
+
+    String good = currentYear.format(DateTimeFormatter.ofPattern("yy"));
+    String bad = currentYear.toString();
 
     assertTrue(matcher.match(good).isExactMatch());
     assertFalse(matcher.match(bad).isExactMatch());


### PR DESCRIPTION
Currently Wiremock supports request matching with dynamic date/time values but not with dynamic year values. In other words, given the following matcher:
```
"request": {
  "method": "GET",
  "urlPath": "/resource",
  "queryParameters": {
    "year": {
      "equalToDateTime": "now",
      "truncateExpected": "first day of year"
    }
  }
}
```
A GET request to the following URI does not match (assuming the current year is 2024):
```
/resource?year=2024
```
Even though a GET request to the following three URIs matches (assuming the current year is 2024 and the system timezone is UTC):
```
/resource?year=2024-01-01T00:00:00.000Z
/resource?year=2024-01-01T00:00:00.000
/resource?year=2024-01-01
```
That is because the current implementation attempts to parse the actual date/time value using  `ZonedDateTime`, `LocalDateTime` and `LocalDate` consecutively and none of these classes can parse a year value in the `yyyy` format.

This PR introduces a very small fix which allows the actual value to be parsed using `Year` in case parsing fails with all three aforementioned classes. A unit test which fails with the current implementation is also added.

## References
Original enhancement request for request matching with dynamic dates: https://github.com/wiremock/wiremock/issues/1475

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
