### PR TITLE
Header checks should be case-insensitive in RequestWrapper

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapper.java
@@ -169,7 +169,7 @@ public class RequestWrapper implements Request {
 
   @Override
   public boolean containsHeader(String key) {
-    return getHeaders().keys().contains(key);
+    return getHeaders().getHeader(key).isPresent();
   }
 
   @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Thomas Akehurst
+ * Copyright (C) 2019-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,17 @@ public class RequestWrapperTest {
     HttpHeader headerTwo = wrappedRequest.header("Two");
     assertThat(headerTwo.values().get(0), is("22"));
     assertThat(headerTwo.values().get(1), is("32"));
+  }
+
+  @Test
+  public void containsHeaderChecksAreCaseInsensitive() {
+    MockRequest request = mockRequest().header("One", "1");
+
+    RequestWrapper wrappedRequest = new RequestWrapper(request);
+
+    assertThat(wrappedRequest.containsHeader("one"), is(true));
+    assertThat(wrappedRequest.containsHeader("onE"), is(true));
+    assertThat(wrappedRequest.containsHeader("ONE"), is(true));
   }
 
   @Test


### PR DESCRIPTION
The `RequestWrapper` `containsHeader` method performs a case-sensitive check on the header name.  This PR updates the method to make sure the check is case-insensitive.

<!-- Please describe your pull request here. -->

## References

Fixes #2845 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
