### PR TITLE
Path params and serve event ID in request

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -47,8 +47,8 @@ public interface Options {
   int DEFAULT_TIMEOUT = 300_000;
   int DEFAULT_CONTAINER_THREADS = 25;
   String DEFAULT_BIND_ADDRESS = "0.0.0.0";
-  int DEFAULT_MAX_PROXY_CLIENT_HTTP_CONNECTIONS = 1000;
-  boolean DEFAULT_DISABLE_PROXY_CLIENT_CONNECTION_REUSE = true;
+  int DEFAULT_MAX_HTTP_CONNECTIONS = 1000;
+  boolean DEFAULT_DISABLE_CONNECTION_REUSE = true;
   Long DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES = 1000L;
 
   int portNumber();
@@ -143,7 +143,7 @@ public interface Options {
 
   int proxyTimeout();
 
-  int getMaxProxyHttpClientConnections();
+  int getMaxHttpClientConnections();
 
   boolean getResponseTemplatingEnabled();
 
@@ -157,5 +157,5 @@ public interface Options {
 
   Set<String> getSupportedProxyEncodings();
 
-  boolean getDisableProxyClientConnectionReuse();
+  boolean getDisableConnectionReuse();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -141,8 +141,8 @@ public class WireMockConfiguration implements Options {
 
   private int proxyTimeout = DEFAULT_TIMEOUT;
 
-  private int maxProxyHttpClientConnections = DEFAULT_MAX_PROXY_CLIENT_HTTP_CONNECTIONS;
-  private boolean disableProxyClientConnectionReuse = DEFAULT_DISABLE_PROXY_CLIENT_CONNECTION_REUSE;
+  private int maxHttpClientConnections = DEFAULT_MAX_HTTP_CONNECTIONS;
+  private boolean disableConnectionReuse = DEFAULT_DISABLE_CONNECTION_REUSE;
 
   private boolean templatingEnabled = true;
   private boolean globalTemplating = false;
@@ -550,12 +550,12 @@ public class WireMockConfiguration implements Options {
   }
 
   public WireMockConfiguration maxHttpClientConnections(int maxHttpClientConnections) {
-    this.maxProxyHttpClientConnections = maxHttpClientConnections;
+    this.maxHttpClientConnections = maxHttpClientConnections;
     return this;
   }
 
   public WireMockConfiguration disableConnectionReuse(boolean disableConnectionReuse) {
-    this.disableProxyClientConnectionReuse = disableConnectionReuse;
+    this.disableConnectionReuse = disableConnectionReuse;
     return this;
   }
 
@@ -849,13 +849,13 @@ public class WireMockConfiguration implements Options {
   }
 
   @Override
-  public int getMaxProxyHttpClientConnections() {
-    return maxProxyHttpClientConnections;
+  public int getMaxHttpClientConnections() {
+    return maxHttpClientConnections;
   }
 
   @Override
-  public boolean getDisableProxyClientConnectionReuse() {
-    return disableProxyClientConnectionReuse;
+  public boolean getDisableConnectionReuse() {
+    return disableConnectionReuse;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestLine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
 import com.github.tomakehurst.wiremock.common.Urls;
-import com.github.tomakehurst.wiremock.common.url.PathTemplate;
+import com.github.tomakehurst.wiremock.common.url.PathParams;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
@@ -26,8 +26,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-@Deprecated
-/** @deprecated Use the accessors on {@link RequestTemplateModel} */
 public class RequestLine {
   private final RequestMethod method;
   private final String scheme;
@@ -37,7 +35,7 @@ public class RequestLine {
   private final String url;
   private final String clientIp;
 
-  private final PathTemplate pathTemplate;
+  private final PathParams pathParams;
 
   private RequestLine(
       RequestMethod method,
@@ -47,7 +45,7 @@ public class RequestLine {
       String url,
       String clientIp,
       Map<String, ListOrSingle<String>> query,
-      PathTemplate pathTemplate) {
+      PathParams pathParams) {
     this.method = method;
     this.scheme = scheme;
     this.host = host;
@@ -55,10 +53,10 @@ public class RequestLine {
     this.url = url;
     this.clientIp = clientIp;
     this.query = query;
-    this.pathTemplate = pathTemplate;
+    this.pathParams = pathParams;
   }
 
-  public static RequestLine fromRequest(final Request request, final PathTemplate pathTemplate) {
+  public static RequestLine fromRequest(final Request request) {
     URI url = URI.create(request.getUrl());
     Map<String, QueryParameter> rawQuery = Urls.splitQuery(url);
     Map<String, ListOrSingle<String>> adaptedQuery =
@@ -74,7 +72,7 @@ public class RequestLine {
         request.getUrl(),
         request.getClientIp(),
         adaptedQuery,
-        pathTemplate);
+        request.getPathParameters());
   }
 
   public RequestMethod getMethod() {
@@ -82,7 +80,7 @@ public class RequestLine {
   }
 
   public Object getPathSegments() {
-    return pathTemplate == null ? new UrlPath(url) : new TemplatedUrlPath(url, pathTemplate);
+    return pathParams.isEmpty() ? new UrlPath(url) : new TemplatedUrlPath(url, pathParams);
   }
 
   public String getPath() {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -16,13 +16,8 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
-import com.github.tomakehurst.wiremock.common.url.PathTemplate;
-import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import com.google.common.collect.Maps;
 import java.util.Map;
-import java.util.TreeMap;
 
 public class RequestTemplateModel {
 
@@ -45,39 +40,14 @@ public class RequestTemplateModel {
     this.body = body;
   }
 
-  public static RequestTemplateModel from(ServeEvent serveEvent) {
-    return from(
-        serveEvent.getId().toString(),
-        serveEvent.getRequest(),
-        serveEvent.getStubMapping().getRequest().getUrlMatcher().getPathTemplate());
-  }
-
-  public static RequestTemplateModel from(final Request request) {
-    return from(request, null);
-  }
-
-  public static RequestTemplateModel from(final Request request, final PathTemplate pathTemplate) {
-    return from(null, request, pathTemplate);
-  }
-
-  public static RequestTemplateModel from(
-      final String id, final Request request, final PathTemplate pathTemplate) {
-    RequestLine requestLine = RequestLine.fromRequest(request, pathTemplate);
-    Map<String, ListOrSingle<String>> adaptedHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    adaptedHeaders.putAll(
-        Maps.toMap(
-            request.getAllHeaderKeys(), input -> ListOrSingle.of(request.header(input).values())));
-    Map<String, ListOrSingle<String>> adaptedCookies =
-        Maps.transformValues(request.getCookies(), cookie -> ListOrSingle.of(cookie.getValues()));
-
-    return new RequestTemplateModel(
-        id, requestLine, adaptedHeaders, adaptedCookies, request.getBodyAsString());
-  }
-
   public String getId() {
     return id;
   }
 
+  @Deprecated
+  /**
+   * @deprecated Use the direct accessors
+   */
   public RequestLine getRequestLine() {
     return requestLine;
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -27,12 +27,10 @@ import com.github.jknack.handlebars.helper.ConditionalHelpers;
 import com.github.jknack.handlebars.helper.NumberHelper;
 import com.github.jknack.handlebars.helper.StringHelpers;
 import com.github.tomakehurst.wiremock.common.Exceptions;
-import com.github.tomakehurst.wiremock.common.url.PathTemplate;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.TemplateModelDataProviderExtension;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.SystemValueHelper;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.WireMockHelpers;
-import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.google.common.cache.Cache;
@@ -131,13 +129,9 @@ public class TemplateEngine {
   }
 
   public Map<String, Object> buildModelForRequest(ServeEvent serveEvent) {
-    final Request request = serveEvent.getRequest();
     final ResponseDefinition responseDefinition = serveEvent.getResponseDefinition();
     final Parameters parameters =
         getFirstNonNull(responseDefinition.getTransformerParameters(), Parameters.empty());
-
-    final PathTemplate pathTemplate =
-        serveEvent.getStubMapping().getRequest().getUrlMatcher().getPathTemplate();
 
     final Map<String, Object> additionalModelData =
         templateModelDataProviders.stream()
@@ -147,7 +141,7 @@ public class TemplateEngine {
 
     final Map<String, Object> model = new HashMap<>();
     model.put("parameters", parameters);
-    model.put("request", RequestTemplateModel.from(request, pathTemplate));
+    model.put("request", RequestTemplateModel.from(serveEvent));
     model.putAll(additionalModelData);
     return model;
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -33,7 +33,6 @@ import com.github.tomakehurst.wiremock.extension.TemplateModelDataProviderExtens
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.SystemValueHelper;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.WireMockHelpers;
 import com.github.tomakehurst.wiremock.http.Request;
-import com.github.tomakehurst.wiremock.http.RequestPathParamsDecorator;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.google.common.cache.Cache;
@@ -148,9 +147,7 @@ public class TemplateEngine {
   }
 
   private static RequestTemplateModel buildRequestModel(ServeEvent serveEvent) {
-    final Request request =
-        RequestPathParamsDecorator.decorate(
-            serveEvent.getRequest(), serveEvent.getStubMapping().getRequest());
+    final Request request = serveEvent.getRequest();
     RequestLine requestLine = RequestLine.fromRequest(request);
     Map<String, ListOrSingle<String>> adaptedHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     adaptedHeaders.putAll(

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -146,6 +146,12 @@ public class TemplateEngine {
     return model;
   }
 
+  public Map<String, Object> buildModelForRequest(Request request) {
+    final Map<String, Object> model = new HashMap<>();
+    model.put("request", buildRequestModel(request));
+    return model;
+  }
+
   private static RequestTemplateModel buildRequestModel(Request request) {
     RequestLine requestLine = RequestLine.fromRequest(request);
     Map<String, ListOrSingle<String>> adaptedHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -141,13 +141,12 @@ public class TemplateEngine {
 
     final Map<String, Object> model = new HashMap<>();
     model.put("parameters", parameters);
-    model.put("request", buildRequestModel(serveEvent));
+    model.put("request", buildRequestModel(serveEvent.getRequest()));
     model.putAll(additionalModelData);
     return model;
   }
 
-  private static RequestTemplateModel buildRequestModel(ServeEvent serveEvent) {
-    final Request request = serveEvent.getRequest();
+  private static RequestTemplateModel buildRequestModel(Request request) {
     RequestLine requestLine = RequestLine.fromRequest(request);
     Map<String, ListOrSingle<String>> adaptedHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     adaptedHeaders.putAll(
@@ -157,7 +156,7 @@ public class TemplateEngine {
         Maps.transformValues(request.getCookies(), cookie -> ListOrSingle.of(cookie.getValues()));
 
     return new RequestTemplateModel(
-        serveEvent.getId().toString(),
+        request.getId() != null ? request.getId().toString() : null,
         requestLine,
         adaptedHeaders,
         adaptedCookies,

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplatedUrlPath.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplatedUrlPath.java
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating;
 import static com.github.tomakehurst.wiremock.common.Strings.isNotEmpty;
 
 import com.github.tomakehurst.wiremock.common.Urls;
-import com.github.tomakehurst.wiremock.common.url.PathTemplate;
+import com.github.tomakehurst.wiremock.common.url.PathParams;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -27,10 +27,10 @@ public class TemplatedUrlPath extends LinkedHashMap<String, String> implements I
 
   private final String originalPath;
 
-  public TemplatedUrlPath(String url, PathTemplate pathTemplate) {
+  public TemplatedUrlPath(String url, PathParams pathParams) {
     this.originalPath = Urls.getPath(url);
     addAllPathSegments();
-    putAll(pathTemplate.parse(originalPath));
+    putAll(pathParams);
   }
 
   private void addAllPathSegments() {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -21,8 +21,15 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 public interface Request {
+
+  // This is populated by the serve event.
+  @JsonIgnore
+  default UUID getId() {
+    return null;
+  }
 
   interface Part {
     String getName();

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.tomakehurst.wiremock.common.url.PathParams;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -57,6 +59,12 @@ public interface Request {
   boolean containsHeader(String key);
 
   Set<String> getAllHeaderKeys();
+
+  // These are calculated from other fields so should not be serialised
+  @JsonIgnore
+  default PathParams getPathParameters() {
+    return PathParams.empty();
+  }
 
   QueryParameter queryParameter(String key);
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/RequestIdDecorator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/RequestIdDecorator.java
@@ -15,33 +15,27 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.tomakehurst.wiremock.common.url.PathParams;
-import com.github.tomakehurst.wiremock.common.url.PathTemplate;
-import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-public class RequestPathParamsDecorator implements Request {
+public class RequestIdDecorator implements Request {
 
   private final Request request;
-  private final PathTemplate pathTemplate;
+  private final UUID id;
 
-  public static Request decorate(Request request, RequestPattern requestPattern) {
-    final PathTemplate pathTemplate = requestPattern.getUrlMatcher().getPathTemplate();
-    return pathTemplate != null ? new RequestPathParamsDecorator(request, pathTemplate) : request;
-  }
-
-  public RequestPathParamsDecorator(Request request, PathTemplate pathTemplate) {
+  public RequestIdDecorator(Request request, UUID id) {
     this.request = request;
-    this.pathTemplate = pathTemplate;
+    this.id = id;
   }
 
   @Override
   public UUID getId() {
-    return request.getId();
+    return id;
   }
 
   @Override
@@ -110,8 +104,9 @@ public class RequestPathParamsDecorator implements Request {
   }
 
   @Override
+  @JsonIgnore
   public PathParams getPathParameters() {
-    return pathTemplate.parse(getUrl());
+    return request.getPathParameters();
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/http/RequestPathParamsDecorator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/RequestPathParamsDecorator.java
@@ -105,11 +105,7 @@ public class RequestPathParamsDecorator implements Request {
 
   @Override
   public PathParams getPathParameters() {
-    return getPathTemplate().map(template -> template.parse(getUrl())).orElse(PathParams.empty());
-  }
-
-  private Optional<PathTemplate> getPathTemplate() {
-    return Optional.of(pathTemplate);
+    return pathTemplate.parse(getUrl());
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/http/RequestPathParamsDecorator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/RequestPathParamsDecorator.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http;
+
+import com.github.tomakehurst.wiremock.common.url.PathParams;
+import com.github.tomakehurst.wiremock.common.url.PathTemplate;
+import com.github.tomakehurst.wiremock.matching.RequestPattern;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class RequestPathParamsDecorator implements Request {
+
+  private final Request request;
+  private final PathTemplate pathTemplate;
+
+  public static Request decorate(Request request, RequestPattern requestPattern) {
+    final PathTemplate pathTemplate = requestPattern.getUrlMatcher().getPathTemplate();
+    return pathTemplate != null ? new RequestPathParamsDecorator(request, pathTemplate) : request;
+  }
+
+  public RequestPathParamsDecorator(Request request, PathTemplate pathTemplate) {
+    this.request = request;
+    this.pathTemplate = pathTemplate;
+  }
+
+  @Override
+  public String getUrl() {
+    return request.getUrl();
+  }
+
+  @Override
+  public String getAbsoluteUrl() {
+    return request.getAbsoluteUrl();
+  }
+
+  @Override
+  public RequestMethod getMethod() {
+    return request.getMethod();
+  }
+
+  @Override
+  public String getScheme() {
+    return request.getScheme();
+  }
+
+  @Override
+  public String getHost() {
+    return request.getHost();
+  }
+
+  @Override
+  public int getPort() {
+    return request.getPort();
+  }
+
+  @Override
+  public String getClientIp() {
+    return request.getClientIp();
+  }
+
+  @Override
+  public String getHeader(String key) {
+    return request.getHeader(key);
+  }
+
+  @Override
+  public HttpHeader header(String key) {
+    return request.header(key);
+  }
+
+  @Override
+  public ContentTypeHeader contentTypeHeader() {
+    return request.contentTypeHeader();
+  }
+
+  @Override
+  public HttpHeaders getHeaders() {
+    return request.getHeaders();
+  }
+
+  @Override
+  public boolean containsHeader(String key) {
+    return request.containsHeader(key);
+  }
+
+  @Override
+  public Set<String> getAllHeaderKeys() {
+    return request.getAllHeaderKeys();
+  }
+
+  @Override
+  public PathParams getPathParameters() {
+    return getPathTemplate().map(template -> template.parse(getUrl())).orElse(PathParams.empty());
+  }
+
+  private Optional<PathTemplate> getPathTemplate() {
+    return Optional.of(pathTemplate);
+  }
+
+  @Override
+  public QueryParameter queryParameter(String key) {
+    return request.queryParameter(key);
+  }
+
+  @Override
+  public FormParameter formParameter(String key) {
+    return request.formParameter(key);
+  }
+
+  @Override
+  public Map<String, FormParameter> formParameters() {
+    return request.formParameters();
+  }
+
+  @Override
+  public Map<String, Cookie> getCookies() {
+    return request.getCookies();
+  }
+
+  @Override
+  public byte[] getBody() {
+    return request.getBody();
+  }
+
+  @Override
+  public String getBodyAsString() {
+    return request.getBodyAsString();
+  }
+
+  @Override
+  public String getBodyAsBase64() {
+    return request.getBodyAsBase64();
+  }
+
+  @Override
+  public boolean isMultipart() {
+    return request.isMultipart();
+  }
+
+  @Override
+  public Collection<Part> getParts() {
+    return request.getParts();
+  }
+
+  @Override
+  public Part getPart(String name) {
+    return request.getPart(name);
+  }
+
+  @Override
+  public boolean isBrowserProxyRequest() {
+    return request.isBrowserProxyRequest();
+  }
+
+  @Override
+  public Optional<Request> getOriginalRequest() {
+    return request.getOriginalRequest();
+  }
+
+  @Override
+  public String getProtocol() {
+    return request.getProtocol();
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
@@ -29,7 +29,7 @@ public class ApacheHttpClientFactory implements HttpClientFactory {
       boolean useSystemProperties) {
     final CloseableHttpClient apacheClient =
         com.github.tomakehurst.wiremock.http.HttpClientFactory.createClient(
-            options.getMaxProxyHttpClientConnections(),
+            options.getMaxHttpClientConnections(),
             options.proxyTimeout(),
             options.proxyVia(),
             options.httpsSettings().trustStore(),
@@ -37,7 +37,7 @@ public class ApacheHttpClientFactory implements HttpClientFactory {
             trustedHosts,
             useSystemProperties,
             options.getProxyTargetRules(),
-            options.getDisableProxyClientConnectionReuse());
+            options.getDisableConnectionReuse());
 
     return new ApacheBackedHttpClient(apacheClient, options.shouldPreserveUserAgentProxyHeader());
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -35,6 +35,7 @@ import com.github.tomakehurst.wiremock.common.url.PathTemplate;
 import com.github.tomakehurst.wiremock.http.Cookie;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.http.RequestPathParamsDecorator;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import java.util.*;
 import java.util.function.Function;
@@ -244,6 +245,7 @@ public class RequestPattern implements NamedValueMatcher<Request> {
   }
 
   public MatchResult match(Request request, Map<String, RequestMatcherExtension> customMatchers) {
+    request = RequestPathParamsDecorator.decorate(request, this);
     final MatchResult standardMatchResult = matcher.match(request);
     if (standardMatchResult.isExactMatch() && customMatcherDefinition != null) {
       RequestMatcherExtension requestMatcher =

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -267,13 +267,13 @@ public class WarConfiguration implements Options {
   }
 
   @Override
-  public int getMaxProxyHttpClientConnections() {
-    return DEFAULT_MAX_PROXY_CLIENT_HTTP_CONNECTIONS;
+  public int getMaxHttpClientConnections() {
+    return DEFAULT_MAX_HTTP_CONNECTIONS;
   }
 
   @Override
-  public boolean getDisableProxyClientConnectionReuse() {
-    return DEFAULT_DISABLE_PROXY_CLIENT_CONNECTION_REUSE;
+  public boolean getDisableConnectionReuse() {
+    return DEFAULT_DISABLE_CONNECTION_REUSE;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -126,10 +126,8 @@ public class CommandLineOptions implements Options {
   private static final String ALLOW_PROXY_TARGETS = "allow-proxy-targets";
   private static final String DENY_PROXY_TARGETS = "deny-proxy-targets";
   private static final String PROXY_TIMEOUT = "proxy-timeout";
-  private static final String MAX_PROXY_HTTP_CLIENT_CONNECTIONS =
-      "max-proxy-http-client-connections";
-  private static final String DISABLE_PROXY_CLIENT_CONNECTION_REUSE =
-      "disable-proxy-client-connection-reuse";
+  private static final String MAX_HTTP_CLIENT_CONNECTIONS = "max-http-client-connections";
+  private static final String DISABLE_CONNECTION_REUSE = "disable-connection-reuse";
   private static final String PROXY_PASS_THROUGH = "proxy-pass-through";
   private static final String SUPPORTED_PROXY_ENCODINGS = "supported-proxy-encodings";
 
@@ -387,14 +385,10 @@ public class CommandLineOptions implements Options {
         .accepts(PROXY_PASS_THROUGH, "Flag to control browser proxy pass through")
         .withRequiredArg();
     optionParser
-        .accepts(
-            MAX_PROXY_HTTP_CLIENT_CONNECTIONS,
-            "Maximum total connections for the proxy HTTP client")
+        .accepts(MAX_HTTP_CLIENT_CONNECTIONS, "Maximum connections for Http Client")
         .withRequiredArg();
     optionParser
-        .accepts(
-            DISABLE_PROXY_CLIENT_CONNECTION_REUSE,
-            "Disable connection reuse for the proxy client. Defaults to true.")
+        .accepts(DISABLE_CONNECTION_REUSE, "Disable http connection reuse")
         .withRequiredArg();
     optionParser
         .accepts(
@@ -999,10 +993,10 @@ public class CommandLineOptions implements Options {
   }
 
   @Override
-  public int getMaxProxyHttpClientConnections() {
-    return optionSet.has(MAX_PROXY_HTTP_CLIENT_CONNECTIONS)
-        ? Integer.parseInt((String) optionSet.valueOf(MAX_PROXY_HTTP_CLIENT_CONNECTIONS))
-        : DEFAULT_MAX_PROXY_CLIENT_HTTP_CONNECTIONS;
+  public int getMaxHttpClientConnections() {
+    return optionSet.has(MAX_HTTP_CLIENT_CONNECTIONS)
+        ? Integer.parseInt((String) optionSet.valueOf(MAX_HTTP_CLIENT_CONNECTIONS))
+        : DEFAULT_MAX_HTTP_CONNECTIONS;
   }
 
   @Override
@@ -1053,9 +1047,9 @@ public class CommandLineOptions implements Options {
   }
 
   @Override
-  public boolean getDisableProxyClientConnectionReuse() {
-    return optionSet.has(DISABLE_PROXY_CLIENT_CONNECTION_REUSE)
-        ? Boolean.parseBoolean((String) optionSet.valueOf(DISABLE_PROXY_CLIENT_CONNECTION_REUSE))
-        : DEFAULT_DISABLE_PROXY_CLIENT_CONNECTION_REUSE;
+  public boolean getDisableConnectionReuse() {
+    return optionSet.has(DISABLE_CONNECTION_REUSE)
+        ? Boolean.parseBoolean((String) optionSet.valueOf(DISABLE_CONNECTION_REUSE))
+        : DEFAULT_DISABLE_CONNECTION_REUSE;
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/store/StubMappingStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/StubMappingStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Thomas Akehurst
+ * Copyright (C) 2022-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/AbstractStubMappings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/AbstractStubMappings.java
@@ -71,7 +71,8 @@ public abstract class AbstractStubMappings implements StubMappings {
   }
 
   @Override
-  public ServeEvent serveFor(final ServeEvent initialServeEvent) {
+  public ServeEvent serveFor(ServeEvent initialServeEvent) {
+    initialServeEvent = initialServeEvent.withIdDecoratedRequest();
     final LoggedRequest request = initialServeEvent.getRequest();
 
     final List<SubEvent> subEvents = new LinkedList<>();

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/AbstractStubMappings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/AbstractStubMappings.java
@@ -94,7 +94,8 @@ public abstract class AbstractStubMappings implements StubMappings {
     ServeEvent serveEvent =
         initialServeEvent
             .withStubMapping(matchingStub)
-            .withResponseDefinition(initialResponseDefinition);
+            .withResponseDefinition(initialResponseDefinition)
+            .withPathParamDecoratedRequest();
 
     triggerListeners(serveEventListeners, AFTER_MATCH, serveEvent);
 

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
@@ -131,6 +131,13 @@ public class ServeEvent {
         id, newLoggedRequest, stubMapping, responseDefinition, response, false, timing, subEvents);
   }
 
+  public ServeEvent withIdDecoratedRequest() {
+    final LoggedRequest newLoggedRequest =
+        LoggedRequest.createFrom(new RequestIdDecorator(request, id));
+    return new ServeEvent(
+        id, newLoggedRequest, stubMapping, responseDefinition, response, false, timing, subEvents);
+  }
+
   public ServeEvent complete(Response response, DataTruncationSettings dataTruncationSettings) {
     timing.logProcessTime(stopwatch);
     timing.setAddedTime((int) response.getInitialDelay());

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
@@ -124,9 +124,11 @@ public class ServeEvent {
   }
 
   public ServeEvent withPathParamDecoratedRequest() {
-    final LoggedRequest newLoggedRequest = LoggedRequest.createFrom(RequestPathParamsDecorator.decorate(request, stubMapping.getRequest()));
+    final LoggedRequest newLoggedRequest =
+        LoggedRequest.createFrom(
+            RequestPathParamsDecorator.decorate(request, stubMapping.getRequest()));
     return new ServeEvent(
-            id, newLoggedRequest, stubMapping, responseDefinition, response, false, timing, subEvents);
+        id, newLoggedRequest, stubMapping, responseDefinition, response, false, timing, subEvents);
   }
 
   public ServeEvent complete(Response response, DataTruncationSettings dataTruncationSettings) {

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
@@ -26,10 +26,7 @@ import com.github.tomakehurst.wiremock.common.Timing;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.PostServeActionDefinition;
 import com.github.tomakehurst.wiremock.extension.ServeEventListenerDefinition;
-import com.github.tomakehurst.wiremock.http.LoggedResponse;
-import com.github.tomakehurst.wiremock.http.Request;
-import com.github.tomakehurst.wiremock.http.Response;
-import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.common.base.Stopwatch;
 import java.util.*;
@@ -124,6 +121,12 @@ public class ServeEvent {
   public ServeEvent withResponseDefinition(ResponseDefinition responseDefinition) {
     return new ServeEvent(
         id, request, stubMapping, responseDefinition, response, false, timing, subEvents);
+  }
+
+  public ServeEvent withPathParamDecoratedRequest() {
+    final LoggedRequest newLoggedRequest = LoggedRequest.createFrom(RequestPathParamsDecorator.decorate(request, stubMapping.getRequest()));
+    return new ServeEvent(
+            id, newLoggedRequest, stubMapping, responseDefinition, response, false, timing, subEvents);
   }
 
   public ServeEvent complete(Response response, DataTruncationSettings dataTruncationSettings) {

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -38,6 +38,7 @@ import java.util.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class LoggedRequest implements Request {
 
+  private final UUID id;
   private final String scheme;
   private final String host;
   private final int port;
@@ -61,6 +62,7 @@ public class LoggedRequest implements Request {
 
   public static LoggedRequest createFrom(Request request) {
     return new LoggedRequest(
+        request.getId(),
         request.getScheme(),
         request.getHost(),
         request.getPort(),
@@ -97,6 +99,7 @@ public class LoggedRequest implements Request {
         null,
         null,
         null,
+        null,
         url,
         absoluteUrl,
         method,
@@ -113,6 +116,7 @@ public class LoggedRequest implements Request {
   }
 
   private LoggedRequest(
+      UUID id,
       String scheme,
       String host,
       Integer port,
@@ -129,6 +133,7 @@ public class LoggedRequest implements Request {
       Collection<Part> multiparts,
       String protocol,
       Map<String, FormParameter> formParameters) {
+    this.id = id;
     this.url = url;
 
     this.absoluteUrl = absoluteUrl;
@@ -158,6 +163,11 @@ public class LoggedRequest implements Request {
 
     lazyBodyAsString = lazy(() -> stringFromBytes(body, encodingFromContentTypeHeaderOrUtf8()));
     lazyBodyAsBase64 = lazy(() -> encodeBase64(body));
+  }
+
+  @Override
+  public UUID getId() {
+    return id;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -29,6 +29,7 @@ import com.github.tomakehurst.wiremock.common.Dates;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Lazy;
 import com.github.tomakehurst.wiremock.common.Urls;
+import com.github.tomakehurst.wiremock.common.url.PathParams;
 import com.github.tomakehurst.wiremock.http.*;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -45,6 +46,7 @@ public class LoggedRequest implements Request {
   private final String clientIp;
   private final RequestMethod method;
   private final HttpHeaders headers;
+  private final PathParams pathParams;
   private final Map<String, Cookie> cookies;
   private final Map<String, QueryParameter> queryParams;
   private final Map<String, FormParameter> formParameters;
@@ -67,6 +69,7 @@ public class LoggedRequest implements Request {
         request.getMethod(),
         request.getClientIp(),
         request.getHeaders(),
+        request.getPathParameters(),
         request.getCookies(),
         request.isBrowserProxyRequest(),
         new Date(),
@@ -99,6 +102,7 @@ public class LoggedRequest implements Request {
         method,
         clientIp,
         headers,
+        PathParams.empty(),
         cookies,
         isBrowserProxyRequest,
         loggedDate,
@@ -117,6 +121,7 @@ public class LoggedRequest implements Request {
       RequestMethod method,
       String clientIp,
       HttpHeaders headers,
+      PathParams pathParams,
       Map<String, Cookie> cookies,
       boolean isBrowserProxyRequest,
       Date loggedDate,
@@ -142,6 +147,7 @@ public class LoggedRequest implements Request {
     this.method = method;
     this.body = body;
     this.headers = headers;
+    this.pathParams = pathParams;
     this.cookies = cookies;
     this.queryParams = url != null ? splitQueryFromUrl(url) : Collections.emptyMap();
     this.formParameters = formParameters;
@@ -224,6 +230,12 @@ public class LoggedRequest implements Request {
   @Override
   public boolean containsHeader(String key) {
     return getHeader(key) != null;
+  }
+
+  @JsonIgnore
+  @Override
+  public PathParams getPathParameters() {
+    return pathParams;
   }
 
   @Override

--- a/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -26,7 +26,6 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.extension.ServeEventListener;
 import com.github.tomakehurst.wiremock.extension.WireMockServices;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.RequestTemplateModel;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.http.client.HttpClient;
@@ -122,13 +121,15 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
   private WebhookDefinition applyTemplating(
       WebhookDefinition webhookDefinition, ServeEvent serveEvent) {
 
-    final Map<String, Object> model = new HashMap<>();
+    final Map<String, Object> model =
+        new HashMap<>(this.templateEngine.buildModelForRequest(serveEvent));
     model.put(
         "parameters",
         webhookDefinition.getExtraParameters() != null
             ? webhookDefinition.getExtraParameters()
             : Collections.<String, Object>emptyMap());
-    model.put("originalRequest", RequestTemplateModel.from(serveEvent.getRequest()));
+    model.put("originalRequest", model.get("request"));
+    model.remove("request");
 
     WebhookDefinition renderedWebhookDefinition =
         webhookDefinition

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,16 +35,19 @@ import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
+import com.github.tomakehurst.wiremock.extension.TemplateModelDataProviderExtension;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.CompositeNotifier;
 import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.common.base.Stopwatch;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import org.apache.hc.core5.http.io.entity.StringEntity;
@@ -90,6 +93,19 @@ public class WebhooksAcceptanceViaServeEventTest {
           .options(
               options()
                   .dynamicPort()
+                  .extensions(
+                      new TemplateModelDataProviderExtension() {
+                        @Override
+                        public Map<String, Object> provideTemplateModelData(ServeEvent serveEvent) {
+                          return Map.of(
+                              "customData", Map.of("path", serveEvent.getRequest().getUrl()));
+                        }
+
+                        @Override
+                        public String getName() {
+                          return "custom-model-data";
+                        }
+                      })
                   .notifier(notifier)
                   .limitProxyTargets(
                       NetworkAddressRules.builder().deny("169.254.0.0-169.254.255.255").build()))
@@ -156,6 +172,59 @@ public class WebhooksAcceptanceViaServeEventTest {
                     containsString("Webhook POST request to"),
                     containsString("/callback returned status"),
                     containsString("200"))));
+  }
+
+  @Test
+  public void originalRequestIdIsTheSameAsRequestId() throws Exception {
+    rule.stubFor(
+        post("/request-id")
+            .willReturn(ok("{{request.id}}").withTransformers("response-template"))
+            .withServeEventListener(
+                "webhook",
+                webhook()
+                    .withMethod(POST)
+                    .withUrl(targetServer.url("/callback"))
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{ \"requestId\": \"{{originalRequest.id}}\" }")));
+
+    verify(0, postRequestedFor(anyUrl()));
+
+    WireMockResponse response = client.post("/request-id", new StringEntity("", TEXT_PLAIN));
+    String requestId = response.content();
+
+    waitForRequestToTargetServer();
+
+    targetServer.verify(
+        1,
+        postRequestedFor(urlEqualTo("/callback"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(equalToJson("{ \"requestId\": \"" + requestId + "\" }")));
+  }
+
+  @Test
+  public void webhooksHaveAccessToTemplateModelDataProviders() throws Exception {
+    rule.stubFor(
+        post("/helpers")
+            .willReturn(ok("{{request.id}}").withTransformers("response-template"))
+            .withServeEventListener(
+                "webhook",
+                webhook()
+                    .withMethod(POST)
+                    .withUrl(targetServer.url("/callback"))
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{ \"url\": \"{{ customData.path }}\" }")));
+
+    verify(0, postRequestedFor(anyUrl()));
+
+    client.post("/helpers", new StringEntity("", TEXT_PLAIN));
+
+    waitForRequestToTargetServer();
+
+    targetServer.verify(
+        1,
+        postRequestedFor(urlEqualTo("/callback"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(equalToJson("{ \"url\": \"/helpers\" }")));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -40,6 +40,7 @@ import java.time.temporal.TemporalAdjusters;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -529,15 +530,15 @@ public class ResponseTemplateTransformerTest {
   }
 
   @Test
-  public void serveEventIdIsUsedAsTheRequestIdInTheTemplateModel() {
-    final String UUID_REGEX = "[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}";
+  public void requestIdIsAvailableIdInTheTemplateModel() {
+    final UUID id = UUID.randomUUID();
 
     ResponseDefinition transformedResponseDef =
-        transform(mockRequest().url("/things"), aResponse().withBody("{{request.id}}"));
+        transform(mockRequest().url("/things").id(id), aResponse().withBody("{{request.id}}"));
 
     String requestId = transformedResponseDef.getBody();
     assertThat(requestId, notNullValue());
-    assertThat(requestId, matchesPattern(UUID_REGEX));
+    assertThat(requestId, is(id.toString()));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -529,6 +529,18 @@ public class ResponseTemplateTransformerTest {
   }
 
   @Test
+  public void serveEventIdIsUsedAsTheRequestIdInTheTemplateModel() {
+    final String UUID_REGEX = "[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}";
+
+    ResponseDefinition transformedResponseDef =
+        transform(mockRequest().url("/things"), aResponse().withBody("{{request.id}}"));
+
+    String requestId = transformedResponseDef.getBody();
+    assertThat(requestId, notNullValue());
+    assertThat(requestId, matchesPattern(UUID_REGEX));
+  }
+
+  @Test
   public void trimContent() {
     String body =
         transform(

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
@@ -31,6 +31,8 @@ import java.util.*;
 
 public class MockRequest implements Request {
 
+  private UUID id = UUID.randomUUID();
+
   private String scheme = "http";
   private String host = "my.domain";
   private int port = 80;
@@ -52,6 +54,11 @@ public class MockRequest implements Request {
 
   public static MockRequest mockRequest() {
     return new MockRequest();
+  }
+
+  public MockRequest id(UUID id) {
+    this.id = id;
+    return this;
   }
 
   public MockRequest scheme(String scheme) {
@@ -143,6 +150,11 @@ public class MockRequest implements Request {
   public MockRequest protocol(String protocol) {
     this.protocol = protocol;
     return this;
+  }
+
+  @Override
+  public UUID getId() {
+    return id;
   }
 
   @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -840,24 +840,21 @@ public class CommandLineOptionsTest {
 
   @Test
   void testMaxHttpClientConnectionsOption() {
-    CommandLineOptions options =
-        new CommandLineOptions("--max-proxy-http-client-connections", "5000");
+    CommandLineOptions options = new CommandLineOptions("--max-http-client-connections", "5000");
 
-    assertThat(options.getMaxProxyHttpClientConnections(), is(5000));
+    assertThat(options.getMaxHttpClientConnections(), is(5000));
   }
 
   @Test
   void testDisableConnectionReuseOptionPassedAsFalse() {
-    CommandLineOptions options =
-        new CommandLineOptions("--disable-proxy-client-connection-reuse", "false");
-    assertFalse(options.getDisableProxyClientConnectionReuse());
+    CommandLineOptions options = new CommandLineOptions("--disable-connection-reuse", "false");
+    assertFalse(options.getDisableConnectionReuse());
   }
 
   @Test
   void testDisableConnectionReuseOptionPassedAsTrue() {
-    CommandLineOptions options =
-        new CommandLineOptions("--disable-proxy-client-connection-reuse", "true");
-    assertTrue(options.getDisableProxyClientConnectionReuse());
+    CommandLineOptions options = new CommandLineOptions("--disable-connection-reuse", "true");
+    assertTrue(options.getDisableConnectionReuse());
   }
 
   public static class ResponseDefinitionTransformerExt1 extends ResponseDefinitionTransformer {


### PR DESCRIPTION
Add path parameters to the request object via decoration when possible i.e. when we know which stub we're trying to match against (and can thus get at the path parameters).

Also add the serve event ID to the request so that this can be utilised in the template model.