### PR TITLE
Make InMemoryObjectStore deterministic

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStoreTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStoreTest.java
@@ -55,7 +55,7 @@ public class InMemoryObjectStoreTest {
   }
 
   @Test
-  void removesLeastRecentlyAccessedWhenPuttingInExcessOfLimit() {
+  void removesLeastRecentlyAccessedWhenPuttingInExcessOfLimit() throws InterruptedException {
     InMemoryObjectStore store = new InMemoryObjectStore(3);
 
     store.put("one", "1");
@@ -63,6 +63,7 @@ public class InMemoryObjectStoreTest {
     store.put("three", "3");
 
     store.get("one");
+    Thread.sleep(100L);
 
     store.put("four", "4");
     assertThat(store.getAllKeys().count(), is(3L));
@@ -101,7 +102,7 @@ public class InMemoryObjectStoreTest {
   }
 
   @Test
-  void tryingToRetrieveMissingKeyDoesNotEjectOtherKeys() {
+  void tryingToRetrieveMissingKeyDoesNotEjectOtherKeys() throws InterruptedException {
     InMemoryObjectStore store = new InMemoryObjectStore(3);
 
     store.put("one", "1");
@@ -111,6 +112,7 @@ public class InMemoryObjectStoreTest {
     assertThat(store.getAllKeys().count(), is(3L));
 
     store.get("four");
+    Thread.sleep(100L);
 
     assertThat(store.getAllKeys().count(), is(3L));
   }


### PR DESCRIPTION
Locks around all write operations, which will reduce throughput when
multiple requests want to update state. This may not be desirable...

`get` is also a write operation, as it touches the LRU cache, but to
speed it up, touching is moved to a background thread.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
