### PR TITLE
Ignore order of xml nodes on same level when matching request body

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -256,6 +256,7 @@ public class WireMock {
   public static EqualToXmlPattern equalToXml(String value, boolean enablePlaceholders) {
     return new EqualToXmlPattern(value, enablePlaceholders, null, null, null, false);
   }
+
   public static EqualToXmlPattern equalToXml(
       String value, boolean enablePlaceholders, boolean ignoreOrderOfSameNode) {
     return new EqualToXmlPattern(value, enablePlaceholders, ignoreOrderOfSameNode);

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -254,7 +254,11 @@ public class WireMock {
   }
 
   public static EqualToXmlPattern equalToXml(String value, boolean enablePlaceholders) {
-    return new EqualToXmlPattern(value, enablePlaceholders, null, null, null);
+    return new EqualToXmlPattern(value, enablePlaceholders, null, null, null, false);
+  }
+  public static EqualToXmlPattern equalToXml(
+      String value, boolean enablePlaceholders, boolean ignoreOrderOfSameNode) {
+    return new EqualToXmlPattern(value, enablePlaceholders, ignoreOrderOfSameNode);
   }
 
   public static EqualToXmlPattern equalToXml(
@@ -267,7 +271,23 @@ public class WireMock {
         enablePlaceholders,
         placeholderOpeningDelimiterRegex,
         placeholderClosingDelimiterRegex,
-        null);
+        null,
+        false);
+  }
+
+  public static EqualToXmlPattern equalToXml(
+      String value,
+      boolean enablePlaceholders,
+      String placeholderOpeningDelimiterRegex,
+      String placeholderClosingDelimiterRegex,
+      boolean ignoreOrderOfSameNode) {
+    return new EqualToXmlPattern(
+        value,
+        enablePlaceholders,
+        placeholderOpeningDelimiterRegex,
+        placeholderClosingDelimiterRegex,
+        null,
+        ignoreOrderOfSameNode);
   }
 
   public static MatchesXPathPattern matchingXPath(String value) {

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -249,6 +249,7 @@ public class EqualToXmlPattern extends StringValuePattern {
           .collect(Collectors.toList());
     }
 
-    private static final Comparator<Node> COMPARATOR = Comparator.comparing(Node::getLocalName);
+    private static final Comparator<Node> COMPARATOR =
+        Comparator.comparing(Node::getLocalName).thenComparing(Node::getTextContent);
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
@@ -56,10 +56,18 @@ public class EqualToXmlPattern extends StringValuePattern {
   private final String placeholderClosingDelimiterRegex;
   private final DifferenceEvaluator diffEvaluator;
   private final Set<ComparisonType> exemptedComparisons;
+  private final Boolean ignoreOrderOfSameNode;
   private final Document expectedXmlDoc;
 
   public EqualToXmlPattern(@JsonProperty("equalToXml") String expectedValue) {
-    this(expectedValue, null, null, null, null);
+    this(expectedValue, null, null, null, null, false);
+  }
+
+  public EqualToXmlPattern(
+      @JsonProperty("equalToXml") String expectedValue,
+      @JsonProperty("enablePlaceholders") Boolean enablePlaceholders,
+      @JsonProperty("ignoreOrderOfSameNode") boolean ignoreOrderOfSameNode) {
+    this(expectedValue, enablePlaceholders, null, null, null, ignoreOrderOfSameNode);
   }
 
   public EqualToXmlPattern(
@@ -67,7 +75,8 @@ public class EqualToXmlPattern extends StringValuePattern {
       @JsonProperty("enablePlaceholders") Boolean enablePlaceholders,
       @JsonProperty("placeholderOpeningDelimiterRegex") String placeholderOpeningDelimiterRegex,
       @JsonProperty("placeholderClosingDelimiterRegex") String placeholderClosingDelimiterRegex,
-      @JsonProperty("exemptedComparisons") Set<ComparisonType> exemptedComparisons) {
+      @JsonProperty("exemptedComparisons") Set<ComparisonType> exemptedComparisons,
+      @JsonProperty("ignoreOrderOfSameNode") Boolean ignoreOrderOfSameNode) {
 
     super(expectedValue);
     expectedXmlDoc = Xml.read(expectedValue); // Throw an exception if we can't parse the document
@@ -75,6 +84,7 @@ public class EqualToXmlPattern extends StringValuePattern {
     this.placeholderOpeningDelimiterRegex = placeholderOpeningDelimiterRegex;
     this.placeholderClosingDelimiterRegex = placeholderClosingDelimiterRegex;
     this.exemptedComparisons = exemptedComparisons;
+    this.ignoreOrderOfSameNode = ignoreOrderOfSameNode;
 
     IgnoreUncountedDifferenceEvaluator baseDifferenceEvaluator =
         new IgnoreUncountedDifferenceEvaluator(exemptedComparisons);
@@ -130,7 +140,7 @@ public class EqualToXmlPattern extends StringValuePattern {
                   .ignoreWhitespace()
                   .ignoreComments()
                   .withDifferenceEvaluator(diffEvaluator)
-                  .withNodeMatcher(new OrderInvariantNodeMatcher())
+                  .withNodeMatcher(new OrderInvariantNodeMatcher(ignoreOrderOfSameNode))
                   .withDocumentBuilderFactory(Xml.newDocumentBuilderFactory())
                   .build();
 
@@ -232,10 +242,17 @@ public class EqualToXmlPattern extends StringValuePattern {
         enablePlaceholders,
         placeholderOpeningDelimiterRegex,
         placeholderClosingDelimiterRegex,
-        new HashSet<>(Arrays.asList(comparisons)));
+        new HashSet<>(Arrays.asList(comparisons)),
+        ignoreOrderOfSameNode);
   }
 
   private static final class OrderInvariantNodeMatcher extends DefaultNodeMatcher {
+    private static Boolean secondaryOrderByTextContent;
+
+    public OrderInvariantNodeMatcher(Boolean secondaryOrderByTextContent) {
+      OrderInvariantNodeMatcher.secondaryOrderByTextContent = secondaryOrderByTextContent;
+    }
+
     @Override
     public Iterable<Map.Entry<Node, Node>> match(
         Iterable<Node> controlNodes, Iterable<Node> testNodes) {
@@ -245,11 +262,16 @@ public class EqualToXmlPattern extends StringValuePattern {
 
     private static Iterable<Node> sort(Iterable<Node> nodes) {
       return StreamSupport.stream(nodes.spliterator(), false)
-          .sorted(COMPARATOR)
+          .sorted(getComparator())
           .collect(Collectors.toList());
     }
 
-    private static final Comparator<Node> COMPARATOR =
-        Comparator.comparing(Node::getLocalName).thenComparing(Node::getTextContent);
+    private static Comparator<Node> getComparator() {
+      if (Objects.nonNull(secondaryOrderByTextContent) && secondaryOrderByTextContent) {
+        return Comparator.comparing(Node::getLocalName).thenComparing(Node::getTextContent);
+      } else {
+        return Comparator.comparing(Node::getLocalName);
+      }
+    }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
@@ -188,13 +188,14 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
         fromNullableTextNode(rootNode.findValue("placeholderClosingDelimiterRegex"));
     Set<ComparisonType> exemptedComparisons =
         comparisonTypeSetFromArray(rootNode.findValue("exemptedComparisons"));
-
+    Boolean ignoreOrderOfSameNode = fromNullable(rootNode.findValue("ignoreOrderOfSameNode"));
     return new EqualToXmlPattern(
         operand.textValue(),
         enablePlaceholders,
         placeholderOpeningDelimiterRegex,
         placeholderClosingDelimiterRegex,
-        exemptedComparisons);
+        exemptedComparisons,
+        ignoreOrderOfSameNode);
   }
 
   private MatchesJsonPathPattern deserialiseMatchesJsonPathPattern(JsonNode rootNode)

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -517,5 +517,39 @@ public class EqualToXmlPatternTest {
         match.getSubEvents().stream().findFirst().get().getData().get("message").toString();
     assertThat(
         message, startsWith("XML document structures must start and end within the same entity"));
+  }
+
+  @Test
+  void ignoreOrderOfSameNodeOnSameLevel() {
+    EqualToXmlPattern pattern =
+        new EqualToXmlPattern("<body><entry>1</entry><entry>2</entry></body>");
+    MatchResult result = pattern.match("<body><entry>2</entry><entry>1</entry></body>");
+    assertTrue(result.isExactMatch());
+  }
+
+  @Test
+  void doesNotMatchWhenSameNodeOnSameLevelHasDifferentValues() {
+    EqualToXmlPattern pattern =
+        new EqualToXmlPattern("<body><entry>1</entry><entry>3</entry></body>");
+    MatchResult result = pattern.match("<body><entry>2</entry><entry>1</entry></body>");
+    assertFalse(result.isExactMatch());
+  }
+
+  @Test
+  void matchesIfMultipleSameNodesOnSameLevelWithDifferentNodes() {
+    EqualToXmlPattern pattern =
+        new EqualToXmlPattern("<body><entry>1</entry><entry>2</entry><other>2</other></body>");
+    MatchResult result =
+        pattern.match("<body><entry>2</entry><entry>1</entry><other>2</other></body>");
+    assertTrue(result.isExactMatch());
+  }
+
+  @Test
+  void matchesIfTwoIdenticalChildNodesAreEmpty() {
+    EqualToXmlPattern pattern =
+            new EqualToXmlPattern("<body><entry/><entry/></body>");
+    MatchResult result =
+            pattern.match("<body><entry/><entry/></body>");
+    assertTrue(result.isExactMatch());
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -335,7 +335,7 @@ public class EqualToXmlPatternTest {
   public void returnsMatchWhenTextNodeIsIgnored() {
     String expectedXml = "<a>#{xmlunit.ignore}</a>";
     String actualXml = "<a>123</a>";
-    EqualToXmlPattern pattern = new EqualToXmlPattern(expectedXml, true, "#\\{", "}", null);
+    EqualToXmlPattern pattern = new EqualToXmlPattern(expectedXml, true, "#\\{", "}", null, false);
     MatchResult matchResult = pattern.match(actualXml);
 
     assertTrue(matchResult.isExactMatch());
@@ -346,7 +346,7 @@ public class EqualToXmlPatternTest {
   public void returnsMatchWhenTextNodeIsIgnored_DefaultDelimiters() {
     String expectedXml = "<a>${xmlunit.ignore}</a>";
     String actualXml = "<a>123</a>";
-    EqualToXmlPattern pattern = new EqualToXmlPattern(expectedXml, true, null, null, null);
+    EqualToXmlPattern pattern = new EqualToXmlPattern(expectedXml, true, null, null, null, false);
     MatchResult matchResult = pattern.match(actualXml);
 
     assertTrue(matchResult.isExactMatch());
@@ -411,7 +411,8 @@ public class EqualToXmlPatternTest {
             enablePlaceholders,
             placeholderOpeningDelimiterRegex,
             placeholderClosingDelimiterRegex,
-            Set.of(SCHEMA_LOCATION, NAMESPACE_URI, ATTR_VALUE));
+            Set.of(SCHEMA_LOCATION, NAMESPACE_URI, ATTR_VALUE),
+            false);
 
     String json = Json.write(pattern);
 
@@ -522,15 +523,23 @@ public class EqualToXmlPatternTest {
   @Test
   void ignoreOrderOfSameNodeOnSameLevel() {
     EqualToXmlPattern pattern =
-        new EqualToXmlPattern("<body><entry>1</entry><entry>2</entry></body>");
+        new EqualToXmlPattern("<body><entry>1</entry><entry>2</entry></body>", false, true);
     MatchResult result = pattern.match("<body><entry>2</entry><entry>1</entry></body>");
     assertTrue(result.isExactMatch());
   }
 
   @Test
+  void dontIgnoreOrderOfSameNodeOnSameLevel() {
+    EqualToXmlPattern pattern =
+        new EqualToXmlPattern("<body><entry>1</entry><entry>2</entry></body>", false, false);
+    MatchResult result = pattern.match("<body><entry>2</entry><entry>1</entry></body>");
+    assertFalse(result.isExactMatch());
+  }
+
+  @Test
   void doesNotMatchWhenSameNodeOnSameLevelHasDifferentValues() {
     EqualToXmlPattern pattern =
-        new EqualToXmlPattern("<body><entry>1</entry><entry>3</entry></body>");
+        new EqualToXmlPattern("<body><entry>1</entry><entry>3</entry></body>", false, true);
     MatchResult result = pattern.match("<body><entry>2</entry><entry>1</entry></body>");
     assertFalse(result.isExactMatch());
   }
@@ -538,7 +547,8 @@ public class EqualToXmlPatternTest {
   @Test
   void matchesIfMultipleSameNodesOnSameLevelWithDifferentNodes() {
     EqualToXmlPattern pattern =
-        new EqualToXmlPattern("<body><entry>1</entry><entry>2</entry><other>2</other></body>");
+        new EqualToXmlPattern(
+            "<body><entry>1</entry><entry>2</entry><other>2</other></body>", false, true);
     MatchResult result =
         pattern.match("<body><entry>2</entry><entry>1</entry><other>2</other></body>");
     assertTrue(result.isExactMatch());
@@ -546,10 +556,8 @@ public class EqualToXmlPatternTest {
 
   @Test
   void matchesIfTwoIdenticalChildNodesAreEmpty() {
-    EqualToXmlPattern pattern =
-            new EqualToXmlPattern("<body><entry/><entry/></body>");
-    MatchResult result =
-            pattern.match("<body><entry/><entry/></body>");
+    EqualToXmlPattern pattern = new EqualToXmlPattern("<body><entry/><entry/></body>", false, true);
+    MatchResult result = pattern.match("<body><entry/><entry/></body>");
     assertTrue(result.isExactMatch());
   }
 }


### PR DESCRIPTION
Ignores the order of nodes on the same level by applying secondary sorting by the text content of the node. This allows to match requests where there can be multiple same tags in arbitrary order
Given example configuration:
```java
    .withRequestBody(equalToXml("<body>" +
            "   <entry>1</entry>" +
            "   <entry>2</entry>" +
            "</body>", false, true))
```
Will match
```xml
<body>
    <entry>2</entry>
    <entry>1</entry>
</body>
```
and match 
```xml
<body>
    <entry>1</entry>
    <entry>2</entry>
</body>
```

Added property to enable secondary sort by node text content. The property name is `ignoreOrderOfSameNode`. Tried to follow pattern similar to `equalToJson` implementation. Update existing `equalToXml` static methods to pass `null` value as the parameter to preserve existing behavior. Added two additional `equalToXml` overloads that accept the `ignoreOrderOfSameNode` parameter:
where we don't use placeholder delimiters
```java
  public static EqualToXmlPattern equalToXml(
      String value, boolean enablePlaceholders, boolean ignoreOrderOfSameNode) {
    return new EqualToXmlPattern(value, enablePlaceholders, ignoreOrderOfSameNode);
  }
```
and 
```java
  public static EqualToXmlPattern equalToXml(
      String value,
      boolean enablePlaceholders,
      String placeholderOpeningDelimiterRegex,
      String placeholderClosingDelimiterRegex,
      boolean ignoreOrderOfSameNode) {
    return new EqualToXmlPattern(
        value,
        enablePlaceholders,
        placeholderOpeningDelimiterRegex,
        placeholderClosingDelimiterRegex,
        null,
        ignoreOrderOfSameNode);
  }
```
where we do use placeholder delimiters. 

Docs are also updated and PR raised to reflect changes: 
## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
