### PR TITLE
disallow json schemas to be invalid json.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPattern.java
@@ -53,11 +53,10 @@ public class MatchesJsonSchemaPattern extends StringValuePattern {
     final JsonSchemaFactory schemaFactory =
         JsonSchemaFactory.getInstance(schemaVersion.toVersionFlag());
     JsonSchema schema;
-    JsonNode schemaAsJson;
+    JsonNode schemaAsJson = Json.read(schemaJson, JsonNode.class);
     int schemaPropertyCount;
     Errors invalidSchemaErrors;
     try {
-      schemaAsJson = Json.read(schemaJson, JsonNode.class);
       schema = schemaFactory.getSchema(schemaAsJson, config);
       schemaPropertyCount = Json.schemaPropertyCount(schemaAsJson);
       invalidSchemaErrors = null;

--- a/src/test/java/com/github/tomakehurst/wiremock/JsonSchemaMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/JsonSchemaMatchingAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,15 @@ package com.github.tomakehurst.wiremock;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.file;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class JsonSchemaMatchingAcceptanceTest extends AcceptanceTestBase {
 
@@ -59,6 +64,45 @@ public class JsonSchemaMatchingAcceptanceTest extends AcceptanceTestBase {
   void doesNotMatchStubWhenRequestBodyIsNotValidJson() {
     String schema = file("schema-validation/new-pet.schema.json");
     String json = file("schema-validation/new-pet.unparseable.json");
+
+    stubFor(
+        post(urlPathEqualTo("/schema-match"))
+            .withRequestBody(matchingJsonSchema(schema))
+            .willReturn(ok()));
+
+    WireMockResponse response = testClient.postJson("/schema-match", json);
+
+    assertThat(response.statusCode(), is(404));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "",
+        "not json",
+        "{\"type\": \"string\"",
+      })
+  void doesNotAcceptStubWhenSchemaIsNotValidJson(String schema) {
+    InvalidInputException e =
+        assertThrows(
+            InvalidInputException.class,
+            () ->
+                stubFor(
+                    post(urlPathEqualTo("/schema-match"))
+                        .withRequestBody(matchingJsonSchema(schema))
+                        .willReturn(ok())));
+
+    assertThat(wireMockServer.getStubMappings(), is(empty()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "{\"id\": 1, \"name\": \"alice\"}",
+        "{\"type\": \"array\", \"items\": {\"$ref\": \"#/does/not/exist\"}}",
+      })
+  void doesNotMatchStubWhenSchemaIsValidJsonButNotValidSchema(String schema) {
+    String json = "{\"id\": 1, \"name\": \"alice\"}";
 
     stubFor(
         post(urlPathEqualTo("/schema-match"))


### PR DESCRIPTION
https://github.com/wiremock/wiremock/pull/2803 explicitly allowed the creation of stubs containing invalid json schemas to account for the possibility of schemas becoming valid/invalid after creation. that pr went a bit too far by allowing json schemas that weren't even valid json (which will always be invalid schemas). this creates problems as other methods in MatchesJsonSchemaPattern expect the schema to at least be valid json. this pr disallows invalid json but keeps the other allowances.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)