### PR TITLE
Fix HttpClientBuilder сode and add options for Connection Management to increase the proxying performance

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -47,6 +47,8 @@ public interface Options {
   int DEFAULT_TIMEOUT = 300_000;
   int DEFAULT_CONTAINER_THREADS = 25;
   String DEFAULT_BIND_ADDRESS = "0.0.0.0";
+  int DEFAULT_MAX_HTTP_CONNECTIONS = 1000;
+  boolean DEFAULT_DISABLE_CONNECTION_REUSE = true;
 
   int portNumber();
 
@@ -138,9 +140,7 @@ public interface Options {
 
   int proxyTimeout();
 
-  default int getMaxHttpClientConnections() {
-    return 1000;
-  }
+  int getMaxHttpClientConnections();
 
   boolean getResponseTemplatingEnabled();
 
@@ -153,4 +153,6 @@ public interface Options {
   boolean getTemplateEscapingDisabled();
 
   Set<String> getSupportedProxyEncodings();
+
+  boolean getDisableConnectionReuse();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -140,6 +140,9 @@ public class WireMockConfiguration implements Options {
 
   private int proxyTimeout = DEFAULT_TIMEOUT;
 
+  private int maxHttpClientConnections = DEFAULT_MAX_HTTP_CONNECTIONS;
+  private boolean disableConnectionReuse = DEFAULT_DISABLE_CONNECTION_REUSE;
+
   private boolean templatingEnabled = true;
   private boolean globalTemplating = false;
   private Set<String> permittedSystemKeys = null;
@@ -540,6 +543,16 @@ public class WireMockConfiguration implements Options {
     return this;
   }
 
+  public WireMockConfiguration maxHttpClientConnections(int maxHttpClientConnections) {
+    this.maxHttpClientConnections = maxHttpClientConnections;
+    return this;
+  }
+
+  public WireMockConfiguration disableConnectionReuse(boolean disableConnectionReuse) {
+    this.disableConnectionReuse = disableConnectionReuse;
+    return this;
+  }
+
   public WireMockConfiguration templatingEnabled(boolean templatingEnabled) {
     this.templatingEnabled = templatingEnabled;
     return this;
@@ -822,6 +835,16 @@ public class WireMockConfiguration implements Options {
   @Override
   public int proxyTimeout() {
     return proxyTimeout;
+  }
+
+  @Override
+  public int getMaxHttpClientConnections() {
+    return maxHttpClientConnections;
+  }
+
+  @Override
+  public boolean getDisableConnectionReuse() {
+    return disableConnectionReuse;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
@@ -79,16 +79,6 @@ public class HttpClientFactory {
             .disableCookieManagement()
             .disableRedirectHandling()
             .disableContentCompression()
-            .setConnectionManager(
-                PoolingHttpClientConnectionManagerBuilder.create()
-                    .setDnsResolver(dnsResolver)
-                    .setMaxConnPerRoute(maxConnections)
-                    .setMaxConnTotal(maxConnections)
-                    .setValidateAfterInactivity(TimeValue.ofSeconds(5)) // TODO Verify duration
-                    .setConnectionFactory(
-                        new ManagedHttpClientConnectionFactory(
-                            null, CharCodingConfig.custom().setCharset(UTF_8).build(), null))
-                    .build())
             .setDefaultRequestConfig(
                 RequestConfig.custom()
                     .setResponseTimeout(Timeout.ofMilliseconds(timeoutMilliseconds))
@@ -121,12 +111,18 @@ public class HttpClientFactory {
     final SSLContext sslContext =
         buildSslContext(trustStoreSettings, trustAllCertificates, trustedHosts);
     LayeredConnectionSocketFactory sslSocketFactory = buildSslConnectionSocketFactory(sslContext);
-    PoolingHttpClientConnectionManager connectionManager =
-        PoolingHttpClientConnectionManagerBuilder.create()
-            .setSSLSocketFactory(sslSocketFactory)
-            .setDnsResolver(dnsResolver)
-            .build();
-    builder.setConnectionManager(connectionManager);
+    builder
+        .setConnectionManager(
+            PoolingHttpClientConnectionManagerBuilder.create()
+                .setSSLSocketFactory(sslSocketFactory)
+                .setDnsResolver(dnsResolver)
+                .setMaxConnPerRoute(maxConnections)
+                .setMaxConnTotal(maxConnections)
+                .setValidateAfterInactivity(TimeValue.ofSeconds(5)) // TODO Verify duration
+                .setConnectionFactory(
+                    new ManagedHttpClientConnectionFactory(
+                        null, CharCodingConfig.custom().setCharset(UTF_8).build(), null))
+                    .build());
 
     return builder.build();
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
@@ -42,7 +42,6 @@ import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.ManagedHttpClientConnectionFactory;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.socket.LayeredConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
@@ -110,18 +110,17 @@ public class HttpClientFactory {
     final SSLContext sslContext =
         buildSslContext(trustStoreSettings, trustAllCertificates, trustedHosts);
     LayeredConnectionSocketFactory sslSocketFactory = buildSslConnectionSocketFactory(sslContext);
-    builder
-        .setConnectionManager(
-            PoolingHttpClientConnectionManagerBuilder.create()
-                .setSSLSocketFactory(sslSocketFactory)
-                .setDnsResolver(dnsResolver)
-                .setMaxConnPerRoute(maxConnections)
-                .setMaxConnTotal(maxConnections)
-                .setValidateAfterInactivity(TimeValue.ofSeconds(5)) // TODO Verify duration
-                .setConnectionFactory(
-                    new ManagedHttpClientConnectionFactory(
-                        null, CharCodingConfig.custom().setCharset(UTF_8).build(), null))
-                    .build());
+    builder.setConnectionManager(
+        PoolingHttpClientConnectionManagerBuilder.create()
+            .setSSLSocketFactory(sslSocketFactory)
+            .setDnsResolver(dnsResolver)
+            .setMaxConnPerRoute(maxConnections)
+            .setMaxConnTotal(maxConnections)
+            .setValidateAfterInactivity(TimeValue.ofSeconds(5)) // TODO Verify duration
+            .setConnectionFactory(
+                new ManagedHttpClientConnectionFactory(
+                    null, CharCodingConfig.custom().setCharset(UTF_8).build(), null))
+            .build());
 
     return builder.build();
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheBackedHttpClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheBackedHttpClient.java
@@ -81,8 +81,7 @@ public class ApacheBackedHttpClient implements HttpClient {
       requestBuilder.setEntity(applyGzipWrapperIfRequired(request, entity));
     }
 
-    ClassicHttpRequest apacheRequest = requestBuilder.build();
-    return apacheRequest;
+      return requestBuilder.build();
   }
 
   private static HttpEntity applyGzipWrapperIfRequired(

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheBackedHttpClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheBackedHttpClient.java
@@ -88,7 +88,7 @@ public class ApacheBackedHttpClient implements HttpClient {
       requestBuilder.setEntity(applyGzipWrapperIfRequired(request, entity));
     }
 
-      return requestBuilder.build();
+    return requestBuilder.build();
   }
 
   private static HttpEntity applyGzipWrapperIfRequired(

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
@@ -37,7 +37,7 @@ public class ApacheHttpClientFactory implements HttpClientFactory {
             trustedHosts,
             useSystemProperties,
             options.getProxyTargetRules(),
-            true);
+            options.getDisableConnectionReuse());
 
     return new ApacheBackedHttpClient(apacheClient);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -262,6 +262,16 @@ public class WarConfiguration implements Options {
   }
 
   @Override
+  public int getMaxHttpClientConnections() {
+    return DEFAULT_MAX_HTTP_CONNECTIONS;
+  }
+
+  @Override
+  public boolean getDisableConnectionReuse() {
+    return DEFAULT_DISABLE_CONNECTION_REUSE;
+  }
+
+  @Override
   public boolean getResponseTemplatingEnabled() {
     return true;
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -385,11 +385,11 @@ public class CommandLineOptions implements Options {
         .accepts(PROXY_PASS_THROUGH, "Flag to control browser proxy pass through")
         .withRequiredArg();
     optionParser
-            .accepts(MAX_HTTP_CLIENT_CONNECTIONS, "Maximum connections for Http Client")
-            .withRequiredArg();
+        .accepts(MAX_HTTP_CLIENT_CONNECTIONS, "Maximum connections for Http Client")
+        .withRequiredArg();
     optionParser
-            .accepts(DISABLE_CONNECTION_REUSE, "Disable http connection reuse")
-            .withRequiredArg();
+        .accepts(DISABLE_CONNECTION_REUSE, "Disable http connection reuse")
+        .withRequiredArg();
     optionParser
         .accepts(
             SUPPORTED_PROXY_ENCODINGS,
@@ -995,8 +995,8 @@ public class CommandLineOptions implements Options {
   @Override
   public int getMaxHttpClientConnections() {
     return optionSet.has(MAX_HTTP_CLIENT_CONNECTIONS)
-            ? Integer.parseInt((String) optionSet.valueOf(MAX_HTTP_CLIENT_CONNECTIONS))
-            : DEFAULT_MAX_HTTP_CONNECTIONS;
+        ? Integer.parseInt((String) optionSet.valueOf(MAX_HTTP_CLIENT_CONNECTIONS))
+        : DEFAULT_MAX_HTTP_CONNECTIONS;
   }
 
   @Override
@@ -1049,7 +1049,7 @@ public class CommandLineOptions implements Options {
   @Override
   public boolean getDisableConnectionReuse() {
     return optionSet.has(DISABLE_CONNECTION_REUSE)
-            ? Boolean.parseBoolean((String) optionSet.valueOf(DISABLE_CONNECTION_REUSE))
-            : DEFAULT_DISABLE_CONNECTION_REUSE;
+        ? Boolean.parseBoolean((String) optionSet.valueOf(DISABLE_CONNECTION_REUSE))
+        : DEFAULT_DISABLE_CONNECTION_REUSE;
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -125,7 +125,8 @@ public class CommandLineOptions implements Options {
   private static final String ALLOW_PROXY_TARGETS = "allow-proxy-targets";
   private static final String DENY_PROXY_TARGETS = "deny-proxy-targets";
   private static final String PROXY_TIMEOUT = "proxy-timeout";
-
+  private static final String MAX_HTTP_CLIENT_CONNECTIONS = "max-http-client-connections";
+  private static final String DISABLE_CONNECTION_REUSE = "disable-connection-reuse";
   private static final String PROXY_PASS_THROUGH = "proxy-pass-through";
   private static final String SUPPORTED_PROXY_ENCODINGS = "supported-proxy-encodings";
 
@@ -379,6 +380,12 @@ public class CommandLineOptions implements Options {
     optionParser
         .accepts(PROXY_PASS_THROUGH, "Flag to control browser proxy pass through")
         .withRequiredArg();
+    optionParser
+            .accepts(MAX_HTTP_CLIENT_CONNECTIONS, "Maximum connections for Http Client")
+            .withRequiredArg();
+    optionParser
+            .accepts(DISABLE_CONNECTION_REUSE, "Disable http connection reuse")
+            .withRequiredArg();
     optionParser
         .accepts(
             SUPPORTED_PROXY_ENCODINGS,
@@ -976,6 +983,13 @@ public class CommandLineOptions implements Options {
   }
 
   @Override
+  public int getMaxHttpClientConnections() {
+    return optionSet.has(MAX_HTTP_CLIENT_CONNECTIONS)
+            ? Integer.parseInt((String) optionSet.valueOf(MAX_HTTP_CLIENT_CONNECTIONS))
+            : DEFAULT_MAX_HTTP_CONNECTIONS;
+  }
+
+  @Override
   public boolean getResponseTemplatingEnabled() {
     return !optionSet.has(DISABLE_RESPONSE_TEMPLATING);
   }
@@ -1020,5 +1034,12 @@ public class CommandLineOptions implements Options {
 
   private int getAsynchronousResponseThreads() {
     return Integer.parseInt((String) optionSet.valueOf(ASYNCHRONOUS_RESPONSE_THREADS));
+  }
+
+  @Override
+  public boolean getDisableConnectionReuse() {
+    return optionSet.has(DISABLE_CONNECTION_REUSE)
+            ? Boolean.parseBoolean((String) optionSet.valueOf(DISABLE_CONNECTION_REUSE))
+            : DEFAULT_DISABLE_CONNECTION_REUSE;
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -818,6 +818,25 @@ public class CommandLineOptionsTest {
     assertThat(supportedProxyEncodings, hasItems("gzip", "deflate"));
   }
 
+  @Test
+  void testMaxHttpClientConnectionsOption() {
+    CommandLineOptions options = new CommandLineOptions("--max-http-client-connections", "5000");
+
+    assertThat(options.getMaxHttpClientConnections(), is(5000));
+  }
+
+  @Test
+  void testDisableConnectionReuseOptionPassedAsFalse() {
+    CommandLineOptions options = new CommandLineOptions("--disable-connection-reuse", "false");
+    assertFalse(options.getDisableConnectionReuse());
+  }
+
+  @Test
+  void testDisableConnectionReuseOptionPassedAsTrue() {
+    CommandLineOptions options = new CommandLineOptions("--disable-connection-reuse", "true");
+    assertTrue(options.getDisableConnectionReuse());
+  }
+
   public static class ResponseDefinitionTransformerExt1 extends ResponseDefinitionTransformer {
 
     @Override


### PR DESCRIPTION
When proxying requests, wiremock created a new socket for each request, and closed the old one. At the same time, when the socket is closed, it is transferred to the TIME_WAIT status and it should take about 60 more seconds before the socket actually closes. Therefore, at high load, wiremock very quickly used ports out of the ephemeral port range. Accordingly, he cannot take the port to create a new connection and the request is queued

![image_2024-06-01_20-05-41](https://github.com/wiremock/wiremock/assets/57095429/d1ed20d0-ecc1-4e43-816c-7aa97a2a463a)

Moreover, when creating HttpClient, we pass the maxConnections parameter, the value of which is used as MaxConnTotal and maxConnPerRoute, but this code overridden the ConnectionManager parameters. Therefore, in fact, we had the following values - MaxConnTotal =25, maxConnPerRoute=5. Which had an even stronger effect on the performance of the proxying by wiremock.

![wiremock code](https://github.com/wiremock/wiremock/assets/57095429/902290ec-22a0-4891-add0-fc05b5ba0453)

He couldn't withstand a load of 300 rps even for two minutes

![image_2024-06-01_19-45-18](https://github.com/wiremock/wiremock/assets/57095429/793d47d4-55e4-4b2a-ae4a-d3330ca9aa3b)

I have corrected the HttpClient build, added two parameters to options - max-http-client-connections and disable-connection-reuse, so that they can be flexibly managed.

After my changes, wiremock easily proxied 300 rps within 5 minutes

![image_2024-06-01_20-12-16](https://github.com/wiremock/wiremock/assets/57095429/0e4b8b6e-ac18-48c7-9d50-96f662648325)

And even 500 rps within 5 minutes

![image_2024-06-01_23-18-32](https://github.com/wiremock/wiremock/assets/57095429/d9906dfe-6073-4505-a2f2-72e46c2f7e77)

And even 1000 rps within 2 minutes

![image_2024-06-01_23-44-51](https://github.com/wiremock/wiremock/assets/57095429/fd855079-ec58-42d8-8118-38324c9cd700)

Now everything depends only on the capabilities of the service where the proxying is carried out

I left maxHttpClientConnections and disableConnectionReuse the same as they were by default

## References

- PR to wiremock.org - https://github.com/wiremock/wiremock.org/pull/284

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
