### PR TITLE
Add fail fast option to EqualToJson

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -224,12 +224,17 @@ public class WireMock {
   }
 
   public static StringValuePattern equalToJson(String value) {
-    return new EqualToJsonPattern(value, null, null);
+    return new EqualToJsonPattern(value, null, null, null);
   }
 
   public static StringValuePattern equalToJson(
       String value, boolean ignoreArrayOrder, boolean ignoreExtraElements) {
-    return new EqualToJsonPattern(value, ignoreArrayOrder, ignoreExtraElements);
+    return new EqualToJsonPattern(value, ignoreArrayOrder, ignoreExtraElements, false);
+  }
+
+  public static StringValuePattern equalToJson(
+      String value, boolean ignoreArrayOrder, boolean ignoreExtraElements, boolean failFast) {
+    return new EqualToJsonPattern(value, ignoreArrayOrder, ignoreExtraElements, failFast);
   }
 
   public static StringValuePattern matchingJsonPath(String value) {

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToJsonPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToJsonPattern.java
@@ -35,25 +35,38 @@ public class EqualToJsonPattern extends StringValuePattern {
   private final Boolean ignoreArrayOrder;
   private final Boolean ignoreExtraElements;
   private final Boolean serializeAsString;
+  private final Boolean failFast;
 
   public EqualToJsonPattern(
       @JsonProperty("equalToJson") String json,
       @JsonProperty("ignoreArrayOrder") Boolean ignoreArrayOrder,
-      @JsonProperty("ignoreExtraElements") Boolean ignoreExtraElements) {
+      @JsonProperty("ignoreExtraElements") Boolean ignoreExtraElements,
+      @JsonProperty("failFast") Boolean failFast) {
     super(json);
     expected = Json.read(json, JsonNode.class);
     this.ignoreArrayOrder = ignoreArrayOrder;
     this.ignoreExtraElements = ignoreExtraElements;
     this.serializeAsString = true;
+    this.failFast = failFast;
+  }
+
+  public EqualToJsonPattern(String json, Boolean ignoreArrayOrder, Boolean ignoreExtraElements) {
+    this(json, ignoreArrayOrder, ignoreExtraElements, false);
   }
 
   public EqualToJsonPattern(
-      JsonNode jsonNode, Boolean ignoreArrayOrder, Boolean ignoreExtraElements) {
+      JsonNode jsonNode, Boolean ignoreArrayOrder, Boolean ignoreExtraElements, Boolean failFast) {
     super(Json.write(jsonNode));
     expected = jsonNode;
     this.ignoreArrayOrder = ignoreArrayOrder;
     this.ignoreExtraElements = ignoreExtraElements;
     this.serializeAsString = false;
+    this.failFast = failFast;
+  }
+
+  public EqualToJsonPattern(
+      JsonNode jsonNode, Boolean ignoreArrayOrder, Boolean ignoreExtraElements) {
+    this(jsonNode, ignoreArrayOrder, ignoreExtraElements, false);
   }
 
   @Override
@@ -71,6 +84,10 @@ public class EqualToJsonPattern extends StringValuePattern {
     if (shouldIgnoreExtraElements()) {
       diffConfig =
           diffConfig.withOptions(Option.IGNORING_EXTRA_ARRAY_ITEMS, Option.IGNORING_EXTRA_FIELDS);
+    }
+
+    if (shouldFailFast()) {
+      diffConfig = diffConfig.withOptions(Option.FAIL_FAST);
     }
 
     final JsonNode actual;
@@ -128,6 +145,14 @@ public class EqualToJsonPattern extends StringValuePattern {
 
   public Boolean isIgnoreExtraElements() {
     return ignoreExtraElements;
+  }
+
+  private boolean shouldFailFast() {
+    return failFast != null && failFast;
+  }
+
+  public Boolean isFailFast() {
+    return failFast;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
@@ -137,12 +137,14 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
 
     Boolean ignoreArrayOrder = fromNullable(rootNode.findValue("ignoreArrayOrder"));
     Boolean ignoreExtraElements = fromNullable(rootNode.findValue("ignoreExtraElements"));
+    Boolean failFast = fromNullable(rootNode.findValue("failFast"));
 
     // Allow either a JSON value or a string containing JSON
     if (operand.isTextual()) {
-      return new EqualToJsonPattern(operand.textValue(), ignoreArrayOrder, ignoreExtraElements);
+      return new EqualToJsonPattern(
+          operand.textValue(), ignoreArrayOrder, ignoreExtraElements, failFast);
     } else {
-      return new EqualToJsonPattern(operand, ignoreArrayOrder, ignoreExtraElements);
+      return new EqualToJsonPattern(operand, ignoreArrayOrder, ignoreExtraElements, failFast);
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToJsonTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToJsonTest.java
@@ -508,7 +508,7 @@ public class EqualToJsonTest {
     assertFalse(matchWithoutFailFast.isExactMatch());
 
     MatchResult matchWithFailFast = patternWithFailFast.match(jsonToMatch);
-    assertFalse(matchWithFailFast.isExactMatch());
+    assertFalse(matchWithFailFast.isExactMatch());  
 
     assertThat(matchWithFailFast.getDistance(), lessThan(matchWithoutFailFast.getDistance()));
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToJsonTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToJsonTest.java
@@ -481,6 +481,39 @@ public class EqualToJsonTest {
   }
 
   @Test
+  public void whenFailingFastTheDistanceShouldBeLessDueToNotProcessingAllTheDifferences() {
+    String json =
+        "{\n"
+            + "    \"outer\": {\n"
+            + "        \"diff:\": true,\n"
+            + "        \"inner:\": {\n"
+            + "            \"wrong\": 1\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+    String jsonToMatch =
+        "{\n"
+            + "    \"outer\": {\n"
+            + "        \"inner:\": {\n"
+            + "            \"thing\": 1\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+
+    EqualToJsonPattern patternWithoutFailFast = new EqualToJsonPattern(json, false, false, false);
+
+    EqualToJsonPattern patternWithFailFast = new EqualToJsonPattern(json, false, false, true);
+
+    MatchResult matchWithoutFailFast = patternWithoutFailFast.match(jsonToMatch);
+    assertFalse(matchWithoutFailFast.isExactMatch());
+
+    MatchResult matchWithFailFast = patternWithFailFast.match(jsonToMatch);
+    assertFalse(matchWithFailFast.isExactMatch());
+
+    assertThat(matchWithFailFast.getDistance(), lessThan(matchWithoutFailFast.getDistance()));
+  }
+
+  @Test
   public void doesNotBreakWhenComparingNestedArraysOfDifferentSizes() {
     String expected =
         "{\"columns\": [{\"name\": \"agreementnumber\",\"a\": 1},{\"name\": \"utilizerstatus\",\"b\": 2}]}";

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToJsonTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToJsonTest.java
@@ -508,7 +508,7 @@ public class EqualToJsonTest {
     assertFalse(matchWithoutFailFast.isExactMatch());
 
     MatchResult matchWithFailFast = patternWithFailFast.match(jsonToMatch);
-    assertFalse(matchWithFailFast.isExactMatch());  
+    assertFalse(matchWithFailFast.isExactMatch());
 
     assertThat(matchWithFailFast.getDistance(), lessThan(matchWithoutFailFast.getDistance()));
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToJsonTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -290,13 +290,15 @@ public class EqualToJsonTest {
             "{\n"
                 + "    \"equalToJson\": \"2\",\n"
                 + "    \"ignoreArrayOrder\": true,\n"
-                + "    \"ignoreExtraElements\": true\n"
+                + "    \"ignoreExtraElements\": true,\n"
+                + "    \"failFast\": true\n"
                 + "}",
             StringValuePattern.class);
 
     assertThat(pattern, instanceOf(EqualToJsonPattern.class));
     assertThat(((EqualToJsonPattern) pattern).isIgnoreArrayOrder(), is(true));
     assertThat(((EqualToJsonPattern) pattern).isIgnoreExtraElements(), is(true));
+    assertThat(((EqualToJsonPattern) pattern).isFailFast(), is(true));
     assertThat(pattern.getExpected(), is("2"));
   }
 
@@ -309,7 +311,8 @@ public class EqualToJsonTest {
             + expectedJson
             + ",  \n"
             + "    \"ignoreArrayOrder\": true,             \n"
-            + "    \"ignoreExtraElements\": true           \n"
+            + "    \"ignoreExtraElements\": true,           \n"
+            + "    \"failFast\": true                       \n"
             + "}                                             ";
     StringValuePattern pattern = Json.read(serializedJson, StringValuePattern.class);
 
@@ -323,7 +326,7 @@ public class EqualToJsonTest {
   public void correctlySerialisesToJsonValueWhenAdditionalParamsPresentAndConstructedWithJsonValue()
       throws JSONException {
     String expectedJson = "{ \"someKey\": \"someValue\" }";
-    EqualToJsonPattern pattern = new EqualToJsonPattern(Json.node(expectedJson), true, true);
+    EqualToJsonPattern pattern = new EqualToJsonPattern(Json.node(expectedJson), true, true, true);
 
     String serialised = Json.write(pattern);
     String expected =
@@ -332,7 +335,8 @@ public class EqualToJsonTest {
             + expectedJson
             + ",  \n"
             + "    \"ignoreArrayOrder\": true,             \n"
-            + "    \"ignoreExtraElements\": true           \n"
+            + "    \"ignoreExtraElements\": true,           \n"
+            + "    \"failFast\": true                       \n"
             + "}                                             ";
     JSONAssert.assertEquals(expected, serialised, false);
   }
@@ -340,14 +344,15 @@ public class EqualToJsonTest {
   @Test
   public void correctlySerialisesToJsonWhenAdditionalParamsPresentAndConstructedWithString()
       throws JSONException {
-    EqualToJsonPattern pattern = new EqualToJsonPattern("4444", true, true);
+    EqualToJsonPattern pattern = new EqualToJsonPattern("4444", true, true, true);
 
     String serialised = Json.write(pattern);
     JSONAssert.assertEquals(
         "{\n"
             + "    \"equalToJson\": \"4444\",\n"
             + "    \"ignoreArrayOrder\": true,\n"
-            + "    \"ignoreExtraElements\": true\n"
+            + "    \"ignoreExtraElements\": true,\n"
+            + "    \"failFast\": true\n"
             + "}",
         serialised,
         false);
@@ -617,12 +622,7 @@ public class EqualToJsonTest {
 
     assertThat(match.getSubEvents().size(), is(1));
     Errors.Error error =
-        match.getSubEvents().stream()
-            .findFirst()
-            .get()
-            .getDataAs(Errors.class)
-            .getErrors()
-            .stream()
+        match.getSubEvents().stream().findFirst().get().getDataAs(Errors.class).getErrors().stream()
             .findFirst()
             .get();
     assertThat(error.getDetail(), startsWith("Unexpected end-of-input"));

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPatternTest.java
@@ -385,7 +385,7 @@ public class MatchesJsonPathPatternTest {
   @Test
   public void correctlySerialisesWhenSubMatcherHasExtraParameters() {
     StringValuePattern matcher =
-        new MatchesJsonPathPattern("$..thing", WireMock.equalToJson("{}", true, true));
+        new MatchesJsonPathPattern("$..thing", WireMock.equalToJson("{}", true, true, true));
 
     String json = Json.write(matcher);
 
@@ -397,7 +397,8 @@ public class MatchesJsonPathPatternTest {
                 + "        \"expression\": \"$..thing\",   \n"
                 + "        \"equalToJson\": \"{}\",        \n"
                 + "        \"ignoreExtraElements\": true,  \n"
-                + "        \"ignoreArrayOrder\": true      \n"
+                + "        \"ignoreArrayOrder\": true,      \n"
+                + "        \"failFast\": true               \n"
                 + "    }                                   \n"
                 + "}"));
   }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

In a recent release of JsonUnit, a `FAIL_FAST` option was added to improve performance.  This allows the diff comparison to exit out when the first difference is found instead of processing all the differences.  This PR adds a new `failFast` property to the `EqualToJsonPattern` to allow us to turn this property on or off.  To maintain backwards compatibility this is turned off (`false`) by default. 

## References

- https://github.com/lukas-krecan/JsonUnit/pull/785

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
