### PR TITLE
Pick random helper enhancements

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/PickRandomHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/PickRandomHelper.java
@@ -30,33 +30,24 @@ public class PickRandomHelper extends HandlebarsHelper<Object> {
           "Must specify either a single list argument or a set of single value arguments.");
     }
 
-    List<Object> candidateValueList = new ArrayList<>();
+    List<Object> valueList = new ArrayList<>();
     if (Iterable.class.isAssignableFrom(context.getClass())) {
-      ((Iterable<Object>) context).forEach(candidateValueList::add);
+      ((Iterable<Object>) context).forEach(valueList::add);
     } else {
-      candidateValueList.add(context);
-      candidateValueList.addAll(Arrays.asList(options.params));
+      valueList.add(context);
+      valueList.addAll(Arrays.asList(options.params));
     }
 
     Integer count = (Integer) options.hash.get("count");
     if (count != null && count > 0) {
-      final List<Object> outputValueList = new ArrayList<>(count);
-      final Set<Integer> usedIndexes = new HashSet<>();
-
-      for (int i = 0; i < count && usedIndexes.size() < candidateValueList.size(); i++) {
-        int index = -1;
-        while (index == -1 || usedIndexes.contains(index)) {
-          index = ThreadLocalRandom.current().nextInt(candidateValueList.size());
-        }
-
-        outputValueList.add(candidateValueList.get(index));
-        usedIndexes.add(index);
+      int desiredLength = Math.min(valueList.size(), count);
+      for (int i = 0; i < desiredLength; i++) {
+        Collections.swap(valueList, i, ThreadLocalRandom.current().nextInt(i, valueList.size()));
       }
-
-      return outputValueList;
+      return valueList.subList(0, desiredLength);
     }
 
-    int index = ThreadLocalRandom.current().nextInt(candidateValueList.size());
-    return candidateValueList.get(index);
+    int index = ThreadLocalRandom.current().nextInt(valueList.size());
+    return valueList.get(index);
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/PickRandomHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/PickRandomHelper.java
@@ -40,20 +40,8 @@ public class PickRandomHelper extends HandlebarsHelper<Object> {
 
     Integer count = (Integer) options.hash.get("count");
     if (count != null && count > 0) {
-      final List<Object> outputValueList = new ArrayList<>(count);
-      final Set<Integer> usedIndexes = new HashSet<>();
-
-      for (int i = 0; i < count && usedIndexes.size() < candidateValueList.size(); i++) {
-        int index = -1;
-        while (index == -1 || usedIndexes.contains(index)) {
-          index = ThreadLocalRandom.current().nextInt(candidateValueList.size());
-        }
-
-        outputValueList.add(candidateValueList.get(index));
-        usedIndexes.add(index);
-      }
-
-      return outputValueList;
+      Collections.shuffle(candidateValueList);
+      return candidateValueList.subList(0, Math.min(candidateValueList.size(), count));
     }
 
     int index = ThreadLocalRandom.current().nextInt(candidateValueList.size());

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/PickRandomHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/PickRandomHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Thomas Akehurst
+ * Copyright (C) 2020-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,6 @@ public class PickRandomHelper extends HandlebarsHelper<Object> {
     }
 
     int index = ThreadLocalRandom.current().nextInt(valueList.size());
-    return valueList.get(index).toString();
+    return valueList.get(index);
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/PickRandomHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/PickRandomHelper.java
@@ -40,8 +40,20 @@ public class PickRandomHelper extends HandlebarsHelper<Object> {
 
     Integer count = (Integer) options.hash.get("count");
     if (count != null && count > 0) {
-      Collections.shuffle(candidateValueList);
-      return candidateValueList.subList(0, Math.min(candidateValueList.size(), count));
+      final List<Object> outputValueList = new ArrayList<>(count);
+      final Set<Integer> usedIndexes = new HashSet<>();
+
+      for (int i = 0; i < count && usedIndexes.size() < candidateValueList.size(); i++) {
+        int index = -1;
+        while (index == -1 || usedIndexes.contains(index)) {
+          index = ThreadLocalRandom.current().nextInt(candidateValueList.size());
+        }
+
+        outputValueList.add(candidateValueList.get(index));
+        usedIndexes.add(index);
+      }
+
+      return outputValueList;
     }
 
     int index = ThreadLocalRandom.current().nextInt(candidateValueList.size());

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -44,6 +44,7 @@ import java.util.UUID;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 public class ResponseTemplateTransformerTest {
@@ -753,6 +754,24 @@ public class ResponseTemplateTransformerTest {
                 + "{{lookup (pickRandom (array one two three)) 'level'}}");
 
     assertThat(body.trim(), anyOf(is("1"), is("2"), is("3")));
+  }
+
+  @RepeatedTest(10)
+  void picksMultipleRandomItemsFromListVariableWhenCountSpecified() {
+    String body =
+        transform(
+            "{{val (pickRandom (array 1 2 3 4 5) count=3) assign='values'}}{{values.0}} {{values.1}} {{values.2}}");
+
+    assertThat(body, matchesRegex("\\d\\ \\d \\d"));
+    assertThat(body.split(" ")[0], not(body.split(" ")[1]));
+  }
+
+  @Test
+  void picksAsManyRandomItemsAsPossibleFromListVariableWhenCountSpecifiedHigherThanItemCount() {
+    String body =
+        transform("{{val (pickRandom (array 1 2 3 4 5) count=8) assign='values'}}{{size values}}");
+
+    assertThat(body, matchesRegex("5"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -760,16 +760,16 @@ public class ResponseTemplateTransformerTest {
   void picksMultipleRandomItemsFromListVariableWhenCountSpecified() {
     String body =
         transform(
-            "{{val (pickRandom (array 1 2 3 4 5) count=3) assign='values'}}{{values.0}} {{values.1}} {{values.2}}");
+            "{{val (pickRandom (array 1 2 3 4 5) count=3) assign='result'}}{{result.0}} {{result.1}} {{result.2}}");
 
-    assertThat(body, matchesRegex("\\d\\ \\d \\d"));
+    assertThat(body, matchesRegex("\\d \\d \\d"));
     assertThat(body.split(" ")[0], not(body.split(" ")[1]));
   }
 
   @Test
   void picksAsManyRandomItemsAsPossibleFromListVariableWhenCountSpecifiedHigherThanItemCount() {
     String body =
-        transform("{{val (pickRandom (array 1 2 3 4 5) count=8) assign='values'}}{{size values}}");
+        transform("{{val (pickRandom (array 1 2 3 4 5) count=8) assign='result'}}{{size result}}");
 
     assertThat(body, matchesRegex("5"));
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -744,6 +744,18 @@ public class ResponseTemplateTransformerTest {
   }
 
   @Test
+  void picksRandomObjectFromListVariable() {
+    String body =
+        transform(
+            "{{val (parseJson '{\"level\":1}') assign='one'}}\n"
+                + "{{val (parseJson '{\"level\":2}') assign='two'}}\n"
+                + "{{val (parseJson '{\"level\":3}') assign='three'}}\n"
+                + "{{lookup (pickRandom (array one two three)) 'level'}}");
+
+    assertThat(body.trim(), anyOf(is("1"), is("2"), is("3")));
+  }
+
+  @Test
   public void squareBracketedRequestParameters1() {
     String body =
         transform(

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -760,9 +760,9 @@ public class ResponseTemplateTransformerTest {
   void picksMultipleRandomItemsFromListVariableWhenCountSpecified() {
     String body =
         transform(
-            "{{val (pickRandom (array 1 2 3 4 5) count=3) assign='result'}}{{result.0}} {{result.1}} {{result.2}}");
+            "{{val (pickRandom (array 1 2 3 4 5) count=3) assign='result'}}{{result.0}} {{result.1}} {{result.2}} size={{size result}}");
 
-    assertThat(body, matchesRegex("\\d \\d \\d"));
+    assertThat(body, matchesRegex("\\d \\d \\d size=3"));
     assertThat(body.split(" ")[0], not(body.split(" ")[1]));
   }
 


### PR DESCRIPTION
* Return objects instead of `.toString()` to support further processing.
* Allow an optional `count` to be specified, returning a collection of items with no duplicates.