### PR TITLE
Enable customization of cipher suites and TLS protocol with WiremockConfiguration

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/HttpsSettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/HttpsSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Thomas Akehurst
+ * Copyright (C) 2013-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.common;
 import static com.github.tomakehurst.wiremock.common.ResourceUtil.getResource;
 
 import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
+import java.util.Arrays;
 
 public class HttpsSettings {
 
@@ -29,6 +30,8 @@ public class HttpsSettings {
   private final String trustStorePath;
   private final String trustStorePassword;
   private final String trustStoreType;
+  private final String[] cipherSuites;
+  private final String[] tlsProtocols;
   private final boolean needClientAuth;
 
   public HttpsSettings(
@@ -40,6 +43,8 @@ public class HttpsSettings {
       String trustStorePath,
       String trustStorePassword,
       String trustStoreType,
+      String[] cipherSuites,
+      String[] tlsProtocols,
       boolean needClientAuth) {
     this.port = port;
     this.keyStorePath = keyStorePath;
@@ -49,6 +54,8 @@ public class HttpsSettings {
     this.trustStorePath = trustStorePath;
     this.trustStorePassword = trustStorePassword;
     this.trustStoreType = trustStoreType;
+    this.cipherSuites = cipherSuites;
+    this.tlsProtocols = tlsProtocols;
     this.needClientAuth = needClientAuth;
   }
 
@@ -88,12 +95,28 @@ public class HttpsSettings {
     return trustStoreType;
   }
 
+  public String[] cipherSuites() {
+    return cipherSuites;
+  }
+
+  public String[] tlsProtocols() {
+    return tlsProtocols;
+  }
+
   public boolean needClientAuth() {
     return needClientAuth;
   }
 
   public boolean hasTrustStore() {
     return trustStorePath != null;
+  }
+
+  public boolean hasCipherSuites() {
+    return cipherSuites != null;
+  }
+
+  public boolean hasTlsProtocols() {
+    return tlsProtocols != null;
   }
 
   public KeyStoreSettings trustStore() {
@@ -123,6 +146,12 @@ public class HttpsSettings {
         + ", trustStoreType='"
         + trustStoreType
         + '\''
+        + ", cipherSuites='"
+        + Arrays.toString(cipherSuites)
+        + '\''
+        + ", tlsProtocols='"
+        + Arrays.toString(tlsProtocols)
+        + '\''
         + ", needClientAuth="
         + needClientAuth
         + '}';
@@ -138,6 +167,8 @@ public class HttpsSettings {
     private String trustStorePath = null;
     private String trustStorePassword = "password";
     private String trustStoreType = "JKS";
+    private String[] cipherSuites = null;
+    private String[] tlsProtocols = null;
     private boolean needClientAuth = false;
 
     public Builder port(int port) {
@@ -180,6 +211,16 @@ public class HttpsSettings {
       return this;
     }
 
+    public Builder cipherSuites(String... cipherSuites) {
+      this.cipherSuites = cipherSuites;
+      return this;
+    }
+
+    public Builder tlsProtocols(String... tlsProtocols) {
+      this.tlsProtocols = tlsProtocols;
+      return this;
+    }
+
     public Builder needClientAuth(boolean needClientAuth) {
       this.needClientAuth = needClientAuth;
       return this;
@@ -195,6 +236,8 @@ public class HttpsSettings {
           trustStorePath,
           trustStorePassword,
           trustStoreType,
+          cipherSuites,
+          tlsProtocols,
           needClientAuth);
     }
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -79,6 +79,8 @@ public class WireMockConfiguration implements Options {
   private String trustStorePath;
   private String trustStorePassword = "password";
   private String trustStoreType = "JKS";
+  private String[] cipherSuites;
+  private String[] tlsProtocols;
   private boolean needClientAuth;
 
   private boolean browserProxyingEnabled = false;
@@ -315,6 +317,16 @@ public class WireMockConfiguration implements Options {
 
   public WireMockConfiguration trustStoreType(String trustStoreType) {
     this.trustStoreType = trustStoreType;
+    return this;
+  }
+
+  public WireMockConfiguration cipherSuites(String... cipherSuites) {
+    this.cipherSuites = cipherSuites;
+    return this;
+  }
+
+  public WireMockConfiguration tlsProtocols(String... tlsProtocols) {
+    this.tlsProtocols = cipherSuites;
     return this;
   }
 
@@ -629,6 +641,8 @@ public class WireMockConfiguration implements Options {
         .trustStorePath(trustStorePath)
         .trustStorePassword(trustStorePassword)
         .trustStoreType(trustStoreType)
+        .cipherSuites(cipherSuites)
+        .tlsProtocols(tlsProtocols)
         .needClientAuth(needClientAuth)
         .build();
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty11/SslContexts.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty11/SslContexts.java
@@ -39,6 +39,8 @@ public class SslContexts {
         SslContexts.defaultSslContextFactory(httpsSettings.keyStore());
     sslContextFactory.setKeyManagerPassword(httpsSettings.keyManagerPassword());
     setupClientAuth(sslContextFactory, httpsSettings);
+    setupCipherSuites(sslContextFactory, httpsSettings);
+    setupTlsProtocols(sslContextFactory, httpsSettings);
     sslContextFactory.setCipherComparator(HTTP2Cipher.COMPARATOR);
     return sslContextFactory;
   }
@@ -70,6 +72,20 @@ public class SslContexts {
       sslContextFactory.setTrustStorePassword(httpsSettings.trustStorePassword());
     }
     sslContextFactory.setNeedClientAuth(httpsSettings.needClientAuth());
+  }
+
+  private static void setupCipherSuites(
+      SslContextFactory.Server sslContextFactory, HttpsSettings httpsSettings) {
+    if (httpsSettings.hasCipherSuites()) {
+      sslContextFactory.setIncludeCipherSuites(httpsSettings.cipherSuites());
+    }
+  }
+
+  private static void setupTlsProtocols(
+      SslContextFactory.Server sslContextFactory, HttpsSettings httpsSettings) {
+    if (httpsSettings.hasTlsProtocols()) {
+      sslContextFactory.setIncludeProtocols(httpsSettings.tlsProtocols());
+    }
   }
 
   private static SslContextFactory.Server buildSslContextFactory(


### PR DESCRIPTION
Adds the ability to customize cipher suites and tls protocols in `WireMockServer` using `WiremockConfiguration`.
With this PR it will be possible to simulate cases where external services deprecates certain tls protocols or cipher suites to guarantee the tested application will continue to work with the remaining supported tls protocol or cipher suites.

When instantiating an WireMockServer will be possible to configure the cipher suites and tls protocol like below:

```java
private static final WireMockServer wireMockServer = new WireMockServer(options()
        .needClientAuth(true)
        .httpDisabled(true)
        .httpsPort(6666)
        .tlsProtocols(LIST_OF_TLS_PROTOCOLS)
        .cipherSuites(LIST_OF_CIPHERS));
```

## References
https://wiremock-community.slack.com/archives/C03N1E6HFPY/p1720564292990239
https://groups.google.com/g/wiremock-user/c/YbgTErqt5ts


- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->
https://github.com/wiremock/wiremock/issues/2808

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
