### PR TITLE
Default the max template cache entries to 1000 instead of infinite

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -47,6 +47,7 @@ public interface Options {
   int DEFAULT_TIMEOUT = 300_000;
   int DEFAULT_CONTAINER_THREADS = 25;
   String DEFAULT_BIND_ADDRESS = "0.0.0.0";
+  Long DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES = 1000L;
 
   int portNumber();
 

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -143,7 +143,7 @@ public class WireMockConfiguration implements Options {
   private boolean templatingEnabled = true;
   private boolean globalTemplating = false;
   private Set<String> permittedSystemKeys = null;
-  private Long maxTemplateCacheEntries = null;
+  private Long maxTemplateCacheEntries = DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES;
   private boolean templateEscapingDisabled = true;
 
   private Set<String> supportedProxyEncodings = null;

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -988,8 +988,8 @@ public class CommandLineOptions implements Options {
   @Override
   public Long getMaxTemplateCacheEntries() {
     return optionSet.has(MAX_TEMPLATE_CACHE_ENTRIES)
-        ? Long.valueOf(optionSet.valueOf(MAX_TEMPLATE_CACHE_ENTRIES).toString())
-        : null;
+        ? Long.parseLong(optionSet.valueOf(MAX_TEMPLATE_CACHE_ENTRIES).toString())
+        : 1000;
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -989,7 +989,7 @@ public class CommandLineOptions implements Options {
   public Long getMaxTemplateCacheEntries() {
     return optionSet.has(MAX_TEMPLATE_CACHE_ENTRIES)
         ? Long.parseLong(optionSet.valueOf(MAX_TEMPLATE_CACHE_ENTRIES).toString())
-        : 1000;
+        : DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES;
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.core;
 
+import static com.github.tomakehurst.wiremock.core.Options.DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -85,5 +86,11 @@ public class WireMockConfigurationTest {
   void setsMaxTemplateCacheEntries() {
     Options config = WireMockConfiguration.wireMockConfig().withMaxTemplateCacheEntries(11L);
     assertThat(config.getMaxTemplateCacheEntries(), is(11L));
+  }
+
+  @Test
+  void maxTemplateCacheEntriesDefaultsWhenNotSpecified() {
+    Options config = WireMockConfiguration.wireMockConfig();
+    assertThat(config.getMaxTemplateCacheEntries(), is(DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.standalone;
 
 import static com.github.tomakehurst.wiremock.common.BrowserProxySettings.DEFAULT_CA_KESTORE_PASSWORD;
 import static com.github.tomakehurst.wiremock.common.BrowserProxySettings.DEFAULT_CA_KEYSTORE_PATH;
+import static com.github.tomakehurst.wiremock.core.Options.DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.matchesMultiLine;
 import static java.util.Arrays.asList;
@@ -465,7 +466,7 @@ public class CommandLineOptionsTest {
   public void maxTemplateCacheEntriesDefaultsWhenNotSpecified() {
     CommandLineOptions options = new CommandLineOptions();
 
-    assertThat(options.getMaxTemplateCacheEntries(), is(1000L));
+    assertThat(options.getMaxTemplateCacheEntries(), is(DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -462,6 +462,13 @@ public class CommandLineOptionsTest {
   }
 
   @Test
+  public void maxTemplateCacheEntriesDefaultsWhenNotSpecified() {
+    CommandLineOptions options = new CommandLineOptions();
+
+    assertThat(options.getMaxTemplateCacheEntries(), is(1000L));
+  }
+
+  @Test
   public void supportsAdminApiBasicAuth() {
     CommandLineOptions options = new CommandLineOptions("--admin-api-basic-auth", "user:pass");
     Authenticator authenticator = options.getAdminAuthenticator();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR defaults the max template cache entries to 1000 instead of infinite.

## References

* https://github.com/wiremock/wiremock/issues/2731


<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
