### PR TITLE
correctly handle InMemoryObjectStore.compute returning null.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStore.java
@@ -63,7 +63,11 @@ public class InMemoryObjectStore implements ObjectStore {
   public <T> T compute(String key, Function<T, T> valueFunction) {
     final T result =
         (T) cache.compute(key, (k, currentValue) -> valueFunction.apply((T) currentValue));
-    touchAndResize(key);
+    if (result != null) {
+      touchAndResize(key);
+    } else {
+      keyUseOrder.remove(key);
+    }
     return result;
   }
 


### PR DESCRIPTION
Previously, if the compute function returned null this was not considered a removal by the LRU cache.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)