### PR TITLE
Fix race condition in getObjectStore

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/store/DefaultStores.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/DefaultStores.java
@@ -82,13 +82,7 @@ public class DefaultStores implements Stores {
   @Override
   public ObjectStore getObjectStore(String name, PersistenceType persistenceTypeHint) {
     if (persistenceTypeHint == EPHEMERAL) {
-      ObjectStore store = objectStores.get(name);
-      if (store == null) {
-        store = new InMemoryObjectStore(10000);
-        objectStores.putIfAbsent(name, store);
-      }
-
-      return store;
+      return objectStores.computeIfAbsent(name, n -> new InMemoryObjectStore(10000));
     } else {
       final FileSource child = fileRoot.child(name);
       return new FileSourceJsonObjectStore(child);


### PR DESCRIPTION
Previously getObjectStore was an unsynchronized check-then-act, with
the result of `putIfAbsent` ignored, so the returned store might not
even be the store kept in the objectStores map.

Using the atomic `computeIfAbsent` avoids this problem.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
