### PR TITLE
Bump both versions of jetty to the latest versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ group = 'org.wiremock'
 project.ext {
   versions = [
     handlebars     : '4.3.1',
-    jetty          : '11.0.20',
+    jetty          : '11.0.24',
     guava          : '33.3.1-jre',
     jackson        : '2.17.2',
     xmlUnit        : '2.10.0',

--- a/wiremock-jetty12/build.gradle
+++ b/wiremock-jetty12/build.gradle
@@ -29,7 +29,7 @@ java {
 
 project.ext {
   versions = [
-    jetty        : '12.0.8',
+    jetty        : '12.0.14',
     junitJupiter : '5.10.2'
   ]
 }


### PR DESCRIPTION
This is to resolve a Denial of Service (DoS) Affecting org.eclipse.jetty:jetty-server package, versions [9.3.12,9.4.56) [10.0.0,10.0.24) [11.0.0,11.0.24) [12.0.0,12.0.9)

See the following for more information:
* https://www.cve.org/CVERecord?id=CVE-2024-8184
* https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-8186142

<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
