### PR TITLE
feat: add admin api route to get file contents from file store

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,7 @@ public class AdminRoutes {
     router.add(GET, "/files", new GetAllStubFilesTask(stores));
     router.add(PUT, "/files/**", new EditStubFileTask(stores));
     router.add(DELETE, "/files/**", new DeleteStubFileTask(stores));
+    router.add(GET, "/files/**", new GetStubFileTask(stores));
 
     router.add(GET, "/scenarios", new GetAllScenariosTask());
     router.add(POST, "/scenarios/reset", new ResetScenariosTask());

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/GetStubFileTask.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/GetStubFileTask.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2016-2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.admin.tasks;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+
+import com.github.tomakehurst.wiremock.admin.AdminTask;
+import com.github.tomakehurst.wiremock.common.url.PathParams;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.store.Stores;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import java.util.Optional;
+
+public class GetStubFileTask implements AdminTask {
+
+  private final Stores stores;
+
+  public GetStubFileTask(Stores stores) {
+    this.stores = stores;
+  }
+
+  @Override
+  public ResponseDefinition execute(Admin admin, ServeEvent serveEvent, PathParams pathParams) {
+    String filename = pathParams.get("0");
+    Optional<byte[]> fileContents = stores.getFilesBlobStore().get(filename);
+
+    return fileContents
+        .map(bytes -> new ResponseDefinition(HTTP_OK, bytes))
+        .orElseGet(ResponseDefinition::notFound);
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -45,6 +45,7 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.toomuchcoding.jsonassert.JsonAssertion;
 import com.toomuchcoding.jsonassert.JsonVerifiable;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -911,6 +912,22 @@ class AdminApiTest extends AcceptanceTestBase {
         "BBB",
         fileSource.getTextFileNamed(fileName).readContentsAsString(),
         "File should have been changed");
+  }
+
+  @Test
+  void getStubFileContent() {
+    String fileName = "foo/bar.txt";
+    FileSource fileSource = wireMockServer.getOptions().filesRoot().child(FILES_ROOT);
+    fileSource.createIfNecessary();
+    fileSource.writeTextFile(fileName, "AAA");
+
+    WireMockResponse response = testClient.get("/__admin/files/foo/bar.txt");
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "AAA",
+        new String(response.binaryContent(), StandardCharsets.UTF_8),
+        "File contents should be in file source");
   }
 
   @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
