### PR TITLE
2759 report webhook errors and results as sub events

### DIFF
--- a/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -38,6 +38,8 @@ import java.util.concurrent.ScheduledExecutorService;
 @SuppressWarnings("deprecation") // maintaining PostServeAction for backwards compatibility
 public class Webhooks extends PostServeAction implements ServeEventListener {
 
+  private static final String WEBHOOK_REQUEST_SUB_EVENT_NAME = "WEBHOOK_REQUEST";
+
   private final ScheduledExecutorService scheduler;
   private final HttpClient httpClient;
   private final List<WebhookTransformer> transformers;
@@ -85,7 +87,7 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
       definition = applyTemplating(definition, serveEvent);
       request = buildRequest(definition);
 
-      serveEvent.appendSubEvent(SubEvent.INFO, LoggedRequest.createFrom(request));
+      serveEvent.appendSubEvent(WEBHOOK_REQUEST_SUB_EVENT_NAME, LoggedRequest.createFrom(request));
     } catch (Exception e) {
       final String msg = "Exception thrown while configuring webhook";
       notifier().error(msg, e);
@@ -106,7 +108,7 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
                     response.getStatus(),
                     response.getBodyAsString()));
             serveEvent.appendSubEvent(
-                SubEvent.INFO,
+                WEBHOOK_REQUEST_SUB_EVENT_NAME,
                 LoggedResponse.from(
                     response, this.dataTruncationSettings.getMaxResponseBodySize()));
           } catch (ProhibitedNetworkAddressException e) {

--- a/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -38,8 +38,6 @@ import java.util.concurrent.ScheduledExecutorService;
 @SuppressWarnings("deprecation") // maintaining PostServeAction for backwards compatibility
 public class Webhooks extends PostServeAction implements ServeEventListener {
 
-  private static final String WEBHOOK_REQUEST_SUB_EVENT_NAME = "WEBHOOK_REQUEST";
-
   private final ScheduledExecutorService scheduler;
   private final HttpClient httpClient;
   private final List<WebhookTransformer> transformers;
@@ -87,7 +85,7 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
       definition = applyTemplating(definition, serveEvent);
       request = buildRequest(definition);
 
-      serveEvent.appendSubEvent(WEBHOOK_REQUEST_SUB_EVENT_NAME, LoggedRequest.createFrom(request));
+      serveEvent.appendSubEvent("WEBHOOK_REQUEST", LoggedRequest.createFrom(request));
     } catch (Exception e) {
       final String msg = "Exception thrown while configuring webhook";
       notifier().error(msg, e);
@@ -108,7 +106,7 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
                     response.getStatus(),
                     response.getBodyAsString()));
             serveEvent.appendSubEvent(
-                WEBHOOK_REQUEST_SUB_EVENT_NAME,
+                "WEBHOOK_RESPONSE",
                 LoggedResponse.from(
                     response, this.dataTruncationSettings.getMaxResponseBodySize()));
           } catch (ProhibitedNetworkAddressException e) {

--- a/src/test/java/com/github/tomakehurst/wiremock/FailingWebhookTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/FailingWebhookTest.java
@@ -160,9 +160,6 @@ public class FailingWebhookTest extends WebhooksAcceptanceTest {
             "scheme", "http",
             "body", "{ \"result\": \"ERROR\" }");
     assertSubEvent(subEvents.get(0), SubEvent.INFO, expectedRequestEntries);
-    assertSubEvent(
-        subEvents.get(1),
-        SubEvent.ERROR,
-        "Failed to fire webhook POST http://localhost/callback-errors: Connect to http://localhost:80 [localhost/127.0.0.1] failed: Connection refused");
+    assertSubEvent(subEvents.get(1), SubEvent.ERROR, "Connection refused");
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/FailingWebhookTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/FailingWebhookTest.java
@@ -168,7 +168,7 @@ public class FailingWebhookTest extends WebhooksAcceptanceTest {
             "method", "POST",
             "scheme", "http",
             "body", "{ \"result\": \"ERROR\" }");
-    assertSubEvent(subEvents.get(0), SubEvent.INFO, expectedRequestEntries);
+    assertSubEvent(subEvents.get(0), WEBHOOK_SUB_EVENT_NAME, expectedRequestEntries);
     assertSubEvent(subEvents.get(1), SubEvent.ERROR, "Connection refused");
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/FailingWebhookTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/FailingWebhookTest.java
@@ -168,7 +168,7 @@ public class FailingWebhookTest extends WebhooksAcceptanceTest {
             "method", "POST",
             "scheme", "http",
             "body", "{ \"result\": \"ERROR\" }");
-    assertSubEvent(subEvents.get(0), WEBHOOK_SUB_EVENT_NAME, expectedRequestEntries);
+    assertSubEvent(subEvents.get(0), WEBHOOK_REQUEST_SUB_EVENT_NAME, expectedRequestEntries);
     assertSubEvent(subEvents.get(1), SubEvent.ERROR, "Connection refused");
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceTest.java
@@ -45,7 +45,13 @@ public class WebhooksAcceptanceTest {
     assertThat(subEvent, notNullValue());
     assertThat(subEvent.getType(), is(type));
     for (Map.Entry<String, Object> entry : data.entrySet()) {
-      assertThat(subEvent.getData(), hasEntry(entry.getKey(), entry.getValue()));
+      boolean hasEntry =
+          subEvent.getData().entrySet().stream()
+              .anyMatch(
+                  e ->
+                      e.getKey().equals(entry.getKey())
+                          && e.getValue().toString().contains(entry.getValue().toString()));
+      assertTrue(hasEntry);
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceTest.java
@@ -19,16 +19,16 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.SubEvent;
 import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 
@@ -37,17 +37,16 @@ public class WebhooksAcceptanceTest {
   protected CountDownLatch latch;
   protected TestNotifier testNotifier = new TestNotifier();
 
-  protected void assertSubEvent(List<ServeEvent> allServeEvents, String type, String message) {
-    assertSubEventContains(allServeEvents, type, List.of(message));
+  protected void assertSubEvent(SubEvent subEvent, String type, String message) {
+    assertSubEvent(subEvent, type, Map.of("message", message));
   }
 
-  protected void assertSubEventContains(
-      List<ServeEvent> allServeEvents, String type, List<String> messages) {
-    assertThat(allServeEvents.size(), greaterThanOrEqualTo(1));
-    SubEvent subEvent = allServeEvents.get(0).getSubEvents().stream().findFirst().orElse(null);
+  protected void assertSubEvent(SubEvent subEvent, String type, Map<String, Object> data) {
     assertThat(subEvent, notNullValue());
     assertThat(subEvent.getType(), is(type));
-    assertThat((String) subEvent.getData().get("message"), stringContainsInOrder(messages));
+    for (Map.Entry<String, Object> entry : data.entrySet()) {
+      assertThat(subEvent.getData(), hasEntry(entry.getKey(), entry.getValue()));
+    }
   }
 
   protected void assertErrorMessage(String expectedErrorMessage) {

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import com.github.tomakehurst.wiremock.stubbing.SubEvent;
+import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+
+public class WebhooksAcceptanceTest {
+
+  protected CountDownLatch latch;
+  protected TestNotifier testNotifier = new TestNotifier();
+
+  protected void assertSubEvent(List<ServeEvent> allServeEvents, String type, String message) {
+    assertSubEventContains(allServeEvents, type, List.of(message));
+  }
+
+  protected void assertSubEventContains(
+      List<ServeEvent> allServeEvents, String type, List<String> messages) {
+    assertThat(allServeEvents.size(), greaterThanOrEqualTo(1));
+    SubEvent subEvent = allServeEvents.get(0).getSubEvents().stream().findFirst().orElse(null);
+    assertThat(subEvent, notNullValue());
+    assertThat(subEvent.getType(), is(type));
+    assertThat((String) subEvent.getData().get("message"), stringContainsInOrder(messages));
+  }
+
+  protected void assertErrorMessage(String expectedErrorMessage) {
+    List<String> errorMessages =
+        await().until(() -> testNotifier.getErrorMessages(), hasSize(greaterThanOrEqualTo(1)));
+    assertThat(errorMessages.get(0), is(expectedErrorMessage));
+  }
+
+  protected void waitForRequestToTargetServer() throws Exception {
+    assertTrue(
+        latch.await(20, SECONDS), "Timed out waiting for target server to receive a request");
+  }
+
+  protected void printAllInfoNotifications() {
+    this.printAllNotifications("All info notifications", testNotifier.getInfoMessages());
+  }
+
+  protected void printAllErrorNotifications() {
+    this.printAllNotifications("All error notifications", testNotifier.getErrorMessages());
+  }
+
+  private void printAllNotifications(String msg, List<String> notifications) {
+    System.out.println(
+        msg
+            + ":\n"
+            + notifications.stream()
+                .map(message -> message.replace("\n", "\n>>> "))
+                .collect(Collectors.joining("\n>>> ")));
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceTest.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 
 public class WebhooksAcceptanceTest {
 
+  protected static final String WEBHOOK_SUB_EVENT_NAME = "WEBHOOK_REQUEST";
   protected CountDownLatch latch;
   protected TestNotifier testNotifier = new TestNotifier();
 

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceTest.java
@@ -34,7 +34,8 @@ import java.util.stream.Collectors;
 
 public class WebhooksAcceptanceTest {
 
-  protected static final String WEBHOOK_SUB_EVENT_NAME = "WEBHOOK_REQUEST";
+  protected static final String WEBHOOK_REQUEST_SUB_EVENT_NAME = "WEBHOOK_REQUEST";
+  protected static final String WEBHOOK_RESPONSE_SUB_EVENT_NAME = "WEBHOOK_RESPONSE";
   protected CountDownLatch latch;
   protected TestNotifier testNotifier = new TestNotifier();
 

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
@@ -159,9 +159,9 @@ public class WebhooksAcceptanceViaPostServeActionTest extends WebhooksAcceptance
             "host", "localhost",
             "scheme", "http",
             "body", "{ \"result\": \"SUCCESS\" }");
-    assertSubEvent(subEvents.get(0), SubEvent.INFO, expectedRequestEntries);
+    assertSubEvent(subEvents.get(0), WEBHOOK_SUB_EVENT_NAME, expectedRequestEntries);
     Map<String, Object> expectedResponseEntries = Map.of("status", 200, "body", "");
-    assertSubEvent(subEvents.get(1), SubEvent.INFO, expectedResponseEntries);
+    assertSubEvent(subEvents.get(1), WEBHOOK_SUB_EVENT_NAME, expectedResponseEntries);
   }
 
   @Test
@@ -405,7 +405,7 @@ public class WebhooksAcceptanceViaPostServeActionTest extends WebhooksAcceptance
             "method", "POST",
             "scheme", "http",
             "body", "{ \"result\": \"SUCCESS\" }");
-    assertSubEvent(subEvents.get(0), SubEvent.INFO, expectedRequestEntries);
+    assertSubEvent(subEvents.get(0), WEBHOOK_SUB_EVENT_NAME, expectedRequestEntries);
     assertSubEvent(subEvents.get(1), SubEvent.ERROR, expectedErrorMessage);
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
@@ -159,9 +159,9 @@ public class WebhooksAcceptanceViaPostServeActionTest extends WebhooksAcceptance
             "host", "localhost",
             "scheme", "http",
             "body", "{ \"result\": \"SUCCESS\" }");
-    assertSubEvent(subEvents.get(0), WEBHOOK_SUB_EVENT_NAME, expectedRequestEntries);
+    assertSubEvent(subEvents.get(0), WEBHOOK_REQUEST_SUB_EVENT_NAME, expectedRequestEntries);
     Map<String, Object> expectedResponseEntries = Map.of("status", 200, "body", "");
-    assertSubEvent(subEvents.get(1), WEBHOOK_SUB_EVENT_NAME, expectedResponseEntries);
+    assertSubEvent(subEvents.get(1), WEBHOOK_RESPONSE_SUB_EVENT_NAME, expectedResponseEntries);
   }
 
   @Test
@@ -405,7 +405,7 @@ public class WebhooksAcceptanceViaPostServeActionTest extends WebhooksAcceptance
             "method", "POST",
             "scheme", "http",
             "body", "{ \"result\": \"SUCCESS\" }");
-    assertSubEvent(subEvents.get(0), WEBHOOK_SUB_EVENT_NAME, expectedRequestEntries);
+    assertSubEvent(subEvents.get(0), WEBHOOK_REQUEST_SUB_EVENT_NAME, expectedRequestEntries);
     assertSubEvent(subEvents.get(1), SubEvent.ERROR, expectedErrorMessage);
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,9 @@ import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
-import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.waitAtMost;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.wiremock.webhooks.Webhooks.webhook;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -39,22 +37,19 @@ import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import com.github.tomakehurst.wiremock.stubbing.SubEvent;
 import com.github.tomakehurst.wiremock.testsupport.CompositeNotifier;
-import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.common.base.Stopwatch;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.stream.Collectors;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class WebhooksAcceptanceViaPostServeActionTest {
-
-  CountDownLatch latch;
+public class WebhooksAcceptanceViaPostServeActionTest extends WebhooksAcceptanceTest {
 
   @RegisterExtension
   public WireMockExtension targetServer =
@@ -79,7 +74,6 @@ public class WebhooksAcceptanceViaPostServeActionTest {
                   .notifier(new ConsoleNotifier("Target", true)))
           .build();
 
-  TestNotifier testNotifier = new TestNotifier();
   CompositeNotifier notifier =
       new CompositeNotifier(testNotifier, new ConsoleNotifier("Main", true));
   WireMockTestClient client;
@@ -99,7 +93,7 @@ public class WebhooksAcceptanceViaPostServeActionTest {
   @BeforeEach
   public void init() {
     testNotifier.reset();
-    targetServer.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200)));
+    targetServer.stubFor(any(anyUrl()).willReturn(ok()));
     latch = new CountDownLatch(1);
     client = new WireMockTestClient(rule.getPort());
     WireMock.configureFor(targetServer.getPort());
@@ -112,7 +106,7 @@ public class WebhooksAcceptanceViaPostServeActionTest {
   public void firesASingleWebhookWhenRequested() throws Exception {
     rule.stubFor(
         post(urlPathEqualTo("/something-async"))
-            .willReturn(aResponse().withStatus(200))
+            .willReturn(ok())
             .withPostServeAction(
                 "webhook",
                 webhook()
@@ -142,11 +136,7 @@ public class WebhooksAcceptanceViaPostServeActionTest {
             .values();
     assertThat(multiHeaderValues, hasItems("one", "two"));
 
-    System.out.println(
-        "All info notifications:\n"
-            + testNotifier.getInfoMessages().stream()
-                .map(message -> message.replace("\n", "\n>>> "))
-                .collect(Collectors.joining("\n>>> ")));
+    printAllInfoNotifications();
 
     waitAtMost(5, SECONDS)
         .until(
@@ -156,6 +146,11 @@ public class WebhooksAcceptanceViaPostServeActionTest {
                     containsString("Webhook POST request to"),
                     containsString("/callback returned status"),
                     containsString("200"))));
+
+    assertSubEventContains(
+        rule.getAllServeEvents(),
+        SubEvent.INFO,
+        List.of("Webhook POST request to", "/callback returned status", "200"));
   }
 
   @Test
@@ -365,11 +360,11 @@ public class WebhooksAcceptanceViaPostServeActionTest {
   }
 
   @Test
-  public void doesNotFireAWebhookWhenRequestedForDeniedTarget() throws Exception {
+  public void doesNotFireAWebhookWhenRequestedForDeniedTarget() {
     StubMapping stub =
         rule.stubFor(
             post(urlPathEqualTo("/webhook"))
-                .willReturn(aResponse().withStatus(200))
+                .willReturn(ok())
                 .withPostServeAction(
                     "webhook",
                     webhook()
@@ -381,24 +376,13 @@ public class WebhooksAcceptanceViaPostServeActionTest {
 
     client.post("/webhook", new StringEntity("", TEXT_PLAIN));
 
-    System.out.println(
-        "All info notifications:\n"
-            + testNotifier.getInfoMessages().stream()
-                .map(message -> message.replace("\n", "\n>>> "))
-                .collect(Collectors.joining("\n>>> ")));
+    printAllInfoNotifications();
 
-    List<String> errorMessages =
-        await().until(() -> testNotifier.getErrorMessages(), hasSize(greaterThanOrEqualTo(1)));
-    assertThat(
-        errorMessages.get(0),
-        is(
-            "The target webhook address http://169.254.2.34/foo specified by stub "
-                + stub.getId()
-                + " is denied in WireMock's configuration."));
-  }
-
-  private void waitForRequestToTargetServer() throws Exception {
-    assertTrue(
-        latch.await(20, SECONDS), "Timed out waiting for target server to receive a request");
+    final String expectedErrorMessage =
+        "The target webhook address http://169.254.2.34/foo specified by stub "
+            + stub.getId()
+            + " is denied in WireMock's configuration.";
+    assertErrorMessage(expectedErrorMessage);
+    assertSubEvent(rule.getAllServeEvents(), SubEvent.ERROR, expectedErrorMessage);
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
@@ -174,9 +174,9 @@ public class WebhooksAcceptanceViaServeEventTest extends WebhooksAcceptanceTest 
             "host", "localhost",
             "scheme", "http",
             "body", "{ \"result\": \"SUCCESS\" }");
-    assertSubEvent(subEvents.get(0), WEBHOOK_SUB_EVENT_NAME, expectedRequestEntries);
+    assertSubEvent(subEvents.get(0), WEBHOOK_REQUEST_SUB_EVENT_NAME, expectedRequestEntries);
     Map<String, Object> expectedResponseEntries = Map.of("status", 200, "body", "");
-    assertSubEvent(subEvents.get(1), WEBHOOK_SUB_EVENT_NAME, expectedResponseEntries);
+    assertSubEvent(subEvents.get(1), WEBHOOK_RESPONSE_SUB_EVENT_NAME, expectedResponseEntries);
   }
 
   @Test
@@ -482,7 +482,7 @@ public class WebhooksAcceptanceViaServeEventTest extends WebhooksAcceptanceTest 
             "method", "POST",
             "scheme", "http",
             "body", "{ \"result\": \"SUCCESS\" }");
-    assertSubEvent(subEvents.get(0), WEBHOOK_SUB_EVENT_NAME, expectedRequestEntries);
+    assertSubEvent(subEvents.get(0), WEBHOOK_REQUEST_SUB_EVENT_NAME, expectedRequestEntries);
     assertSubEvent(subEvents.get(1), SubEvent.ERROR, expectedErrorMessage);
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
@@ -174,9 +174,9 @@ public class WebhooksAcceptanceViaServeEventTest extends WebhooksAcceptanceTest 
             "host", "localhost",
             "scheme", "http",
             "body", "{ \"result\": \"SUCCESS\" }");
-    assertSubEvent(subEvents.get(0), SubEvent.INFO, expectedRequestEntries);
+    assertSubEvent(subEvents.get(0), WEBHOOK_SUB_EVENT_NAME, expectedRequestEntries);
     Map<String, Object> expectedResponseEntries = Map.of("status", 200, "body", "");
-    assertSubEvent(subEvents.get(1), SubEvent.INFO, expectedResponseEntries);
+    assertSubEvent(subEvents.get(1), WEBHOOK_SUB_EVENT_NAME, expectedResponseEntries);
   }
 
   @Test
@@ -482,7 +482,7 @@ public class WebhooksAcceptanceViaServeEventTest extends WebhooksAcceptanceTest 
             "method", "POST",
             "scheme", "http",
             "body", "{ \"result\": \"SUCCESS\" }");
-    assertSubEvent(subEvents.get(0), SubEvent.INFO, expectedRequestEntries);
+    assertSubEvent(subEvents.get(0), WEBHOOK_SUB_EVENT_NAME, expectedRequestEntries);
     assertSubEvent(subEvents.get(1), SubEvent.ERROR, expectedErrorMessage);
   }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR adds `INFO` sub events for the successful webhook request/response as well as `ERROR` sub events for any error conditions that occur. Requests and Responses are logged as a `LoggedRequest` and `LoggedResponse` where the `LoggedResponse` body limit is taken from the configured `maxLoggedResponseSize`

## References

impements https://github.com/wiremock/wiremock/issues/2759

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
