### PR TITLE
com.networknt:json-schema-validator:1.4.0 -> 1.4.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ dependencies {
 
   api 'commons-fileupload:commons-fileupload:1.5'
 
-  api 'com.networknt:json-schema-validator:1.4.0'
+  api 'com.networknt:json-schema-validator:1.4.3'
 
   testFixturesApi("org.junit.jupiter:junit-jupiter:$versions.junitJupiter")
   testFixturesApi("org.junit.platform:junit-platform-testkit")


### PR DESCRIPTION
1.4.3 has important fixes to the SchemaLocation parsing around JSON
Pointers
