### PR TITLE
Allow Admin implementations to clean up resources

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -212,7 +212,7 @@ public class WireMockServer implements Container, Stubbing, Admin {
               } catch (InterruptedException e) {
                 throw new RuntimeException(e);
               }
-              server.stop();
+              server.close();
             });
     shutdownThread.start();
   }
@@ -569,6 +569,12 @@ public class WireMockServer implements Container, Stubbing, Admin {
   @Override
   public GetGlobalSettingsResult getGlobalSettings() {
     return wireMockApp.getGlobalSettings();
+  }
+
+  @Override
+  public void close() {
+    stop();
+    wireMockApp.close();
   }
 
   public void checkForUnmatchedRequests() {

--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -47,6 +47,7 @@ import com.github.tomakehurst.wiremock.security.NotAuthorisedException;
 import com.github.tomakehurst.wiremock.stubbing.StubImport;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.verification.*;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
@@ -432,6 +433,11 @@ public class HttpAdminClient implements Admin {
   public GetGlobalSettingsResult getGlobalSettings() {
     return executeRequest(
         adminRoutes.requestSpecForTask(GetGlobalSettingsTask.class), GetGlobalSettingsResult.class);
+  }
+
+  @Override
+  public void close() throws IOException {
+    httpClient.close();
   }
 
   public int port() {

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.verification.*;
 import java.util.UUID;
 
-public interface Admin {
+public interface Admin extends AutoCloseable {
 
   void addStubMapping(StubMapping stubMapping);
 
@@ -113,4 +113,7 @@ public interface Admin {
   void importStubs(StubImport stubImport);
 
   GetGlobalSettingsResult getGlobalSettings();
+
+  @Override
+  default void close() throws Exception {}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -619,6 +619,11 @@ public class WireMockApp implements StubServer, Admin {
     }
   }
 
+  @Override
+  public void close() {
+    shutdownServer();
+  }
+
   public Set<String> getLoadedExtensionNames() {
     return extensions.getAllExtensionNames();
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/junit/DslWrapper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/DslWrapper.java
@@ -351,4 +351,9 @@ public class DslWrapper implements Admin, Stubbing {
   public List<NearMiss> findAllNearMissesFor(RequestPatternBuilder requestPatternBuilder) {
     return stubbing.findAllNearMissesFor(requestPatternBuilder);
   }
+
+  @Override
+  public void close() throws Exception {
+    admin.close();
+  }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockClassRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockClassRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Thomas Akehurst
+ * Copyright (C) 2013-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ public class WireMockClassRule extends WireMockServer implements MethodRule, Tes
             base.evaluate();
           } finally {
             after();
-            stop();
+            close();
           }
         }
       }

--- a/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public class WireMockRule extends WireMockServer implements TestRule {
           }
         } finally {
           after();
-          stop();
+          close();
         }
       }
     };

--- a/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockStaticRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockStaticRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Thomas Akehurst
+ * Copyright (C) 2012-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ public class WireMockStaticRule implements MethodRule {
   }
 
   public void stopServer() {
-    wireMockServer.stop();
+    wireMockServer.close();
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -268,7 +268,7 @@ public class WireMockExtension extends DslWrapper
 
   private void stopServerIfRunning() {
     if (wireMockServer.isRunning()) {
-      wireMockServer.stop();
+      wireMockServer.close();
     }
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,7 +125,7 @@ public class WireMockServerRunner {
 
   public void stop() {
     if (wireMockServer != null) {
-      wireMockServer.stop();
+      wireMockServer.close();
     }
   }
 

--- a/src/test/java/benchmarks/JsonPathAdvancedMatchingBenchmark.java
+++ b/src/test/java/benchmarks/JsonPathAdvancedMatchingBenchmark.java
@@ -78,7 +78,7 @@ public class JsonPathAdvancedMatchingBenchmark {
 
     @TearDown
     public void tearDown() {
-      wm.stop();
+      wm.close();
     }
   }
 

--- a/src/test/java/benchmarks/JsonPathSimpleMatchingBenchmark.java
+++ b/src/test/java/benchmarks/JsonPathSimpleMatchingBenchmark.java
@@ -78,7 +78,7 @@ public class JsonPathSimpleMatchingBenchmark {
 
     @TearDown
     public void tearDown() {
-      wm.stop();
+      wm.close();
     }
   }
 

--- a/src/test/java/benchmarks/PathAndMethodMatchingBenchmark.java
+++ b/src/test/java/benchmarks/PathAndMethodMatchingBenchmark.java
@@ -60,7 +60,7 @@ public class PathAndMethodMatchingBenchmark {
 
     @TearDown
     public void tearDown() {
-      wm.stop();
+      wm.close();
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
@@ -55,7 +55,7 @@ public class AcceptanceTestBase {
 
   @AfterAll
   public static void serverShutdown() {
-    wireMockServer.stop();
+    wireMockServer.close();
   }
 
   public static void setupServerWithEmptyFileRoot() {

--- a/src/test/java/com/github/tomakehurst/wiremock/BindAddressTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/BindAddressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public class BindAddressTest {
   @AfterEach
   public void stop() {
     if (wireMockServer != null) {
-      wireMockServer.stop();
+      wireMockServer.close();
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/BrowserProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/BrowserProxyAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Thomas Akehurst
+ * Copyright (C) 2013-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ class BrowserProxyAcceptanceTest {
   @AfterEach
   public void stopServer() {
     if (proxy.isRunning()) {
-      proxy.stop();
+      proxy.close();
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/DeadlockTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/DeadlockTest.java
@@ -48,7 +48,7 @@ public class DeadlockTest {
 
   @AfterAll
   public static void tearDown() {
-    wireMockServer.stop();
+    wireMockServer.close();
   }
 
   @BeforeEach

--- a/src/test/java/com/github/tomakehurst/wiremock/ExtensionFactoryTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ExtensionFactoryTest.java
@@ -50,7 +50,7 @@ public class ExtensionFactoryTest {
   @AfterEach
   void stopServer() {
     if (wm != null) {
-      wm.stop();
+      wm.close();
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpClientSubstitutionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpClientSubstitutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public class HttpClientSubstitutionTest {
 
   @AfterEach
   void cleanup() {
-    wm.stop();
+    wm.close();
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpsAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Thomas Akehurst
+ * Copyright (C) 2013-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,11 +70,11 @@ class HttpsAcceptanceTest {
   @AfterEach
   public void serverShutdown() {
     if (wireMockServer != null) {
-      wireMockServer.stop();
+      wireMockServer.close();
     }
 
     if (proxy != null) {
-      proxy.shutdown();
+      proxy.close();
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
@@ -182,7 +182,7 @@ public class HttpsBrowserProxyAcceptanceTest {
 
       assertThat(response.statusCode(), is(500));
     } finally {
-      scepticalProxy.stop();
+      scepticalProxy.close();
     }
   }
 
@@ -208,7 +208,7 @@ public class HttpsBrowserProxyAcceptanceTest {
       assertThat(response.statusCode(), is(200));
       assertThat(response.content(), is("Got it"));
     } finally {
-      scepticalProxy.stop();
+      scepticalProxy.close();
     }
   }
 
@@ -233,7 +233,7 @@ public class HttpsBrowserProxyAcceptanceTest {
       assertThat(response.statusCode(), is(200));
       assertThat(response.content(), is("Got it"));
     } finally {
-      scepticalProxy.stop();
+      scepticalProxy.close();
     }
   }
 
@@ -281,7 +281,7 @@ public class HttpsBrowserProxyAcceptanceTest {
 
       // then no exception is thrown
     } finally {
-      proxyWithCustomCaKeyStore.stop();
+      proxyWithCustomCaKeyStore.close();
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/JvmProxyConfigAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/JvmProxyConfigAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public class JvmProxyConfigAcceptanceTest {
   @AfterEach
   public void cleanup() {
     if (wireMockServer != null) {
-      wireMockServer.stop();
+      wireMockServer.close();
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/MappingsLoaderAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MappingsLoaderAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class MappingsLoaderAcceptanceTest {
 
   @AfterEach
   public void stopWireMock() {
-    wireMockServer.stop();
+    wireMockServer.close();
   }
 
   private void buildWireMock(Options options) {

--- a/src/test/java/com/github/tomakehurst/wiremock/NotMatchedPageAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/NotMatchedPageAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class NotMatchedPageAcceptanceTest {
 
   @AfterEach
   public void stop() {
-    wm.stop();
+    wm.close();
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/PortNumberTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/PortNumberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public class PortNumberTest {
   public void stopServers() {
     for (WireMockServer wireMockServer : createdServers) {
       if (wireMockServer.isRunning()) {
-        wireMockServer.stop();
+        wireMockServer.close();
       }
     }
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/PostServeActionExtensionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/PostServeActionExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class PostServeActionExtensionTest {
   @AfterEach
   public void cleanup() {
     if (wm != null) {
-      wm.stop();
+      wm.close();
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
@@ -102,8 +102,8 @@ public class ProxyAcceptanceTest {
 
   @AfterEach
   public void stop() {
-    targetService.stop();
-    proxyingService.stop();
+    targetService.close();
+    proxyingService.close();
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/RecordApiAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecordApiAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ public class RecordApiAcceptanceTest extends AcceptanceTestBase {
   public void proxyServerShutdown() {
     // delete any persisted stub mappings to ensure test isolation
     proxyingService.resetMappings();
-    proxyingService.stop();
+    proxyingService.close();
   }
 
   private static final String DEFAULT_SNAPSHOT_RESPONSE =

--- a/src/test/java/com/github/tomakehurst/wiremock/RecordingDslAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecordingDslAcceptanceTest.java
@@ -79,7 +79,7 @@ public class RecordingDslAcceptanceTest extends AcceptanceTestBase {
   @AfterEach
   public void proxyServerShutdown() {
     proxyingService.resetMappings();
-    proxyingService.stop();
+    proxyingService.close();
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/RequestFilterAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RequestFilterAcceptanceTest.java
@@ -139,7 +139,7 @@ public class RequestFilterAcceptanceTest {
 
     assertThat(client.get("/subpath/item").content(), is("From the proxy"));
 
-    proxyTarget.stop();
+    proxyTarget.close();
   }
 
   @BeforeEach
@@ -149,7 +149,7 @@ public class RequestFilterAcceptanceTest {
 
   @AfterEach
   public void stopServer() {
-    wm.stop();
+    wm.close();
   }
 
   private void initialise(RequestFilter... filters) {

--- a/src/test/java/com/github/tomakehurst/wiremock/RequestFilterV2AcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RequestFilterV2AcceptanceTest.java
@@ -160,7 +160,7 @@ public class RequestFilterV2AcceptanceTest {
 
     assertThat(client.get("/subpath/item").content(), is("From the proxy"));
 
-    proxyTarget.stop();
+    proxyTarget.close();
   }
 
   @Test
@@ -196,7 +196,7 @@ public class RequestFilterV2AcceptanceTest {
 
   @AfterEach
   public void stopServer() {
-    wm.stop();
+    wm.close();
   }
 
   private void initialise(Extension... filters) {

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionBuilderAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionBuilderAcceptanceTest.java
@@ -36,7 +36,7 @@ public class ResponseDefinitionBuilderAcceptanceTest {
 
   @AfterEach
   public void stopServer() {
-    wm.stop();
+    wm.close();
   }
 
   private void initialise() {

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionTransformerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionTransformerAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2023 Thomas Akehurst
+ * Copyright (C) 2014-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,7 +178,7 @@ public class ResponseDefinitionTransformerAcceptanceTest {
   @AfterEach
   public void cleanup() {
     if (wm != null) {
-      wm.stop();
+      wm.close();
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionTransformerV2AcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionTransformerV2AcceptanceTest.java
@@ -199,7 +199,7 @@ public class ResponseDefinitionTransformerV2AcceptanceTest {
   @AfterEach
   public void cleanup() {
     if (wm != null) {
-      wm.stop();
+      wm.close();
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/ServeEventListenerExtensionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ServeEventListenerExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ public class ServeEventListenerExtensionTest {
   @AfterEach
   public void cleanup() {
     if (wm != null) {
-      wm.stop();
+      wm.close();
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ public class SnapshotDslAcceptanceTest extends AcceptanceTestBase {
   @AfterEach
   public void proxyServerShutdown() {
     proxyingService.resetMappings();
-    proxyingService.stop();
+    proxyingService.close();
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -97,7 +97,7 @@ public class StandaloneAcceptanceTest {
   public void stopServerRunner() {
     runner.stop();
     if (otherServer != null) {
-      otherServer.stop();
+      otherServer.close();
     }
     System.setOut(stdOut);
     System.setErr(stdErr);

--- a/src/test/java/com/github/tomakehurst/wiremock/TransferEncodingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/TransferEncodingAcceptanceTest.java
@@ -156,6 +156,6 @@ public class TransferEncodingAcceptanceTest {
 
   @AfterEach
   public void cleanup() {
-    wm.stop();
+    wm.close();
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockClientWithProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockClientWithProxyAcceptanceTest.java
@@ -46,7 +46,7 @@ public class WireMockClientWithProxyAcceptanceTest {
 
   @AfterAll
   public static void stopServer() {
-    wireMockServer.stop();
+    wireMockServer.close();
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Thomas Akehurst
+ * Copyright (C) 2013-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class WireMockServerTests {
       wireMockServer.start();
     } finally {
       if (wireMockServer != null) {
-        wireMockServer.stop();
+        wireMockServer.close();
       }
     }
   }
@@ -62,7 +62,8 @@ public class WireMockServerTests {
 
   @Test
   public void addFilenameTemplateAsOptionAndValidFormat() {
-    Options options = options().dynamicPort().filenameTemplate("{{{request.url}}}-{{{request.url}}}.json");
+    Options options =
+        options().dynamicPort().filenameTemplate("{{{request.url}}}-{{{request.url}}}.json");
     WireMockServer wireMockServer = new WireMockServer(options);
     wireMockServer.start();
     assertThat(wireMockServer.getOptions(), is(options));

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ClientAuthenticationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ClientAuthenticationAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ class ClientAuthenticationAcceptanceTest {
 
   @AfterEach
   public void stopServer() {
-    server.stop();
+    server.close();
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
@@ -44,7 +44,7 @@ class WireMockClientAcceptanceTest {
 
   @AfterEach
   public void stopServer() {
-    wireMockServer.stop();
+    wireMockServer.close();
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientWithProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientWithProxyAcceptanceTest.java
@@ -46,7 +46,7 @@ public class WireMockClientWithProxyAcceptanceTest {
 
   @AfterAll
   public static void stopServer() {
-    wireMockServer.stop();
+    wireMockServer.close();
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/mappingssource/MappingsLoaderExtensionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/mappingssource/MappingsLoaderExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public class MappingsLoaderExtensionTest {
 
   @AfterEach
   public void stopWireMock() {
-    wireMockServer.stop();
+    wireMockServer.close();
   }
 
   private void buildWireMock(Options options) {

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/webhooks/WebhooksRegistrationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/webhooks/WebhooksRegistrationTest.java
@@ -22,11 +22,8 @@ import static org.hamcrest.Matchers.not;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.standalone.WireMockServerRunner;
-import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
-
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,7 +57,7 @@ class WebhooksRegistrationTest {
 
   private void stopServer() {
     if (server != null && server.isRunning()) {
-      server.stop();
+      server.close();
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
@@ -101,7 +101,7 @@ public abstract class HttpClientFactoryCertificateVerificationTest {
   @AfterEach
   public void stopServer() {
     if (server != null) {
-      server.stop();
+      server.close();
     }
   }
 

--- a/src/test/java/ignored/JUnit5ProxyTest.java
+++ b/src/test/java/ignored/JUnit5ProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ public class JUnit5ProxyTest {
     responseBody = EntityUtils.toString(response.getEntity());
     assertEquals("Domain 2", responseBody);
 
-    wireMockServer.stop();
+    wireMockServer.close();
     JvmProxyConfigurer.restorePrevious();
   }
 }

--- a/src/test/scala/com/github/tomakehurst/wiremock/WireMockScalaAcceptanceTest.scala
+++ b/src/test/scala/com/github/tomakehurst/wiremock/WireMockScalaAcceptanceTest.scala
@@ -40,7 +40,7 @@ class WireMockScalaAcceptanceTest {
 	
 	@AfterEach
 	def stopServer(): Unit = {
-		wireMockServer.stop()
+		wireMockServer.close()
 	}
 
 	@Test


### PR DESCRIPTION
By making `Admin` extend `Autocloseable` we are able to allow
`HttpAdminClient` to call close on its `CloseableHttpClient`, releasing
the resources.

In the process we can also allow `WireMockServer` & `WireMockApp` to
work with try-with-resources.

<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
