### PR TITLE
Add missing admin endpoints to open api spec

### DIFF
--- a/src/main/resources/swagger/examples/health.yaml
+++ b/src/main/resources/swagger/examples/health.yaml
@@ -1,0 +1,5 @@
+status: "healthy"
+message: "Wiremock is ok"
+version: "3.8.0"
+uptimeInSeconds: 14355
+timestamp: "2024-07-03T13:16:06.172362Z"

--- a/src/main/resources/swagger/schemas/health.yaml
+++ b/src/main/resources/swagger/schemas/health.yaml
@@ -1,0 +1,17 @@
+type: object
+properties:
+  status:
+    type: string
+    example: "health"
+  message:
+    type: string
+    example: "Wiremock is ok"
+  version:
+    type: string
+    example: "3.8.0"
+  uptimeInSeconds:
+    type: integer
+    example: 14355
+  timestamp:
+    type: string
+    example: "2024-07-03T13:16:06.172362Z"

--- a/src/main/resources/swagger/schemas/health.yaml
+++ b/src/main/resources/swagger/schemas/health.yaml
@@ -3,18 +3,23 @@ properties:
   status:
     type: string
     example: "healthy"
+    description: "The status of the server"
     enum:
       - healthy
       - unhealthy
   message:
     type: string
+    description: "Longer message regarding the status of the server"
     example: "Wiremock is ok"
   version:
     type: string
+    description: "The WireMock version"
     example: "3.8.0"
   uptimeInSeconds:
     type: integer
+    description: "How long the server has been running"
     example: 14355
   timestamp:
     type: string
+    description: "The current timestamp"
     example: "2024-07-03T13:16:06.172362Z"

--- a/src/main/resources/swagger/schemas/health.yaml
+++ b/src/main/resources/swagger/schemas/health.yaml
@@ -2,7 +2,10 @@ type: object
 properties:
   status:
     type: string
-    example: "health"
+    example: "healthy"
+    enum:
+      - healthy
+      - unhealthy
   message:
     type: string
     example: "Wiremock is ok"

--- a/src/main/resources/swagger/wiremock-admin-api.json
+++ b/src/main/resources/swagger/wiremock-admin-api.json
@@ -5187,6 +5187,90 @@
           }
         }
       }
+    },
+    "/__admin/version" : {
+      "get" : {
+        "operationId" : "getVersion",
+        "summary" : "Return the version of the WireMock server",
+        "description" : "Returns the version of the WireMock server",
+        "tags" : [ "System" ],
+        "responses" : {
+          "200" : {
+            "description" : "Successfully returned the version of the WireMock server",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "version" : {
+                      "type" : "string",
+                      "example" : "3.8.0"
+                    }
+                  }
+                },
+                "example" : {
+                  "version" : "3.8.0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/__admin/health" : {
+      "get" : {
+        "operationId" : "getHealth",
+        "summary" : "Return the health of the WireMock server",
+        "description" : "Returns the health of the WireMock server",
+        "tags" : [ "System" ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful health and uptime data",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "The status of the server",
+                      "example": "healthy",
+                      "enum": ["healthy", "unhealthy"]
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Longer message regarding the status of the server",
+                      "example": "Wiremock is ok"
+                    },
+                    "version": {
+                      "type": "string",
+                      "description": "The WireMock version",
+                      "example": "3.8.0"
+                    },
+                    "upTimeInSeconds": {
+                      "type": "integer",
+                      "description": "How long the server has been running",
+                      "example": 14355
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "description": "The current timestamp",
+                      "example": "2024-07-03T13:16:06.172362Z"
+                    }
+                  }
+                },
+                "example" : {
+                  "status" : "healthy",
+                  "message" : "Wiremock is ok",
+                  "version" : "3.8.0",
+                  "uptimeInSeconds" : 14355,
+                  "timestamp" : "2024-07-03T13:16:06.172362Z"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/src/main/resources/swagger/wiremock-admin-api.json
+++ b/src/main/resources/swagger/wiremock-admin-api.json
@@ -4025,7 +4025,7 @@
                       "targetBaseUrl": {
                         "type": "string",
                         "description": "Target URL when using the record and playback API",
-                        "example" : "https://example.wiremock.org"
+                        "example": "https://example.wiremock.org"
                       }
                     }
                   }
@@ -5081,6 +5081,98 @@
         }
       }
     },
