### PR TITLE
Part request model updates

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestPartTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestPartTemplateModel.java
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating;
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
 import com.github.tomakehurst.wiremock.http.Body;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.TreeMap;
 
 public class RequestPartTemplateModel {
@@ -52,5 +53,14 @@ public class RequestPartTemplateModel {
 
   public boolean isBinary() {
     return body.isBinary();
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", "[", "]")
+        .add("name='" + name + "'")
+        .add("headers=" + headers)
+        .add("body=" + body.asString())
+        .toString();
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -101,6 +101,12 @@ public class ResponseTemplateTransformer
                   file.readContentsAsString());
           applyTemplatedResponseBody(newResponseDefBuilder, model, bodyTemplate, false);
         }
+      } else if (responseDefinition.specifiesBinaryBodyContent()) {
+        HandlebarsOptimizedTemplate bodyTemplate =
+            templateEngine.getTemplate(
+                HttpTemplateCacheKey.forInlineBody(responseDefinition),
+                responseDefinition.getReponseBody().asString());
+        applyTemplatedResponseBody(newResponseDefBuilder, model, bodyTemplate, false);
       }
 
       if (responseDefinition.getHeaders() != null) {

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -203,7 +203,8 @@ public class ResponseTemplateTransformerTest {
     ResponseDefinition transformedResponseDef =
         transform(mockRequest().url("/base64"), aResponse().withBase64Body(templateAsBase64));
 
-    assertThat(transformedResponseDef.getBody(), is(base64));
+    assertThat(transformedResponseDef.getBase64Body(), is(base64));
+    assertThat(transformedResponseDef.getReponseBody().asString(), is("Hello World"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.*;
 
 import com.github.jknack.handlebars.Helper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.common.Encoding;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformerV2;
 import com.github.tomakehurst.wiremock.http.Request;
@@ -192,6 +193,17 @@ public class ResponseTemplateTransformerTest {
             aResponse().withBodyFile("/greet-{{request.query.name}}.txt"));
 
     assertThat(transformedResponseDef.getBody(), is("Hello Ram"));
+  }
+
+  @Test
+  public void templatizeBase64Body() {
+    var base64 = "SGVsbG8gV29ybGQ="; // Hello World
+    String template = "{{#val '" + base64 + "' assign='myBase64'}}{{/val}}{{{myBase64}}}";
+    String templateAsBase64 = Encoding.encodeBase64(template.getBytes());
+    ResponseDefinition transformedResponseDef =
+        transform(mockRequest().url("/base64"), aResponse().withBase64Body(templateAsBase64));
+
+    assertThat(transformedResponseDef.getBody(), is(base64)); // SGVsbG8gV29ybGQ&#x3D;
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -203,7 +203,7 @@ public class ResponseTemplateTransformerTest {
     ResponseDefinition transformedResponseDef =
         transform(mockRequest().url("/base64"), aResponse().withBase64Body(templateAsBase64));
 
-    assertThat(transformedResponseDef.getBody(), is(base64)); // SGVsbG8gV29ybGQ&#x3D;
+    assertThat(transformedResponseDef.getBody(), is(base64));
   }
 
   @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->


- Add a toString to the RequestPartTemplateModel
- Allow templates to be processed in the response definition if base64

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
