### PR TITLE
Add request id to the template model

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -27,12 +27,10 @@ import com.github.jknack.handlebars.helper.ConditionalHelpers;
 import com.github.jknack.handlebars.helper.NumberHelper;
 import com.github.jknack.handlebars.helper.StringHelpers;
 import com.github.tomakehurst.wiremock.common.Exceptions;
-import com.github.tomakehurst.wiremock.common.url.PathTemplate;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.TemplateModelDataProviderExtension;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.SystemValueHelper;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.WireMockHelpers;
-import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.google.common.cache.Cache;
@@ -131,13 +129,9 @@ public class TemplateEngine {
   }
 
   public Map<String, Object> buildModelForRequest(ServeEvent serveEvent) {
-    final Request request = serveEvent.getRequest();
     final ResponseDefinition responseDefinition = serveEvent.getResponseDefinition();
     final Parameters parameters =
         getFirstNonNull(responseDefinition.getTransformerParameters(), Parameters.empty());
-
-    final PathTemplate pathTemplate =
-        serveEvent.getStubMapping().getRequest().getUrlMatcher().getPathTemplate();
 
     final Map<String, Object> additionalModelData =
         templateModelDataProviders.stream()
@@ -147,7 +141,7 @@ public class TemplateEngine {
 
     final Map<String, Object> model = new HashMap<>();
     model.put("parameters", parameters);
-    model.put("request", RequestTemplateModel.from(request, pathTemplate));
+    model.put("request", RequestTemplateModel.from(serveEvent));
     model.putAll(additionalModelData);
     return model;
   }

--- a/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -26,7 +26,6 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.extension.ServeEventListener;
 import com.github.tomakehurst.wiremock.extension.WireMockServices;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.RequestTemplateModel;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.http.client.HttpClient;
@@ -122,13 +121,15 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
   private WebhookDefinition applyTemplating(
       WebhookDefinition webhookDefinition, ServeEvent serveEvent) {
 
-    final Map<String, Object> model = new HashMap<>();
+    final Map<String, Object> model =
+        new HashMap<>(this.templateEngine.buildModelForRequest(serveEvent));
     model.put(
         "parameters",
         webhookDefinition.getExtraParameters() != null
             ? webhookDefinition.getExtraParameters()
             : Collections.<String, Object>emptyMap());
-    model.put("originalRequest", RequestTemplateModel.from(serveEvent));
+    model.put("originalRequest", model.get("request"));
+    model.remove("request");
 
     WebhookDefinition renderedWebhookDefinition =
         webhookDefinition

--- a/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -128,7 +128,7 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
         webhookDefinition.getExtraParameters() != null
             ? webhookDefinition.getExtraParameters()
             : Collections.<String, Object>emptyMap());
-    model.put("originalRequest", RequestTemplateModel.from(serveEvent.getRequest()));
+    model.put("originalRequest", RequestTemplateModel.from(serveEvent));
 
     WebhookDefinition renderedWebhookDefinition =
         webhookDefinition

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
@@ -35,6 +35,7 @@ import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
+import com.github.tomakehurst.wiremock.extension.TemplateModelDataProviderExtension;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
@@ -46,6 +47,7 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.common.base.Stopwatch;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import org.apache.hc.core5.http.io.entity.StringEntity;
@@ -91,6 +93,19 @@ public class WebhooksAcceptanceViaServeEventTest {
           .options(
               options()
                   .dynamicPort()
+                  .extensions(
+                      new TemplateModelDataProviderExtension() {
+                        @Override
+                        public Map<String, Object> provideTemplateModelData(ServeEvent serveEvent) {
+                          return Map.of(
+                              "customData", Map.of("path", serveEvent.getRequest().getUrl()));
+                        }
+
+                        @Override
+                        public String getName() {
+                          return "custom-model-data";
+                        }
+                      })
                   .notifier(notifier)
                   .limitProxyTargets(
                       NetworkAddressRules.builder().deny("169.254.0.0-169.254.255.255").build()))
@@ -184,6 +199,32 @@ public class WebhooksAcceptanceViaServeEventTest {
         postRequestedFor(urlEqualTo("/callback"))
             .withHeader("Content-Type", equalTo("application/json"))
             .withRequestBody(equalToJson("{ \"requestId\": \"" + requestId + "\" }")));
+  }
+
+  @Test
+  public void webhooksHaveAccessToTemplateModelDataProviders() throws Exception {
+    rule.stubFor(
+        post("/helpers")
+            .willReturn(ok("{{request.id}}").withTransformers("response-template"))
+            .withServeEventListener(
+                "webhook",
+                webhook()
+                    .withMethod(POST)
+                    .withUrl(targetServer.url("/callback"))
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{ \"url\": \"{{ customData.path }}\" }")));
+
+    verify(0, postRequestedFor(anyUrl()));
+
+    client.post("/helpers", new StringEntity("", TEXT_PLAIN));
+
+    waitForRequestToTargetServer();
+
+    targetServer.verify(
+        1,
+        postRequestedFor(urlEqualTo("/callback"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(equalToJson("{ \"url\": \"/helpers\" }")));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -529,6 +529,18 @@ public class ResponseTemplateTransformerTest {
   }
 
   @Test
+  public void serveEventIdIsUsedAsTheRequestIdInTheTemplateModel() {
+    final String UUID_REGEX = "[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}";
+
+    ResponseDefinition transformedResponseDef =
+        transform(mockRequest().url("/things"), aResponse().withBody("{{request.id}}"));
+
+    String requestId = transformedResponseDef.getBody();
+    assertThat(requestId, notNullValue());
+    assertThat(requestId, matchesPattern(UUID_REGEX));
+  }
+
+  @Test
   public void trimContent() {
     String body =
         transform(


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR adds the unique serveEvent Id to the `request` template model and also exposes the same id in the webhook `originalRequest` template model.

## References

resolves https://github.com/wiremock/wiremock/issues/2756

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
