### PR TITLE
Stop ejecting existing key on read of missing key

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStoreTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStoreTest.java
@@ -99,4 +99,19 @@ public class InMemoryObjectStoreTest {
 
     assertThat(store.getAllKeys().count(), is(0L));
   }
+
+  @Test
+  void tryingToRetrieveMissingKeyDoesNotEjectOtherKeys() {
+    InMemoryObjectStore store = new InMemoryObjectStore(3);
+
+    store.put("one", "1");
+    store.put("two", "2");
+    store.put("three", "3");
+
+    assertThat(store.getAllKeys().count(), is(3L));
+
+    store.get("four");
+
+    assertThat(store.getAllKeys().count(), is(3L));
+  }
 }


### PR DESCRIPTION
On attempting to read a value for a key not in the store we were adding
that key to the set of keys, and in the process wrongly concluding the
cache was over its limits and ejecting a real value.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
