### PR TITLE
Add option to enable jetty12 virtual threads

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -158,4 +158,6 @@ public interface Options {
   Set<String> getSupportedProxyEncodings();
 
   boolean getDisableConnectionReuse();
+
+  boolean getVirtualThreadsEnabled();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -152,6 +152,8 @@ public class WireMockConfiguration implements Options {
 
   private Set<String> supportedProxyEncodings = null;
 
+  private boolean virtualThreadsEnabled = false;
+
   private MappingsSource getMappingsSource() {
     if (mappingsSource == null) {
       mappingsSource =
@@ -593,6 +595,11 @@ public class WireMockConfiguration implements Options {
     return withSupportedProxyEncodings(Set.of(supportedProxyEncodings));
   }
 
+  public WireMockConfiguration virtualThreadsEnabled(boolean virtualThreadsEnabled) {
+    this.virtualThreadsEnabled = virtualThreadsEnabled;
+    return this;
+  }
+
   @Override
   public int portNumber() {
     return portNumber;
@@ -886,5 +893,10 @@ public class WireMockConfiguration implements Options {
   @Override
   public Set<String> getSupportedProxyEncodings() {
     return supportedProxyEncodings;
+  }
+
+  @Override
+  public boolean getVirtualThreadsEnabled() {
+    return virtualThreadsEnabled;
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServer.java
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.core.WireMockApp;
 import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
 import com.github.tomakehurst.wiremock.http.HttpServer;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
+import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.servlet.*;
 import java.io.IOException;
@@ -66,7 +67,7 @@ public abstract class JettyHttpServer implements HttpServer {
       STRICT_HTTP_HEADERS_APPLIED.set(true);
     }
 
-    jettyServer = createServer(options);
+    jettyServer = createServer(options, options.threadPoolFactory());
 
     NetworkTrafficListenerAdapter networkTrafficListenerAdapter =
         new NetworkTrafficListenerAdapter(options.networkTrafficListener());
@@ -116,8 +117,8 @@ public abstract class JettyHttpServer implements HttpServer {
     }
   }
 
-  protected Server createServer(Options options) {
-    final Server server = new Server(options.threadPoolFactory().buildThreadPool(options));
+  protected Server createServer(Options options, ThreadPoolFactory threadPoolFactory) {
+    final Server server = new Server(threadPoolFactory.buildThreadPool(options));
     final JettySettings jettySettings = options.jettySettings();
     final Optional<Long> stopTimeout = jettySettings.getStopTimeout();
     stopTimeout.ifPresent(server::setStopTimeout);

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -305,4 +305,9 @@ public class WarConfiguration implements Options {
   public Set<String> getSupportedProxyEncodings() {
     return null;
   }
+
+  @Override
+  public boolean getVirtualThreadsEnabled() {
+    return false;
+  }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -97,6 +97,7 @@ public class CommandLineOptions implements Options {
   private static final String JETTY_HEADER_RESPONSE_SIZE = "jetty-header-response-size";
   private static final String JETTY_STOP_TIMEOUT = "jetty-stop-timeout";
   private static final String JETTY_IDLE_TIMEOUT = "jetty-idle-timeout";
+  private static final String JETTY_USE_VIRTUAL_THREADS = "jetty-use-virtual-threads";
   private static final String ROOT_DIR = "root-dir";
   private static final String CONTAINER_THREADS = "container-threads";
   private static final String GLOBAL_RESPONSE_TEMPLATING = "global-response-templating";
@@ -1051,5 +1052,10 @@ public class CommandLineOptions implements Options {
     return optionSet.has(DISABLE_CONNECTION_REUSE)
         ? Boolean.parseBoolean((String) optionSet.valueOf(DISABLE_CONNECTION_REUSE))
         : DEFAULT_DISABLE_CONNECTION_REUSE;
+  }
+
+  @Override
+  public boolean getVirtualThreadsEnabled() {
+    return optionSet.has(JETTY_USE_VIRTUAL_THREADS);
   }
 }

--- a/wiremock-jetty12/build.gradle
+++ b/wiremock-jetty12/build.gradle
@@ -29,7 +29,7 @@ java {
 
 project.ext {
   versions = [
-    jetty        : '12.0.8',
+    jetty        : '12.0.10',
     junitJupiter : '5.10.2'
   ]
 }

--- a/wiremock-jetty12/src/main/java/com/github/tomakehurst/wiremock/jetty12/Jetty12HttpServer.java
+++ b/wiremock-jetty12/src/main/java/com/github/tomakehurst/wiremock/jetty12/Jetty12HttpServer.java
@@ -32,6 +32,7 @@ import com.github.tomakehurst.wiremock.core.WireMockApp;
 import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
 import com.github.tomakehurst.wiremock.http.RequestHandler;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
+import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
 import com.github.tomakehurst.wiremock.jetty.JettyFaultInjectorFactory;
 import com.github.tomakehurst.wiremock.jetty.JettyHttpServer;
 import com.github.tomakehurst.wiremock.jetty.JettyHttpUtils;
@@ -72,6 +73,14 @@ public class Jetty12HttpServer extends JettyHttpServer {
       AdminRequestHandler adminRequestHandler,
       StubRequestHandler stubRequestHandler) {
     super(options, adminRequestHandler, stubRequestHandler);
+  }
+
+  @Override
+  protected Server createServer(Options options, ThreadPoolFactory threadPoolFactory) {
+    if (options.getVirtualThreadsEnabled()) {
+      threadPoolFactory = new VirtualThreadPoolFactory();
+    }
+    return new Server(threadPoolFactory.buildThreadPool(options));
   }
 
   @Override

--- a/wiremock-jetty12/src/main/java/com/github/tomakehurst/wiremock/jetty12/VirtualThreadPoolFactory.java
+++ b/wiremock-jetty12/src/main/java/com/github/tomakehurst/wiremock/jetty12/VirtualThreadPoolFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
+import org.eclipse.jetty.util.thread.ThreadPool;
+import org.eclipse.jetty.util.thread.VirtualThreadPool;
+
+public class VirtualThreadPoolFactory implements ThreadPoolFactory {
+
+  @Override
+  public ThreadPool buildThreadPool(Options options) {
+    return new VirtualThreadPool();
+  }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Add option to enable jetty12 virtual threads pool.

## References

- https://github.com/wiremock/wiremock/issues/2735

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
