### PR TITLE
fix failing diffing for multiple path params.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
@@ -297,6 +297,7 @@ public class Diff {
         String parameterName = entry.getKey();
         final String parameterValue = entry.getValue();
         final StringValuePattern pattern = pathParameters.get(parameterName);
+        if (pattern == null) continue;
         String operator = generateOperatorString(pattern, " = ");
         DiffLine<String> section =
             new DiffLine<>(

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/diff/DiffTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/diff/DiffTest.java
@@ -558,4 +558,21 @@ class DiffTest {
                 "ANY\n" + "/thing\n" + "\n" + "$.accountNum [equalTo] 1234",
                 "ANY\n" + "/thing\n" + "\n" + "not json")));
   }
+
+  @Test
+  void pathParametersWithNoMatcherAreNotRendered() {
+    Diff diff =
+        new Diff(
+            newRequestPattern(ANY, urlPathTemplate("/things/{thingId}/bookings/{bookingId}"))
+                .withPathParam("thingId", equalTo("1234"))
+                .build(),
+            mockRequest().url("/things/4321/bookings/whatever"));
+
+    assertThat(
+        diff.toString(),
+        is(
+            junitStyleDiffMessage(
+                "ANY\n/things/4321/bookings/whatever\n\nPath parameter: thingId = 1234\n",
+                "ANY\n/things/4321/bookings/whatever\n\n4321\n")));
+  }
 }


### PR DESCRIPTION
Fixes diff report rendering failures when a stub contains multiple path parameters but only some have matchers.

## References

Fixes https://github.com/wiremock/wiremock/issues/2826

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)