### PR TITLE
Add support for reversing order of offsetting and truncating expected date/time values

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractDateTimePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractDateTimePattern.java
@@ -35,9 +35,10 @@ public abstract class AbstractDateTimePattern extends StringValuePattern {
   private DateTimeOffset expectedOffset;
   private DateTimeTruncation truncateExpected;
   private DateTimeTruncation truncateActual;
+  private boolean applyTruncationLast = false;
 
   protected AbstractDateTimePattern(String dateTimeSpec) {
-    this(dateTimeSpec, null, (DateTimeTruncation) null, null, null, null);
+    this(dateTimeSpec, null, (DateTimeTruncation) null, null, false, null, null);
   }
 
   protected AbstractDateTimePattern(
@@ -62,6 +63,7 @@ public abstract class AbstractDateTimePattern extends StringValuePattern {
       String actualDateFormat,
       String truncateExpected,
       String truncateActual,
+      boolean applyTruncationLast,
       Integer expectedOffsetAmount,
       DateTimeUnit expectedOffsetUnit) {
     this(
@@ -69,6 +71,7 @@ public abstract class AbstractDateTimePattern extends StringValuePattern {
         actualDateFormat,
         truncateExpected != null ? DateTimeTruncation.fromString(truncateExpected) : null,
         truncateActual != null ? DateTimeTruncation.fromString(truncateActual) : null,
+        applyTruncationLast,
         expectedOffsetAmount,
         expectedOffsetUnit);
   }
@@ -78,6 +81,7 @@ public abstract class AbstractDateTimePattern extends StringValuePattern {
       String actualDateFormat,
       DateTimeTruncation truncateExpected,
       DateTimeTruncation truncateActual,
+      boolean applyTruncationLast,
       Integer expectedOffsetAmount,
       DateTimeUnit expectedOffsetUnit) {
     super(dateTimeSpec);
@@ -101,6 +105,7 @@ public abstract class AbstractDateTimePattern extends StringValuePattern {
 
     this.truncateExpected = truncateExpected;
     this.truncateActual = truncateActual;
+    this.applyTruncationLast = applyTruncationLast;
   }
 
   public AbstractDateTimePattern(ZonedDateTime zonedDateTime) {
@@ -179,6 +184,12 @@ public abstract class AbstractDateTimePattern extends StringValuePattern {
     return (T) this;
   }
 
+  @SuppressWarnings("unchecked")
+  public <T extends AbstractDateTimePattern> T applyTruncationLast(boolean applyTruncationLast) {
+    this.applyTruncationLast = applyTruncationLast;
+    return (T) this;
+  }
+
   public String getActualFormat() {
     return actualDateTimeFormat;
   }
@@ -189,6 +200,10 @@ public abstract class AbstractDateTimePattern extends StringValuePattern {
 
   public String getTruncateActual() {
     return stringOrNull(truncateActual);
+  }
+
+  public Boolean getApplyTruncationLast() {
+    return applyTruncationLast ? true : null;
   }
 
   private static String stringOrNull(Object obj) {
@@ -212,9 +227,14 @@ public abstract class AbstractDateTimePattern extends StringValuePattern {
 
   private ZonedDateTime calculateExpectedFromNow() {
     final ZonedDateTime now = ZonedDateTime.now();
-    final ZonedDateTime truncated = truncateExpected != null ? truncateExpected.truncate(now) : now;
-
-    return expectedOffset.shift(truncated);
+    if (applyTruncationLast) {
+      final ZonedDateTime shifted = expectedOffset.shift(now);
+      return truncateExpected != null ? truncateExpected.truncate(shifted) : shifted;
+    } else {
+      final ZonedDateTime truncated =
+          truncateExpected != null ? truncateExpected.truncate(now) : now;
+      return expectedOffset.shift(truncated);
+    }
   }
 
   protected abstract MatchResult getMatchResult(

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/AfterDateTimePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/AfterDateTimePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ public class AfterDateTimePattern extends AbstractDateTimePattern {
       @JsonProperty("actualFormat") String actualDateFormat,
       @JsonProperty("truncateExpected") String truncateExpected,
       @JsonProperty("truncateActual") String truncateActual,
+      @JsonProperty("applyTruncationLast") boolean applyTruncationLast,
       @JsonProperty("expectedOffset") Integer expectedOffsetAmount,
       @JsonProperty("expectedOffsetUnit") DateTimeUnit expectedOffsetUnit) {
     super(
@@ -47,6 +48,7 @@ public class AfterDateTimePattern extends AbstractDateTimePattern {
         actualDateFormat,
         truncateExpected,
         truncateActual,
+        applyTruncationLast,
         expectedOffsetAmount,
         expectedOffsetUnit);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/BeforeDateTimePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/BeforeDateTimePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ public class BeforeDateTimePattern extends AbstractDateTimePattern {
       @JsonProperty("actualFormat") String actualDateFormat,
       @JsonProperty("truncateExpected") String truncateExpected,
       @JsonProperty("truncateActual") String truncateActual,
+      @JsonProperty("applyTruncationLast") boolean applyTruncationLast,
       @JsonProperty("expectedOffset") Integer expectedOffsetAmount,
       @JsonProperty("expectedOffsetUnit") DateTimeUnit expectedOffsetUnit) {
     super(
@@ -47,6 +48,7 @@ public class BeforeDateTimePattern extends AbstractDateTimePattern {
         actualDateFormat,
         truncateExpected,
         truncateActual,
+        applyTruncationLast,
         expectedOffsetAmount,
         expectedOffsetUnit);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToDateTimePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToDateTimePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ public class EqualToDateTimePattern extends AbstractDateTimePattern {
       @JsonProperty("actualFormat") String actualDateFormat,
       @JsonProperty("truncateExpected") String truncateExpected,
       @JsonProperty("truncateActual") String truncateActual,
+      @JsonProperty("applyTruncationLast") boolean applyTruncationLast,
       @JsonProperty("expectedOffset") Integer expectedOffsetAmount,
       @JsonProperty("expectedOffsetUnit") DateTimeUnit expectedOffsetUnit) {
     super(
@@ -47,6 +48,7 @@ public class EqualToDateTimePattern extends AbstractDateTimePattern {
         actualDateFormat,
         truncateExpected,
         truncateActual,
+        applyTruncationLast,
         expectedOffsetAmount,
         expectedOffsetUnit);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
@@ -251,6 +251,7 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
     JsonNode formatNode = rootNode.findValue("actualFormat");
     JsonNode truncateExpectedNode = rootNode.findValue("truncateExpected");
     JsonNode truncateActualNode = rootNode.findValue("truncateActual");
+    JsonNode applyTruncationLastNode = rootNode.findValue("applyTruncationLast");
     JsonNode expectedOffsetAmountNode = rootNode.findValue("expectedOffset");
     JsonNode expectedOffsetUnitNode = rootNode.findValue("expectedOffsetUnit");
 
@@ -261,6 +262,7 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
             formatNode != null ? formatNode.textValue() : null,
             truncateExpectedNode != null ? truncateExpectedNode.textValue() : null,
             truncateActualNode != null ? truncateActualNode.textValue() : null,
+            applyTruncationLastNode != null && applyTruncationLastNode.booleanValue(),
             expectedOffsetAmountNode != null ? expectedOffsetAmountNode.intValue() : null,
             expectedOffsetUnitNode != null
                 ? DateTimeUnit.valueOf(expectedOffsetUnitNode.textValue().toUpperCase())
@@ -271,6 +273,7 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
             formatNode != null ? formatNode.textValue() : null,
             truncateExpectedNode != null ? truncateExpectedNode.textValue() : null,
             truncateActualNode != null ? truncateActualNode.textValue() : null,
+            applyTruncationLastNode != null && applyTruncationLastNode.booleanValue(),
             expectedOffsetAmountNode != null ? expectedOffsetAmountNode.intValue() : null,
             expectedOffsetUnitNode != null
                 ? DateTimeUnit.valueOf(expectedOffsetUnitNode.textValue().toUpperCase())
@@ -281,6 +284,7 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
             formatNode != null ? formatNode.textValue() : null,
             truncateExpectedNode != null ? truncateExpectedNode.textValue() : null,
             truncateActualNode != null ? truncateActualNode.textValue() : null,
+            applyTruncationLastNode != null && applyTruncationLastNode.booleanValue(),
             expectedOffsetAmountNode != null ? expectedOffsetAmountNode.intValue() : null,
             expectedOffsetUnitNode != null
                 ? DateTimeUnit.valueOf(expectedOffsetUnitNode.textValue().toUpperCase())

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/AfterDateTimePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/AfterDateTimePatternTest.java
@@ -135,13 +135,15 @@ public class AfterDateTimePatternTest {
             "{\n"
                 + "  \"after\": \"now\",\n"
                 + "  \"truncateExpected\": \"first hour of day\",\n"
-                + "  \"truncateActual\": \"last day of year\"\n"
+                + "  \"truncateActual\": \"last day of year\",\n"
+                + "  \"applyTruncationLast\": true\n"
                 + "}",
             AfterDateTimePattern.class);
 
     assertThat(matcher.getExpected(), is("now +0 seconds"));
     assertThat(matcher.getTruncateExpected(), is("first hour of day"));
     assertThat(matcher.getTruncateActual(), is("last day of year"));
+    assertTrue(matcher.getApplyTruncationLast());
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/BeforeDateTimePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/BeforeDateTimePatternTest.java
@@ -284,6 +284,7 @@ public class BeforeDateTimePatternTest {
 
     assertThat(matcher.getExpected(), is("2021-06-15T00:00:00"));
     assertThat(matcher.getActualFormat(), is("dd/MM/yyyy"));
+    assertNull(matcher.getApplyTruncationLast());
   }
 
   @Test
@@ -292,12 +293,14 @@ public class BeforeDateTimePatternTest {
         Json.read(
             "{\n"
                 + "  \"before\": \"15 days\",\n"
-                + "  \"truncateActual\": \"first day of year\"\n"
+                + "  \"truncateActual\": \"first day of year\",\n"
+                + "  \"applyTruncationLast\": true\n"
                 + "}",
             BeforeDateTimePattern.class);
 
     assertThat(matcher.getTruncateExpected(), nullValue());
     assertThat(matcher.getTruncateActual(), is("first day of year"));
+    assertTrue(matcher.getApplyTruncationLast());
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToDateTimePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToDateTimePatternTest.java
@@ -33,7 +33,10 @@ import com.github.tomakehurst.wiremock.http.MultiValue;
 import com.google.common.collect.Lists;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class EqualToDateTimePatternTest {
 
@@ -188,7 +191,8 @@ public class EqualToDateTimePatternTest {
         WireMock.isNow()
             .expectedOffset(DateTimeOffset.fromString("now -5 days"))
             .truncateExpected(DateTimeTruncation.LAST_DAY_OF_MONTH)
-            .truncateActual(DateTimeTruncation.FIRST_DAY_OF_YEAR);
+            .truncateActual(DateTimeTruncation.FIRST_DAY_OF_YEAR)
+            .applyTruncationLast(true);
 
     assertThat(
         Json.write(matcher),
@@ -196,7 +200,8 @@ public class EqualToDateTimePatternTest {
             "{\n"
                 + "  \"equalToDateTime\": \"now -5 days\",\n"
                 + "  \"truncateExpected\": \"last day of month\",\n"
-                + "  \"truncateActual\": \"first day of year\"\n"
+                + "  \"truncateActual\": \"first day of year\",\n"
+                + "  \"applyTruncationLast\": true\n"
                 + "}"));
   }
 
@@ -216,6 +221,40 @@ public class EqualToDateTimePatternTest {
 
     assertTrue(matcher.match(good.toString()).isExactMatch());
     assertFalse(matcher.match(bad.toString()).isExactMatch());
+  }
+
+  @Test
+  public void deserialisesFromJsonWithApplyTruncationLast() {
+    AbstractDateTimePattern matcher =
+        Json.read(
+            "{\n"
+                + "  \"equalToDateTime\": \"now\",\n"
+                + "  \"expectedOffset\": 1,\n"
+                + "  \"expectedOffsetUnit\": \"months\",\n"
+                + "  \"truncateExpected\": \"last day of month\",\n"
+                + "  \"applyTruncationLast\": true\n"
+                + "}",
+            EqualToDateTimePattern.class);
+
+    ZonedDateTime february1st = ZonedDateTime.parse("2024-02-01T00:00:00Z");
+
+    ZonedDateTime march31st = february1st.plusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
+
+    ZonedDateTime march29th = february1st.with(TemporalAdjusters.lastDayOfMonth()).plusMonths(1);
+
+    // Mock static method ZonedDateTime::now so that it always returns 2024-02-01
+    try (MockedStatic<ZonedDateTime> mockedZonedDateTime =
+        Mockito.mockStatic(ZonedDateTime.class, Mockito.CALLS_REAL_METHODS)) {
+      mockedZonedDateTime.when(ZonedDateTime::now).thenReturn(february1st);
+
+      // Matcher expects March 31st when applyTruncationLast is set to true
+      assertTrue(matcher.match(march31st.toString()).isExactMatch());
+
+      AbstractDateTimePattern matcherWithApplyTruncationLast = matcher.applyTruncationLast(false);
+
+      // Matcher expects March 29th when applyTruncationLast is set to false
+      assertTrue(matcherWithApplyTruncationLast.match(march29th.toString()).isExactMatch());
+    }
   }
 
   @Test


### PR DESCRIPTION
Given the matcher below:
```
"request": {
  "method": "GET",
  "urlPath": "/resource",
  "queryParameters": {
    "date": {
      "equalToDateTime": "now +1 months",
      "truncateExpected": "last day of month"
    }
  }
}
```
One would expect for the `last day of month` truncation to be applied to the `now +1 months` expected date/time value.

Instead, what currently happens is the `last day of month` truncation is applied to `now` and the result is then offset by `+1 months`.

This is very counterintuitive and not what someone would expect by looking at the matcher above.

This PR reverses the order of offsetting and truncating expected date/time values with the truncations now being applied last.

## References
A more in depth discussion of the issue can be found in the enhancement proposal: #2789

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [[wiremock.org](http://wiremock.org/)](https://github.com/wiremock/wiremock.org)