+    "/__admin/files": {
+      "get": {
+        "operationId": "getAllFileNames",
+        "summary": "Get all file names",
+        "tags": [
+          "Files"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "example": [
+                    "file1.json",
+                    "file2.json",
+                    "file3.txt"
+                  ]
+                }
+              }
+            },
+            "description": "All scenarios"
+          }
+        }
+      }
+    },
+    "/__admin/files/{fileId}": {
+      "parameters": [
+        {
+          "description": "The name of the file",
+          "in": "path",
+          "name": "fileId",
+          "required": true,
+          "example": "file1.json",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getFileById",
+        "summary": "Get file by ID",
+        "tags": [
+          "Files"
+        ],
+        "responses": {
+          "404": {
+            "description": "File not found"
+          },
+          "200": {
+            "description": "The contents of the file"
+          }
+        }
+      },
+      "put": {
+        "operationId": "updateFileById",
+        "summary": "Update or create a file",
+        "tags": [
+          "Files"
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "byte"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK - contents of the request body as a string"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteFileById",
+        "summary": "Delete a file if it exists",
+        "tags": [
+          "Files"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/__admin/settings": {
       "post": {
         "operationId": "updateGlobalSettings",
@@ -5174,42 +5266,43 @@
         }
       }
     },
-    "/__admin/shutdown": {
-      "post": {
-        "operationId": "shutdownServer",
-        "description": "Shutdown the WireMock server",
+    "/__admin/shutdown" : {
+      "post" : {
+        "operationId" : "shutdownServer",
+        "summary" : "Shutdown the WireMock server",
+        "description" : "Shutdown the WireMock server",
+        "tags" : [ "System" ],
+        "responses" : {
+          "200" : {
+            "description" : "Server will be shut down"
+          }
+        }
+      }
+    },
+    "/__admin/version": {
+      "get": {
+        "operationId": "getVersion",
+        "summary": "Return the version of the WireMock server",
+        "description": "Returns the version of the WireMock server",
         "tags": [
           "System"
         ],
         "responses": {
           "200": {
-            "description": "Server will be shut down"
-          }
-        }
-      }
-    },
-    "/__admin/version" : {
-      "get" : {
-        "operationId" : "getVersion",
-        "summary" : "Return the version of the WireMock server",
-        "description" : "Returns the version of the WireMock server",
-        "tags" : [ "System" ],
-        "responses" : {
-          "200" : {
-            "description" : "Successfully returned the version of the WireMock server",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "object",
-                  "properties" : {
-                    "version" : {
-                      "type" : "string",
-                      "example" : "3.8.0"
+            "description": "Successfully returned the version of the WireMock server",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "string",
+                      "example": "3.8.0"
                     }
                   }
                 },
-                "example" : {
-                  "version" : "3.8.0"
+                "example": {
+                  "version": "3.8.0"
                 }
               }
             }
@@ -5217,25 +5310,30 @@
         }
       }
     },
-    "/__admin/health" : {
-      "get" : {
-        "operationId" : "getHealth",
-        "summary" : "Return the health of the WireMock server",
-        "description" : "Returns the health of the WireMock server",
-        "tags" : [ "System" ],
-        "responses" : {
-          "200" : {
-            "description" : "Successful health and uptime data",
-            "content" : {
-              "application/json" : {
-                "schema" : {
+    "/__admin/health": {
+      "get": {
+        "operationId": "getHealth",
+        "summary": "Return the health of the WireMock server",
+        "description": "Returns the health of the WireMock server",
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful health and uptime data",
+            "content": {
+              "application/json": {
+                "schema": {
                   "type": "object",
                   "properties": {
                     "status": {
                       "type": "string",
                       "description": "The status of the server",
                       "example": "healthy",
-                      "enum": ["healthy", "unhealthy"]
+                      "enum": [
+                        "healthy",
+                        "unhealthy"
+                      ]
                     },
                     "message": {
                       "type": "string",
@@ -5259,12 +5357,12 @@
                     }
                   }
                 },
-                "example" : {
-                  "status" : "healthy",
-                  "message" : "Wiremock is ok",
-                  "version" : "3.8.0",
-                  "uptimeInSeconds" : 14355,
-                  "timestamp" : "2024-07-03T13:16:06.172362Z"
+                "example": {
+                  "status": "healthy",
+                  "message": "Wiremock is ok",
+                  "version": "3.8.0",
+                  "uptimeInSeconds": 14355,
+                  "timestamp": "2024-07-03T13:16:06.172362Z"
                 }
               }
             }

--- a/src/main/resources/swagger/wiremock-admin-api.json
+++ b/src/main/resources/swagger/wiremock-admin-api.json
@@ -6,7 +6,7 @@
   },
   "externalDocs": {
     "description": "WireMock user documentation",
-    "url": "http://wiremock.org/docs/"
+    "url": "https://wiremock.org/docs/"
   },
   "servers": [
     {
@@ -19,7 +19,7 @@
       "description": "Operations on stub mappings",
       "externalDocs": {
         "description": "User documentation",
-        "url": "http://wiremock.org/docs/stubbing/"
+        "url": "https://wiremock.org/docs/stubbing/"
       }
     },
     {
@@ -27,7 +27,7 @@
       "description": "Logged requests and responses received by the mock service",
       "externalDocs": {
         "description": "User documentation",
-        "url": "http://wiremock.org/docs/verifying/"
+        "url": "https://wiremock.org/docs/verifying/"
       }
     },
     {
@@ -35,7 +35,7 @@
       "description": "Near misses allow querying of received requests or request patterns according to similarity",
       "externalDocs": {
         "description": "User documentation",
-        "url": "http://wiremock.org/docs/verifying/#near-misses"
+        "url": "https://wiremock.org/docs/verifying/#near-misses"
       }
     },
     {
@@ -43,7 +43,7 @@
       "description": "Stub mapping record and snapshot functions",
       "externalDocs": {
         "description": "User documentation",
-        "url": "http://wiremock.org/docs/record-playback/"
+        "url": "https://wiremock.org/docs/record-playback/"
       }
     },
     {
@@ -51,8 +51,12 @@
       "description": "Scenarios support modelling of stateful behaviour",
       "externalDocs": {
         "description": "User documentation",
-        "url": "http://wiremock.org/docs/stateful-behaviour/"
+        "url": "https://wiremock.org/docs/stateful-behaviour/"
       }
+    },
+    {
+      "name": "Files",
+      "description": "Manage the files used to support WireMock stubs"
     },
     {
       "name": "System",
@@ -4021,14 +4025,14 @@
                       "targetBaseUrl": {
                         "type": "string",
                         "description": "Target URL when using the record and playback API",
-                        "example": "http://example.mocklab.io"
+                        "example" : "https://example.wiremock.org"
                       }
                     }
                   }
                 ]
               },
               "example": {
-                "targetBaseUrl": "http://example.mocklab.io",
+                "targetBaseUrl": "https://example.wiremock.org",
                 "filters": {
                   "urlPathPattern": "/api/.*",
                   "method": "GET"
@@ -5786,14 +5790,14 @@
                     "targetBaseUrl": {
                       "type": "string",
                       "description": "Target URL when using the record and playback API",
-                      "example": "http://example.mocklab.io"
+                      "example": "https://example.wiremock.org"
                     }
                   }
                 }
               ]
             },
             "example": {
-              "targetBaseUrl": "http://example.mocklab.io",
+              "targetBaseUrl": "https://example.wiremock.org",
               "filters": {
                 "urlPathPattern": "/api/.*",
                 "method": "GET"

--- a/src/main/resources/swagger/wiremock-admin-api.json
+++ b/src/main/resources/swagger/wiremock-admin-api.json
@@ -2,7 +2,8 @@
   "openapi": "3.0.0",
   "info": {
     "title": "WireMock",
-    "version": "3.8.0"
+    "version": "3.8.0",
+    "description": "WireMock offers a REST API for administration, troubleshooting and analysis purposes"
   },
   "externalDocs": {
     "description": "WireMock user documentation",

--- a/src/main/resources/swagger/wiremock-admin-api.yaml
+++ b/src/main/resources/swagger/wiremock-admin-api.yaml
@@ -569,6 +569,42 @@ paths:
       responses:
         '200':
           description: Server will be shut down
+          
+  /__admin/version:
+    get:
+      operationId: getVersion
+      summary: Return the version of the WireMock server
+      description: Returns the version of the WireMock server
+      tags:
+        - System
+      responses:
+        '200':
+          description: Successfully returned the version of the WireMock server
+          content: 
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                    example: "3.8.0"
+
+  /__admin/health:
+    get:
+      operationId: getHealth
+      summary: Return the health of the WireMock server
+      description: Returns the health of the WireMock server
+      tags:
+        - System
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: 'schemas/health.yaml'
+              example:
+                $ref: 'examples/health.yaml'
+          description: Successful health and uptime data
 
 components:
   requestBodies:

--- a/src/main/resources/swagger/wiremock-admin-api.yaml
+++ b/src/main/resources/swagger/wiremock-admin-api.yaml
@@ -37,6 +37,8 @@ tags:
     externalDocs:
       description: User documentation
       url: https://wiremock.org/docs/stateful-behaviour/
+  - name: Files
+    description: Manage the files used to support WireMock stubs
   - name: System
     description: Global operations
 
@@ -331,6 +333,7 @@ paths:
                 $ref: "examples/requests.yaml"
                     
                     
+
   /__admin/requests/remove-by-metadata:
     post:
       operationId: removeRequestsByMetadata
@@ -525,6 +528,66 @@ paths:
         '200':
           description: Successfully reset
 
+
+  /__admin/files:
+    get:
+      operationId: getAllFileNames
+      summary: Get all file names
+      tags:
+        - Files
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                example: ["file1.json", "file2.json", "file3.txt"]
+          description: All scenarios
+          
+  /__admin/files/{fileId}:
+    parameters:
+      - description: The name of the file
+        in: path
+        name: fileId
+        required: true
+        example: file1.json
+        schema:
+          type: string
+    get:
+      operationId: getFileById
+      summary: Get file by ID
+      tags:
+        - Files
+      responses:
+        '404':
+          description: File not found
+        '200':
+          description: The contents of the file
+    put:
+      operationId: updateFileById
+      summary: Update or create a file
+      tags:
+        - Files
+      requestBody:
+        content:
+          application/octet-stream:
+            schema: 
+              type: string
+              format: byte
+      responses:
+        '200':
+          description: OK - contents of the request body as a string
+    delete:
+      operationId: deleteFileById
+      summary: Delete a file if it exists
+      tags:
+        - Files
+      responses:
+        '200':
+          description: OK
+
   /__admin/settings:
     post:
       operationId: updateGlobalSettings
@@ -570,6 +633,7 @@ paths:
         '200':
           description: Server will be shut down
           
+
   /__admin/version:
     get:
       operationId: getVersion
@@ -598,13 +662,13 @@ paths:
         - System
       responses:
         '200':
+          description: Successful health and uptime data
           content:
             application/json:
               schema:
                 $ref: 'schemas/health.yaml'
               example:
                 $ref: 'examples/health.yaml'
-          description: Successful health and uptime data
 
 components:
   requestBodies:

--- a/src/main/resources/swagger/wiremock-admin-api.yaml
+++ b/src/main/resources/swagger/wiremock-admin-api.yaml
@@ -3,6 +3,7 @@ openapi: 3.0.0
 info:
   title: WireMock
   version: 3.8.0
+  description: "WireMock offers a REST API for administration, troubleshooting and analysis purposes"
 
 externalDocs:
   description: WireMock user documentation

--- a/src/main/resources/swagger/wiremock-admin-api.yaml
+++ b/src/main/resources/swagger/wiremock-admin-api.yaml
@@ -6,7 +6,7 @@ info:
 
 externalDocs:
   description: WireMock user documentation
-  url: http://wiremock.org/docs/
+  url: https://wiremock.org/docs/
 
 servers:
   - url: /
@@ -16,27 +16,27 @@ tags:
     description: Operations on stub mappings
     externalDocs:
       description: User documentation
-      url: http://wiremock.org/docs/stubbing/
+      url: https://wiremock.org/docs/stubbing/
   - name: Requests
     description: Logged requests and responses received by the mock service
     externalDocs:
       description: User documentation
-      url: http://wiremock.org/docs/verifying/
+      url: https://wiremock.org/docs/verifying/
   - name: Near Misses
     description: Near misses allow querying of received requests or request patterns according to similarity
     externalDocs:
       description: User documentation
-      url: http://wiremock.org/docs/verifying/#near-misses
+      url: https://wiremock.org/docs/verifying/#near-misses
   - name: Recordings
     description: Stub mapping record and snapshot functions
     externalDocs:
       description: User documentation
-      url: http://wiremock.org/docs/record-playback/
+      url: https://wiremock.org/docs/record-playback/
   - name: Scenarios
     description: Scenarios support modelling of stateful behaviour
     externalDocs:
       description: User documentation
-      url: http://wiremock.org/docs/stateful-behaviour/
+      url: https://wiremock.org/docs/stateful-behaviour/
   - name: System
     description: Global operations
 
@@ -330,6 +330,7 @@ paths:
               example:
                 $ref: "examples/requests.yaml"
                     
+                    
   /__admin/requests/remove-by-metadata:
     post:
       operationId: removeRequestsByMetadata
@@ -561,6 +562,7 @@ paths:
   /__admin/shutdown:
     post:
       operationId: shutdownServer
+      summary: Shutdown the WireMock server
       description: Shutdown the WireMock server
       tags:
          - System
@@ -602,7 +604,7 @@ components:
                   targetBaseUrl:
                     type: string
                     description: Target URL when using the record and playback API
-                    example: http://example.mocklab.io
+                    example: https://example.wiremock.org
           example:
             $ref: "examples/record-spec.yaml"
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR updates the OpenAPI spec with the missing admin endpoints.

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
