### PR TITLE
fix: stop showing path parameter non match message incorrectly.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
@@ -292,7 +292,7 @@ public class Diff {
 
       for (Map.Entry<String, String> entry : requestPathParameterValues.entrySet()) {
         String parameterName = entry.getKey();
-        final String parameterValue = parameterName + ": " + entry.getValue();
+        final String parameterValue = entry.getValue();
         final StringValuePattern pattern = pathParameters.get(parameterName);
         String operator = generateOperatorString(pattern, " = ");
         DiffLine<String> section =

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/diff/PlainTextDiffRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/diff/PlainTextDiffRendererTest.java
@@ -620,6 +620,22 @@ class PlainTextDiffRendererTest {
         equalsMultiLine(file("not-found-diff-sample_json-path-body-not-json.txt")));
   }
 
+  @Test
+  void doesNotIncorrectlyShowUrlPathParametersNonMatchMessage() {
+    Diff diff =
+        new Diff(
+            get(urlPathTemplate("/contacts/{contactId}"))
+                .withPathParam("contactId", equalTo("123"))
+                .withHeader("Authorization", equalTo("Token 456"))
+                .build(),
+            mockRequest().method(GET).url("/contacts/123").header("Authorization", "Token 789"));
+
+    String output = diffRenderer.render(diff);
+
+    assertThat(
+        output, equalsMultiLine(file("not-found-diff-sample_no_path_parameter_message.txt")));
+  }
+
   public static class MyCustomMatcher extends RequestMatcherExtension {
 
     @Override

--- a/src/test/resources/not-found-diff-sample_no_path_parameter_message.txt
+++ b/src/test/resources/not-found-diff-sample_no_path_parameter_message.txt
@@ -7,9 +7,11 @@
 -----------------------------------------------------------------------------------------------------------------------
                                                            |
 GET                                                        | GET
-[path template] /contacts/{contactId}                      | /contacts/345
+[path template] /contacts/{contactId}                      | /contacts/123
                                                            |
-Path parameter: contactId = 123                            | 345                                                 <<<<< Path parameter does not match
+Authorization: Token 456                                   | Authorization: Token 789                            <<<<< Header does not match
+                                                           |
+Path parameter: contactId = 123                            | 123
                                                            |
                                                            |
 -----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Currently, when a request is not matched, its diff report always shows all path parameters matchers as not matching, regardless of if they actually were matched or not. This PR fixes that bug.

## References

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)