### PR TITLE
Support filename capabilities for Multipart's part

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -34,6 +34,8 @@ public interface Request {
   interface Part {
     String getName();
 
+    String getFilename();
+
     HttpHeader getHeader(String name);
 
     HttpHeaders getHeaders();

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -34,7 +34,7 @@ public interface Request {
   interface Part {
     String getName();
 
-    String getFilename();
+    String getFileName();
 
     HttpHeader getHeader(String name);
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
@@ -38,6 +38,11 @@ public class FileItemPartAdapter implements Request.Part {
   }
 
   @Override
+  public String getFilename() {
+    return fileItem.getName();
+  }
+
+  @Override
   public HttpHeader getHeader(String name) {
     Iterator<String> headerValues = fileItem.getHeaders().getHeaders(name);
     List<String> values = new ArrayList<>();

--- a/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
@@ -38,7 +38,7 @@ public class FileItemPartAdapter implements Request.Part {
   }
 
   @Override
-  public String getFilename() {
+  public String getFileName() {
     return fileItem.getName();
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MultipartValuePatternBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.Map;
 public class MultipartValuePatternBuilder {
 
   private String name = null;
+  private String filename = null;
   private Map<String, MultiValuePattern> headerPatterns = new LinkedHashMap<>();
   private List<ContentPattern<?>> bodyPatterns = new LinkedList<>();
   private MultipartValuePattern.MatchingType matchingType = MultipartValuePattern.MatchingType.ANY;
@@ -45,6 +46,11 @@ public class MultipartValuePatternBuilder {
     return withHeader("Content-Disposition", containing("name=\"" + name + "\""));
   }
 
+  public MultipartValuePatternBuilder withFileName(String filename) {
+    this.filename = filename;
+    return withHeader("Content-Disposition", containing("filename=\"" + filename + "\""));
+  }
+
   public MultipartValuePatternBuilder withHeader(String name, StringValuePattern headerPattern) {
     headerPatterns.put(name, MultiValuePattern.of(headerPattern));
     return this;
@@ -59,7 +65,7 @@ public class MultipartValuePatternBuilder {
     return headerPatterns.isEmpty() && bodyPatterns.isEmpty()
         ? null
         : headerPatterns.isEmpty()
-            ? new MultipartValuePattern(name, matchingType, null, bodyPatterns)
-            : new MultipartValuePattern(name, matchingType, headerPatterns, bodyPatterns);
+            ? new MultipartValuePattern(name, filename, matchingType, null, bodyPatterns)
+            : new MultipartValuePattern(name, filename, matchingType, headerPatterns, bodyPatterns);
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletMultipartAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletMultipartAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Thomas Akehurst
+ * Copyright (C) 2013-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ public class WireMockHttpServletMultipartAdapter implements Request.Part {
   @Override
   public String getName() {
     return mPart.getName();
+  }
+
+  @Override
+  public String getFilename() {
+    return mPart.getSubmittedFileName();
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletMultipartAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletMultipartAdapter.java
@@ -53,7 +53,7 @@ public class WireMockHttpServletMultipartAdapter implements Request.Part {
   }
 
   @Override
-  public String getFilename() {
+  public String getFileName() {
     return mPart.getSubmittedFileName();
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/diff/MissingMultipart.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/diff/MissingMultipart.java
@@ -28,7 +28,7 @@ public class MissingMultipart implements Request.Part {
   }
 
   @Override
-  public String getFilename() {
+  public String getFileName() {
     return "[request is not multipart]";
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/diff/MissingMultipart.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/diff/MissingMultipart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Thomas Akehurst
+ * Copyright (C) 2018-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,11 @@ public class MissingMultipart implements Request.Part {
 
   @Override
   public String getName() {
+    return "[request is not multipart]";
+  }
+
+  @Override
+  public String getFilename() {
     return "[request is not multipart]";
   }
 

--- a/src/main/resources/swagger/schemas/request-pattern.yaml
+++ b/src/main/resources/swagger/schemas/request-pattern.yaml
@@ -107,6 +107,8 @@ properties:
       properties:
         name:
           type: string
+        filename:
+          type: string
         matchingType:
           type: string
           description: Determines whether all or any of the parts must match the criteria for an overall match.

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -766,7 +766,7 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
                 aMultipart()
                     .withHeader("Content-Type", containing("application/octet-stream"))
                     .withFileName("plain-example.txt"))
-            .willReturn(aResponse().withStatus(HTTP_OK).withBodyFile("plain-example.txt")));
+            .willReturn(ok()));
 
     WireMockResponse response =
         testClient.post(
@@ -801,7 +801,7 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
                 aMultipart()
                     .withHeader("Content-Type", containing("application/octet-stream"))
                     .withFileName("plain-example.txt"))
-            .willReturn(aResponse().withStatus(HTTP_OK).withBodyFile("plain-example.txt")));
+            .willReturn(ok()));
 
     WireMockResponse response =
         testClient.post(

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapperTest.java
@@ -194,19 +194,26 @@ public class RequestWrapperTest {
   @Test
   public void transformsMultiparts() {
     MockRequest request =
-        mockRequest().part(mockPart().name("one").body("1")).part(mockPart().name("two").body("2"));
+        mockRequest()
+            .part(mockPart().name("one").filename("text1.txt").body("1"))
+            .part(mockPart().name("two").filename("text2.txt").body("2"));
 
     Request wrappedRequest =
         RequestWrapper.create()
             .transformParts(
                 existingPart ->
                     existingPart.getName().equals("one")
-                        ? mockPart().name("one").body("1111")
-                        : mockPart().name("two").body("2222"))
+                        ? mockPart().name("one").filename("text1.txt").body("1111")
+                        : mockPart().name("two").filename("sample2.txt").body("2222"))
             .wrap(request);
 
     assertThat(wrappedRequest.getPart("one").getBody().asString(), is("1111"));
     assertThat(wrappedRequest.getPart("two").getBody().asString(), is("2222"));
-    assertThat(wrappedRequest.getParts(), hasItem(mockPart().name("one").body("1111")));
+    assertThat(
+        wrappedRequest.getParts(),
+        hasItem(mockPart().name("one").filename("text1.txt").body("1111")));
+    assertThat(
+        wrappedRequest.getParts(),
+        hasItem(mockPart().name("two").filename("sample2.txt").body("2222")));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockMultipart.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockMultipart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Thomas Akehurst
+ * Copyright (C) 2018-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.Objects;
 public class MockMultipart implements Request.Part {
 
   private String name;
+  private String filename;
   private List<HttpHeader> headers = new ArrayList<>();
   private Body body;
 
@@ -35,6 +36,11 @@ public class MockMultipart implements Request.Part {
 
   public MockMultipart name(String name) {
     this.name = name;
+    return this;
+  }
+
+  public MockMultipart filename(String filename) {
+    this.filename = filename;
     return this;
   }
 
@@ -64,6 +70,11 @@ public class MockMultipart implements Request.Part {
   }
 
   @Override
+  public String getFilename() {
+    return filename;
+  }
+
+  @Override
   public HttpHeader getHeader(String key) {
     return getHeaders().getHeader(key);
   }
@@ -84,19 +95,21 @@ public class MockMultipart implements Request.Part {
     if (o == null || getClass() != o.getClass()) return false;
     MockMultipart that = (MockMultipart) o;
     return Objects.equals(name, that.name)
+        && Objects.equals(filename, that.filename)
         && Objects.equals(headers, that.headers)
         && Objects.equals(body, that.body);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, headers, body);
+    return Objects.hash(name, filename, headers, body);
   }
 
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder("MockMultipart{");
     sb.append("name='").append(name).append('\'');
+    sb.append("filename='").append(filename).append('\'');
     sb.append(", headers=").append(headers);
     sb.append(", body=").append(body);
     sb.append('}');

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockMultipart.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockMultipart.java
@@ -70,7 +70,7 @@ public class MockMultipart implements Request.Part {
   }
 
   @Override
-  public String getFilename() {
+  public String getFileName() {
     return filename;
   }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
## Changes

- Added getFilename() in Request.Part interface
- Implemented the new method in FileItemPartAdapter, MissingMultipart, MockMultipart, WireMockHttpServletMultipartAdapter  following the conventions getName() to get part name and getFilename() to get the part filename.
- Updated RequestWrapperTest.transformsMultiparts() to include filename


## References

Issue:  FileItemPartAdapter returning multipart's field name instead of a filename #2750
Included Suggestion: Update FileItemPartAdapter.java #2764


<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
