### PR TITLE
Multipart request template model

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestPartTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestPartTemplateModel.java
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating;
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
 import com.github.tomakehurst.wiremock.http.Body;
 import java.util.Map;
+import java.util.TreeMap;
 
 public class RequestPartTemplateModel {
 
@@ -28,7 +29,8 @@ public class RequestPartTemplateModel {
   public RequestPartTemplateModel(
       String name, Map<String, ListOrSingle<String>> headers, Body body) {
     this.name = name;
-    this.headers = headers;
+    this.headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    this.headers.putAll(headers);
     this.body = body;
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestPartTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestPartTemplateModel.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating;
+
+import com.github.tomakehurst.wiremock.common.ListOrSingle;
+import com.github.tomakehurst.wiremock.http.Body;
+import java.util.Map;
+
+public class RequestPartTemplateModel {
+
+  private final String name;
+  private final Map<String, ListOrSingle<String>> headers;
+  private final Body body;
+
+  public RequestPartTemplateModel(
+      String name, Map<String, ListOrSingle<String>> headers, Body body) {
+    this.name = name;
+    this.headers = headers;
+    this.body = body;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Map<String, ListOrSingle<String>> getHeaders() {
+    return headers;
+  }
+
+  public String getBody() {
+    return body.asString();
+  }
+
+  public String getBodyAsBase64() {
+    return body.asBase64();
+  }
+
+  public boolean isBinary() {
+    return body.isBinary();
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
+import com.github.tomakehurst.wiremock.http.Body;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import java.util.Map;
 
@@ -27,7 +28,7 @@ public class RequestTemplateModel {
   private final Map<String, ListOrSingle<String>> cookies;
 
   private final boolean isMultipart;
-  private final String body;
+  private final Body body;
   private final Map<String, RequestPartTemplateModel> parts;
 
   protected RequestTemplateModel(
@@ -36,7 +37,7 @@ public class RequestTemplateModel {
       Map<String, ListOrSingle<String>> headers,
       Map<String, ListOrSingle<String>> cookies,
       boolean isMultipart,
-      String body,
+      Body body,
       Map<String, RequestPartTemplateModel> parts) {
     this.id = id;
     this.requestLine = requestLine;
@@ -104,7 +105,15 @@ public class RequestTemplateModel {
   }
 
   public String getBody() {
-    return body;
+    return body.asString();
+  }
+
+  public String getBodyAsBase64() {
+    return body.asBase64();
+  }
+
+  public boolean isBinary() {
+    return body.isBinary();
   }
 
   public boolean isMultipart() {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -25,19 +25,26 @@ public class RequestTemplateModel {
   private final RequestLine requestLine;
   private final Map<String, ListOrSingle<String>> headers;
   private final Map<String, ListOrSingle<String>> cookies;
+
+  private final boolean isMultipart;
   private final String body;
+  private final Map<String, RequestPartTemplateModel> parts;
 
   protected RequestTemplateModel(
       String id,
       RequestLine requestLine,
       Map<String, ListOrSingle<String>> headers,
       Map<String, ListOrSingle<String>> cookies,
-      String body) {
+      boolean isMultipart,
+      String body,
+      Map<String, RequestPartTemplateModel> parts) {
     this.id = id;
     this.requestLine = requestLine;
     this.headers = headers;
     this.cookies = cookies;
+    this.isMultipart = isMultipart;
     this.body = body;
+    this.parts = parts;
   }
 
   public String getId() {
@@ -98,6 +105,14 @@ public class RequestTemplateModel {
 
   public String getBody() {
     return body;
+  }
+
+  public boolean isMultipart() {
+    return isMultipart;
+  }
+
+  public Map<String, RequestPartTemplateModel> getParts() {
+    return parts;
   }
 
   public String getClientIp() {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -32,6 +32,7 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.TemplateModelDataProviderExtension;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.SystemValueHelper;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.WireMockHelpers;
+import com.github.tomakehurst.wiremock.http.Body;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
@@ -168,7 +169,7 @@ public class TemplateEngine {
         adaptedHeaders,
         adaptedCookies,
         request.isMultipart(),
-        request.getBodyAsString(),
+        Body.ofBinaryOrText(request.getBody(), request.contentTypeHeader()),
         buildRequestPartModel(request));
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -32,6 +32,7 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.TemplateModelDataProviderExtension;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.SystemValueHelper;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.WireMockHelpers;
+import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
@@ -166,7 +167,29 @@ public class TemplateEngine {
         requestLine,
         adaptedHeaders,
         adaptedCookies,
-        request.getBodyAsString());
+        request.isMultipart(),
+        request.getBodyAsString(),
+        buildRequestPartModel(request));
+  }
+
+  private static Map<String, RequestPartTemplateModel> buildRequestPartModel(Request request) {
+
+    if (request.isMultipart()) {
+      return request.getParts().stream()
+          .collect(
+              Collectors.toMap(
+                  Request.Part::getName,
+                  part ->
+                      new RequestPartTemplateModel(
+                          part.getName(),
+                          part.getHeaders().all().stream()
+                              .collect(
+                                  Collectors.toMap(
+                                      HttpHeader::key, header -> ListOrSingle.of(header.values()))),
+                          part.getBody())));
+    }
+
+    return Collections.emptyMap();
   }
 
   public long getCacheSize() {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
@@ -75,7 +75,7 @@ public class Body {
 
   public static Body ofBinaryOrText(byte[] content, ContentTypeHeader contentTypeHeader) {
     return new Body(
-        content, ContentTypes.determineIsTextFromMimeType(contentTypeHeader.mimeTypePart()));
+        content, !ContentTypes.determineIsTextFromMimeType(contentTypeHeader.mimeTypePart()));
   }
 
   public static Body fromOneOf(byte[] bytes, String str, JsonNode json, String base64) {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
@@ -44,7 +44,7 @@ public class ContentTypeHeader extends HttpHeader {
   }
 
   public String mimeTypePart() {
-    return parts != null ? parts[0] : null;
+    return parts != null && parts.length > 0 ? parts[0] : null;
   }
 
   public Optional<String> encodingPart() {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Thomas Akehurst
+ * Copyright (C) 2019-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.http.multipart;
 
-import com.github.tomakehurst.wiremock.http.Body;
-import com.github.tomakehurst.wiremock.http.HttpHeader;
-import com.github.tomakehurst.wiremock.http.HttpHeaders;
-import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -63,7 +60,7 @@ public class FileItemPartAdapter implements Request.Part {
 
   @Override
   public Body getBody() {
-    return new Body(fileItem.get());
+    return Body.ofBinaryOrText(fileItem.get(), new ContentTypeHeader(fileItem.getContentType()));
   }
 
   public static final Function<FileItem, Request.Part> TO_PARTS = FileItemPartAdapter::new;

--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartTemplatingAcceptanceTest.java
@@ -87,8 +87,6 @@ public class MultipartTemplatingAcceptanceTest {
 
   // TODO list parts and/or get the count
 
-  // TODO add bodyAsBase64 to main request body template model for consistency
-
   // TODO case-insensitive map for headers or normalisation of key case?
 
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartTemplatingAcceptanceTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.core5.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class MultipartTemplatingAcceptanceTest {
+
+  WireMockTestClient client;
+
+  @RegisterExtension
+  public static WireMockExtension wm =
+      WireMockExtension.newInstance()
+          .options(options().dynamicPort().templatingEnabled(true).globalTemplating(true))
+          .build();
+
+  @BeforeEach
+  void init() {
+    client = new WireMockTestClient(wm.getPort());
+  }
+
+  @Test
+  public void multipartRequestPartsAreAvailableViaTemplating() {
+    wm.stubFor(
+        post("/templated")
+            .willReturn(
+                ok(
+                    "multipart:{{request.multipart}}\n"
+                        + "text:binary={{request.parts.text.binary}}:{{request.parts.text.headers.content-type}}:{{request.parts.text.body}}\n"
+                        + "file:binary={{request.parts.file.binary}}:{{request.parts.file.headers.content-type}}:{{request.parts.file.bodyAsBase64}}")));
+
+    WireMockResponse response =
+        client.post(
+            "/templated",
+            MultipartEntityBuilder.create()
+                .addTextBody("text", "hello", ContentType.TEXT_PLAIN)
+                .addBinaryBody(
+                    "file", "ABCD".getBytes(), ContentType.APPLICATION_OCTET_STREAM, "abcd.bin")
+                .build());
+
+    assertThat(
+        response.content(),
+        is(
+            "multipart:true\n"
+                + "text:binary=false:text/plain; charset=ISO-8859-1:hello\n"
+                + "file:binary=true:application/octet-stream:QUJDRA=="));
+  }
+
+  @Test
+  public void returnsEmptyPartsInTemplateWhenRequestIsNotMultipart() {
+    wm.stubFor(
+        post("/templated")
+            .willReturn(
+                ok(
+                    "multipart:{{request.multipart}}\n"
+                        + "text:{{request.parts.text.headers.content-type}}:{{request.parts.text.body}}")));
+
+    WireMockResponse response = client.postJson("/templated", "{}");
+
+    assertThat(response.content(), is("multipart:false\n" + "text::"));
+  }
+
+  // TODO list parts and/or get the count
+
+  // TODO add bodyAsBase64 to main request body template model for consistency
+
+  // TODO case-insensitive map for headers or normalisation of key case?
+
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
@@ -296,7 +296,7 @@ public class ResponseTemplatingAcceptanceTest {
     }
 
     @Test
-    void canReadNumericPathVariableValuesWhenUsingPathTemnplate() {
+    void canReadNumericPathVariableValuesWhenUsingPathTemplate() {
       wm.stubFor(
           get(urlPathTemplate("/v1/first/{0}/second/{1}"))
               .willReturn(ok("1: {{request.path.0}}, 2: {{request.path.1}}")));
@@ -315,6 +315,15 @@ public class ResponseTemplatingAcceptanceTest {
       String content = client.get("/v1/first/first1/second/second2").content();
 
       assertThat(content, is(" v1 first first1 second second2 "));
+    }
+
+    @Test
+    void bodyAsBase64IsAvailableOnTheRequestModel() {
+      wm.stubFor(post("/v1/base64").willReturn(ok("{{request.bodyAsBase64}}")));
+
+      String content = client.postJson("/v1/base64", "{'foo':'bar'}").content();
+
+      assertThat(content, is("eydmb28nOidiYXInfQ=="));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR exposes the multipart data to the request template model allowing it to be used in response templates.  Part of this change has also added the `Body` object to the request model which allows us to expose the base64 representation of the body to the template model.  This is for both the actual request and the individual parts of a multipart request.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
