### PR TITLE
Add a toString to the ResponsePartTemplateModel class

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestPartTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestPartTemplateModel.java
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating;
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
 import com.github.tomakehurst.wiremock.http.Body;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.TreeMap;
 
 public class RequestPartTemplateModel {
@@ -52,5 +53,14 @@ public class RequestPartTemplateModel {
 
   public boolean isBinary() {
     return body.isBinary();
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", "[", "]")
+        .add("name='" + name + "'")
+        .add("headers=" + headers)
+        .add("body=" + body.asString())
+        .toString();
   }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Add a toString to the ResponsePartTemplateModel class

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->
## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
