### PR TITLE
Fixed method name typo in MultipartBodyMatchingAcceptanceTest.class

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartBodyMatchingAcceptanceTest.java
@@ -192,7 +192,7 @@ public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
     connection.setRequestProperty(
         "Content-Type", "Multipart/Form-Data; boundary=\"" + boundary + "\"");
     try (final OutputStream contentStream = connection.getOutputStream()) {
-      contentStream.write(getRequestBodyForCamelasedContentTypeInformationWithBoundary(boundary));
+      contentStream.write(getRequestBodyForCamelcasedContentTypeInformationWithBoundary(boundary));
     }
     assertThat(connection.getResponseCode(), is(200));
   }
@@ -208,7 +208,7 @@ public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
     return connection;
   }
 
-  private byte[] getRequestBodyForCamelasedContentTypeInformationWithBoundary(String boundary) {
+  private byte[] getRequestBodyForCamelcasedContentTypeInformationWithBoundary(String boundary) {
     return ("--"
             + boundary
             + "\r\n"
@@ -245,7 +245,7 @@ public class MultipartBodyMatchingAcceptanceTest extends AcceptanceTestBase {
     connection.setRequestProperty(
         "Content-Type", "    Multipart/Form-Data; boundary=\"" + boundary + "\"");
     try (final OutputStream contentStream = connection.getOutputStream()) {
-      contentStream.write(getRequestBodyForCamelasedContentTypeInformationWithBoundary(boundary));
+      contentStream.write(getRequestBodyForCamelcasedContentTypeInformationWithBoundary(boundary));
     }
     assertThat(connection.getResponseCode(), is(200));
   }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- Fixed typo in method name of MultipartBodyMatchingAcceptanceTest.class
     `getRequestBodyForCamelasedContentTypeInformationWithBoundary ` to
     `getRequestBodyForCamelcasedContentTypeInformationWithBoundary`


## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
