### PR TITLE
Allow configuring max items of an ObjectStore

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/store/DefaultStores.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/DefaultStores.java
@@ -80,9 +80,10 @@ public class DefaultStores implements Stores {
   }
 
   @Override
-  public ObjectStore getObjectStore(String name, PersistenceType persistenceTypeHint) {
+  public ObjectStore getObjectStore(
+      String name, PersistenceType persistenceTypeHint, int maxItems) {
     if (persistenceTypeHint == EPHEMERAL) {
-      return objectStores.computeIfAbsent(name, n -> new InMemoryObjectStore(10000));
+      return objectStores.computeIfAbsent(name, n -> new InMemoryObjectStore(maxItems));
     } else {
       final FileSource child = fileRoot.child(name);
       return new FileSourceJsonObjectStore(child);

--- a/src/main/java/com/github/tomakehurst/wiremock/store/Stores.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/Stores.java
@@ -52,5 +52,9 @@ public interface Stores extends StoresLifecycle {
     return getObjectStore(name, PersistenceType.EPHEMERAL);
   }
 
-  ObjectStore getObjectStore(String name, PersistenceType persistenceTypeHint);
+  default ObjectStore getObjectStore(String name, PersistenceType persistenceTypeHint) {
+    return getObjectStore(name, persistenceTypeHint, 10_000);
+  }
+
+  ObjectStore getObjectStore(String name, PersistenceType persistenceTypeHint, int maxSize);
 }


### PR DESCRIPTION
Previously it was hardcoded to 10,000, this PR allows clients of
`Stores` to specify any max size whilst maintaining backwards
compatibility by overloading the `getObjectStore` method.

Note that the maxItems parameter only affects an ephemeral object store
at present.

<!-- Please describe your pull request here. -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
