### PR TITLE
add getAndPut method to Store.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStore.java
@@ -59,6 +59,13 @@ public class InMemoryObjectStore implements ObjectStore {
   }
 
   @Override
+  public Optional<Object> getAndPut(String key, Object content) {
+    Object previousValue = cache.put(key, content);
+    touchAndResize(key);
+    return Optional.ofNullable(previousValue);
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public <T> T compute(String key, Function<T, T> valueFunction) {
     final T result =

--- a/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStore.java
@@ -78,6 +78,12 @@ public class InMemoryObjectStore implements ObjectStore {
   }
 
   @Override
+  public Optional<Object> getAndRemove(String key) {
+    keyUseOrder.remove(key);
+    return Optional.ofNullable(cache.remove(key));
+  }
+
+  @Override
   public void clear() {
     cache.clear();
     keyUseOrder.clear();

--- a/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryRequestJournalStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryRequestJournalStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Thomas Akehurst
+ * Copyright (C) 2022-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,8 +66,13 @@ public class InMemoryRequestJournalStore implements RequestJournalStore {
 
   @Override
   public void remove(UUID id) {
+    getAndRemove(id);
+  }
+
+  @Override
+  public Optional<ServeEvent> getAndRemove(UUID id) {
     deque.stream().filter(eventId -> eventId.equals(id)).forEach(deque::remove);
-    serveEvents.remove(id);
+    return Optional.ofNullable(serveEvents.remove(id));
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryRequestJournalStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryRequestJournalStore.java
@@ -59,8 +59,15 @@ public class InMemoryRequestJournalStore implements RequestJournalStore {
 
   @Override
   public void put(UUID id, ServeEvent event) {
+    getAndPut(id, event);
+  }
+
+  @Override
+  public Optional<ServeEvent> getAndPut(UUID id, ServeEvent event) {
     if (deque.contains(id)) {
-      serveEvents.put(id, event);
+      return Optional.ofNullable(serveEvents.put(id, event));
+    } else {
+      return Optional.empty();
     }
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryScenariosStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryScenariosStore.java
@@ -47,6 +47,11 @@ public class InMemoryScenariosStore implements ScenariosStore {
   }
 
   @Override
+  public Optional<Scenario> getAndPut(String key, Scenario content) {
+    return Optional.ofNullable(scenarioMap.put(key, content));
+  }
+
+  @Override
   public void remove(String key) {
     scenarioMap.remove(key);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryScenariosStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/InMemoryScenariosStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Thomas Akehurst
+ * Copyright (C) 2022-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,11 @@ public class InMemoryScenariosStore implements ScenariosStore {
   @Override
   public void remove(String key) {
     scenarioMap.remove(key);
+  }
+
+  @Override
+  public Optional<Scenario> getAndRemove(String key) {
+    return Optional.ofNullable(scenarioMap.remove(key));
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/store/Store.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/Store.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Thomas Akehurst
+ * Copyright (C) 2022-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ public interface Store<K, V> {
   void put(K key, V content);
 
   void remove(K key);
+
+  Optional<V> getAndRemove(K key);
 
   void clear();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/store/Store.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/Store.java
@@ -28,6 +28,8 @@ public interface Store<K, V> {
 
   void put(K key, V content);
 
+  Optional<V> getAndPut(K key, V content);
+
   void remove(K key);
 
   Optional<V> getAndRemove(K key);

--- a/src/main/java/com/github/tomakehurst/wiremock/store/files/FileSourceBlobStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/files/FileSourceBlobStore.java
@@ -89,6 +89,13 @@ public class FileSourceBlobStore implements BlobStore, PathBased {
   }
 
   @Override
+  public Optional<byte[]> getAndPut(String key, byte[] content) {
+    Optional<byte[]> previousValue = get(key);
+    put(key, content);
+    return previousValue;
+  }
+
+  @Override
   public void remove(String key) {
     fileSource.deleteFile(key);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/store/files/FileSourceBlobStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/files/FileSourceBlobStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Thomas Akehurst
+ * Copyright (C) 2022-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,13 @@ public class FileSourceBlobStore implements BlobStore, PathBased {
   @Override
   public void remove(String key) {
     fileSource.deleteFile(key);
+  }
+
+  @Override
+  public Optional<byte[]> getAndRemove(String key) {
+    Optional<byte[]> value = get(key);
+    remove(key);
+    return value;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/store/files/FileSourceJsonObjectStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/files/FileSourceJsonObjectStore.java
@@ -102,6 +102,17 @@ public class FileSourceJsonObjectStore implements ObjectStore, PathBased {
   }
 
   @Override
+  public Optional<Object> getAndRemove(String key) {
+    return keyLocks.withLock(
+        key,
+        () -> {
+          final Optional<Object> value = get(key);
+          remove(key);
+          return value;
+        });
+  }
+
+  @Override
   public void clear() {
     fileSource.listFilesRecursively().forEach(file -> fileSource.deleteFile(file.getPath()));
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/store/files/FileSourceJsonObjectStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/files/FileSourceJsonObjectStore.java
@@ -97,6 +97,17 @@ public class FileSourceJsonObjectStore implements ObjectStore, PathBased {
   }
 
   @Override
+  public Optional<Object> getAndPut(String key, Object content) {
+    return keyLocks.withLock(
+        key,
+        () -> {
+          final Optional<Object> value = get(key);
+          put(key, content);
+          return value;
+        });
+  }
+
+  @Override
   public void remove(String key) {
     fileSource.deleteFile(createFileName(key));
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStoreTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStoreTest.java
@@ -138,4 +138,22 @@ public class InMemoryObjectStoreTest {
     store.compute("three", previousValue::getAndSet);
     assertThat(previousValue.get(), is(nullValue()));
   }
+
+  @Test
+  void gettingAndRemovingAnItemObeysCacheLimits() {
+    InMemoryObjectStore store = new InMemoryObjectStore(3);
+
+    store.put("one", "1");
+    store.put("two", "2");
+    store.put("three", "3");
+
+    assertThat(store.getAndRemove("two"), is(Optional.of("2")));
+    assertThat(store.getAndRemove("two"), is(Optional.empty()));
+
+    store.put("four", "4");
+    assertThat(store.getAllKeys().collect(toList()), containsInAnyOrder("one", "three", "four"));
+
+    store.put("five", "5");
+    assertThat(store.getAllKeys().collect(toList()), containsInAnyOrder("three", "four", "five"));
+  }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStoreTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/InMemoryObjectStoreTest.java
@@ -156,4 +156,21 @@ public class InMemoryObjectStoreTest {
     store.put("five", "5");
     assertThat(store.getAllKeys().collect(toList()), containsInAnyOrder("three", "four", "five"));
   }
+
+  @Test
+  void gettingAndPuttingAnItemObeysCacheLimits() {
+    InMemoryObjectStore store = new InMemoryObjectStore(3);
+
+    store.put("one", "1");
+    store.put("two", "2");
+    store.put("three", "3");
+
+    assertThat(store.getAndPut("one", "4"), is(Optional.of("1")));
+
+    assertThat(store.getAllKeys().collect(toList()), containsInAnyOrder("one", "two", "three"));
+
+    assertThat(store.getAndPut("four", "4"), is(Optional.empty()));
+
+    assertThat(store.getAllKeys().collect(toList()), containsInAnyOrder("one", "three", "four"));
+  }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/store/files/BlobStoreFileSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/files/BlobStoreFileSourceTest.java
@@ -171,6 +171,11 @@ public class BlobStoreFileSourceTest {
     public void put(String key, byte[] content) {}
 
     @Override
+    public Optional<byte[]> getAndPut(String key, byte[] content) {
+      return Optional.empty();
+    }
+
+    @Override
     public void remove(String key) {}
 
     @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/store/files/BlobStoreFileSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/files/BlobStoreFileSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Thomas Akehurst
+ * Copyright (C) 2022-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,6 +172,11 @@ public class BlobStoreFileSourceTest {
 
     @Override
     public void remove(String key) {}
+
+    @Override
+    public Optional<byte[]> getAndRemove(String key) {
+      return Optional.empty();
+    }
 
     @Override
     public void clear() {}

--- a/src/test/java/com/github/tomakehurst/wiremock/store/files/FileSourceBlobStoreTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/files/FileSourceBlobStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,17 @@
  */
 package com.github.tomakehurst.wiremock.store.files;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.tomakehurst.wiremock.store.BlobStore;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class FileSourceBlobStoreTest {
   private static final String DIRECTORY_PATH =
@@ -46,5 +51,15 @@ class FileSourceBlobStoreTest {
           Optional<InputStream> result = fileSourceBlobStore.getStream("any-key");
           assertEquals(Optional.empty(), result);
         });
+  }
+
+  @Test
+  void returnsFileContentsBeforeDeletion(@TempDir Path tempDir) {
+    BlobStore blobStore = new FileSourceBlobStore(tempDir.toString());
+
+    String filePath = "folder/tmp-file.json";
+    String contents = "{}";
+    blobStore.put(filePath, contents.getBytes());
+    assertThat(blobStore.getAndRemove(filePath).map(String::new), is(Optional.of(contents)));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/store/files/FileSourceBlobStoreTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/files/FileSourceBlobStoreTest.java
@@ -62,4 +62,18 @@ class FileSourceBlobStoreTest {
     blobStore.put(filePath, contents.getBytes());
     assertThat(blobStore.getAndRemove(filePath).map(String::new), is(Optional.of(contents)));
   }
+
+  @Test
+  void returnsPreviousFileContentsBeforeOverwrite(@TempDir Path tempDir) {
+    BlobStore blobStore = new FileSourceBlobStore(tempDir.toString());
+
+    String filePath = "folder/tmp-file.json";
+    String contents = "{}";
+    blobStore.put(filePath, contents.getBytes());
+    String newContent = "[\"new content\"]";
+    assertThat(
+        blobStore.getAndPut(filePath, newContent.getBytes()).map(String::new),
+        is(Optional.of(contents)));
+    assertThat(blobStore.get(filePath).map(String::new), is(Optional.of(newContent)));
+  }
 }


### PR DESCRIPTION
Adds a getAndRemove method to the Store interface to allow atomic retrieval and replacement of entries.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)