### PR TITLE
Prevent creating multiple stub mappings with the same ID

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/AbstractStubMappings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/AbstractStubMappings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Thomas Akehurst
+ * Copyright (C) 2022-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,9 @@ import static com.github.tomakehurst.wiremock.http.ResponseDefinition.copyOf;
 import static java.util.stream.Collectors.toList;
 
 import com.github.tomakehurst.wiremock.admin.NotFoundException;
+import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Pair;
 import com.github.tomakehurst.wiremock.extension.Parameters;
@@ -149,6 +151,16 @@ public abstract class AbstractStubMappings implements StubMappings {
 
   @Override
   public void addMapping(StubMapping mapping) {
+    if (store.get(mapping.getId()).isPresent()) {
+      String msg =
+          "ID of the provided stub mapping '"
+              + mapping.getUuid()
+              + "' is already taken by another stub mapping";
+      notifier().error(msg);
+      throw new InvalidInputException(
+          Errors.singleWithDetail(109, "Duplicate stub mapping ID", msg));
+    }
+
     for (StubLifecycleListener listener : stubLifecycleListeners) {
       listener.beforeStubCreated(mapping);
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -168,7 +168,7 @@ public class ResponseTemplatingAcceptanceTest {
       assertThat(response.content(), is("one"));
       assertThat(response.firstHeader("X-Value"), is("one"));
 
-      wm.stubFor(
+      wm.editStub(
           get(urlPathEqualTo(url))
               .withId(id)
               .willReturn(
@@ -183,17 +183,14 @@ public class ResponseTemplatingAcceptanceTest {
 
     @Test
     public void supportsDisablingTemplatingOfBodyFilesPerStub() {
-      UUID id = UUID.randomUUID();
       wm.stubFor(
           get(urlPathEqualTo("/templated"))
-              .withId(id)
               .willReturn(aResponse().withBodyFile("templated-example-1.txt")));
 
       assertThat(client.get("/templated").content(), is("templated"));
 
       wm.stubFor(
           get(urlPathEqualTo("/templated"))
-              .withId(id)
               .willReturn(
                   aResponse()
                       .withBodyFile("templated-example-1.txt")
@@ -203,7 +200,6 @@ public class ResponseTemplatingAcceptanceTest {
 
       wm.stubFor(
           get(urlPathMatching("/templated/.*"))
-              .withId(id)
               .willReturn(
                   aResponse()
                       .withBodyFile("templated-example-{{request.path.1}}.txt")

--- a/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
@@ -46,11 +46,10 @@ class HttpAdminClientTest {
   void shouldSendEmptyRequestForResetToDefaultMappings() {
     var server = new WireMockServer(options().dynamicPort());
     server.start();
-    server.addStubMapping(
-        server.stubFor(
-            post(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/mappings/reset"))
-                .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
-                .willReturn(ok())));
+    server.stubFor(
+        post(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/mappings/reset"))
+            .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
+            .willReturn(ok()));
     var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
 
     client.resetToDefaultMappings();
@@ -60,11 +59,10 @@ class HttpAdminClientTest {
   void shouldSendEmptyRequestForResetAll() {
     var server = new WireMockServer(options().dynamicPort());
     server.start();
-    server.addStubMapping(
-        server.stubFor(
-            post(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/reset"))
-                .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
-                .willReturn(ok())));
+    server.stubFor(
+        post(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/reset"))
+            .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
+            .willReturn(ok()));
     var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
 
     client.resetAll();
@@ -75,11 +73,10 @@ class HttpAdminClientTest {
     var server = new WireMockServer(options().dynamicPort());
     server.start();
     var expectedResponse = new GetScenariosResult(List.of(Scenario.inStartedState("scn1")));
-    server.addStubMapping(
-        server.stubFor(
-            get(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/scenarios"))
-                .withHeader(HttpHeaders.CONTENT_LENGTH, absent())
-                .willReturn(jsonResponse(expectedResponse, HttpStatus.SC_OK))));
+    server.stubFor(
+        get(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/scenarios"))
+            .withHeader(HttpHeaders.CONTENT_LENGTH, absent())
+            .willReturn(jsonResponse(expectedResponse, HttpStatus.SC_OK)));
     var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
 
     assertThat(client.getAllScenarios()).usingRecursiveComparison().isEqualTo(expectedResponse);


### PR DESCRIPTION
This pull request implements the fix outlined in [this issue](https://github.com/wiremock/wiremock/issues/2734) to prevent the creation of multiple stub mappings with the same ID.

## References

https://github.com/wiremock/wiremock/issues/2734

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)