### PR TITLE
HTTP server loading refinement

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -17,7 +17,6 @@ package com.github.tomakehurst.wiremock;
 
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.checkState;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static java.util.stream.Collectors.toList;
 
 import com.github.tomakehurst.wiremock.admin.model.*;
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
@@ -29,7 +28,6 @@ import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.core.Container;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockApp;
-import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.junit.Stubbing;
@@ -48,7 +46,6 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.stubbing.StubMappingJsonRecorder;
 import com.github.tomakehurst.wiremock.verification.*;
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.UUID;
 import org.eclipse.jetty.util.Jetty;
@@ -88,11 +85,7 @@ public class WireMockServer implements Container, Stubbing, Admin {
     return new HttpServerFactoryLoader(
             options,
             wireMockApp.getExtensions(),
-            () ->
-                ServiceLoader.load(Extension.class).stream()
-                    .filter(extension -> HttpServerFactory.class.isAssignableFrom(extension.type()))
-                    .map(e -> (HttpServerFactory) e.get())
-                    .collect(toList()),
+            HttpServerFactoryLoader.systemServiceLoader(),
             isJetty11())
         .load();
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -48,7 +48,6 @@ import com.github.tomakehurst.wiremock.verification.*;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import org.eclipse.jetty.util.Jetty;
 
 public class WireMockServer implements Container, Stubbing, Admin {
 
@@ -86,16 +85,8 @@ public class WireMockServer implements Container, Stubbing, Admin {
             options,
             wireMockApp.getExtensions(),
             HttpServerFactoryLoader.systemServiceLoader(),
-            isJetty11())
+            HttpServerFactoryLoader.isJetty11())
         .load();
-  }
-
-  private static boolean isJetty11() {
-    try {
-      return Jetty.VERSION.startsWith("11");
-    } catch (Throwable e) {
-      return false;
-    }
   }
 
   public WireMockServer(

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -103,6 +103,8 @@ public interface Options {
 
   HttpServerFactory httpServerFactory();
 
+  boolean hasDefaultHttpServerFactory();
+
   HttpClientFactory httpClientFactory();
 
   ThreadPoolFactory threadPoolFactory();

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -41,7 +41,6 @@ import com.github.tomakehurst.wiremock.http.client.HttpClientFactory;
 import com.github.tomakehurst.wiremock.http.trafficlistener.DoNothingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.jetty.JettyHttpServerFactory;
-import com.github.tomakehurst.wiremock.jetty.QueuedThreadPoolFactory;
 import com.github.tomakehurst.wiremock.security.Authenticator;
 import com.github.tomakehurst.wiremock.security.BasicAuthenticator;
 import com.github.tomakehurst.wiremock.security.NoAuthenticator;
@@ -105,7 +104,7 @@ public class WireMockConfiguration implements Options {
   private String proxyHostHeader;
   private HttpServerFactory httpServerFactory = new JettyHttpServerFactory();
   private HttpClientFactory httpClientFactory = new ApacheHttpClientFactory();
-  private ThreadPoolFactory threadPoolFactory = new QueuedThreadPoolFactory();
+  private ThreadPoolFactory threadPoolFactory;
   private Integer jettyAcceptors;
   private Integer jettyAcceptQueueSize;
   private Integer jettyHeaderBufferSize;

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -716,6 +716,11 @@ public class WireMockConfiguration implements Options {
   }
 
   @Override
+  public boolean hasDefaultHttpServerFactory() {
+    return httpServerFactory.getClass().equals(JettyHttpServerFactory.class);
+  }
+
+  @Override
   public HttpClientFactory httpClientFactory() {
     return httpClientFactory;
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/ExtensionFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/ExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Thomas Akehurst
+ * Copyright (C) 2023-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,14 @@ import java.util.List;
 public interface ExtensionFactory {
 
   /**
-   * Allows the factory to check the runtime environment and prevent itself being used if not compatible e.g.
-   * because the wrong Jetty version is present.
+   * Allows the factory to check the runtime environment and prevent itself being used if not
+   * compatible e.g. because the wrong Jetty version is present.
+   *
    * @return true if the factory can be loaded.
    */
-  default boolean isLoadable() { return true; }
+  default boolean isLoadable() {
+    return true;
+  }
 
   List<Extension> create(WireMockServices services);
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/ExtensionFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/ExtensionFactory.java
@@ -18,5 +18,13 @@ package com.github.tomakehurst.wiremock.extension;
 import java.util.List;
 
 public interface ExtensionFactory {
+
+  /**
+   * Allows the factory to check the runtime environment and prevent itself being used if not compatible e.g.
+   * because the wrong Jetty version is present.
+   * @return true if the factory can be loaded.
+   */
+  default boolean isLoadable() { return true; }
+
   List<Extension> create(WireMockServices services);
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/Extensions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/Extensions.java
@@ -117,7 +117,7 @@ public class Extensions implements WireMockServices {
 
   private Stream<ExtensionFactory> loadExtensionFactoriesAsServices() {
     final ServiceLoader<ExtensionFactory> loader = ServiceLoader.load(ExtensionFactory.class);
-    return loader.stream().map(ServiceLoader.Provider::get);
+    return loader.stream().map(ServiceLoader.Provider::get).filter(ExtensionFactory::isLoadable);
   }
 
   private void configureTemplating() {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/DefaultFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/DefaultFactory.java
@@ -13,23 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.tomakehurst.wiremock.jetty12;
+package com.github.tomakehurst.wiremock.http;
 
-import com.github.tomakehurst.wiremock.core.Options;
-import com.github.tomakehurst.wiremock.http.*;
-
-public class Jetty12HttpServerFactory implements HttpServerFactory, DefaultFactory {
-
-  @Override
-  public String getName() {
-    return "jetty12-http-server-factory";
-  }
-
-  @Override
-  public HttpServer buildHttpServer(
-      Options options,
-      AdminRequestHandler adminRequestHandler,
-      StubRequestHandler stubRequestHandler) {
-    return new Jetty12HttpServer(options, adminRequestHandler, stubRequestHandler);
-  }
-}
+/**
+ * Marker interface signifying this factory should only be used if user-supplied extensions are not
+ * present.
+ */
+public interface DefaultFactory {}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactory.java
@@ -23,7 +23,7 @@ public interface HttpServerFactory extends Extension {
 
   @Override
   default String getName() {
-    return "http-server-factory";
+    return "http-server-factory-" + getClass().getSimpleName();
   }
 
   HttpServer buildHttpServer(

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactoryLoader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactoryLoader.java
@@ -22,6 +22,8 @@ import com.github.tomakehurst.wiremock.common.FatalStartupException;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.extension.Extensions;
+import org.eclipse.jetty.util.Jetty;
+
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
@@ -79,5 +81,13 @@ public class HttpServerFactoryLoader {
   private static FatalStartupException couldNotFindSuitableServerException() {
     return new FatalStartupException(
         "Jetty 11 is not present and no suitable HttpServerFactory extension was found. Please ensure that the classpath includes a WireMock extension that provides an HttpServerFactory implementation. See http://wiremock.org/docs/extending-wiremock/ for more information.");
+  }
+
+  public static boolean isJetty11() {
+    try {
+      return Jetty.VERSION.startsWith("11");
+    } catch (Throwable e) {
+      return false;
+    }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactoryLoader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactoryLoader.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+import com.github.tomakehurst.wiremock.common.FatalStartupException;
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.extension.Extensions;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class HttpServerFactoryLoader {
+
+  private final Options options;
+  private final Extensions extensions;
+  private final Supplier<List<HttpServerFactory>> serviceLoader;
+  private final boolean isJetty11;
+
+  public HttpServerFactoryLoader(
+      Options options,
+      Extensions extensions,
+      Supplier<List<HttpServerFactory>> serviceLoader,
+      boolean isJetty11) {
+    this.options = options;
+    this.extensions = extensions;
+    this.serviceLoader = serviceLoader;
+    this.isJetty11 = isJetty11;
+  }
+
+  public HttpServerFactory load() {
+    final List<HttpServerFactory> extensionCandidates =
+        extensions.ofType(HttpServerFactory.class).values().stream().collect(toUnmodifiableList());
+    if (!extensionCandidates.isEmpty()) {
+      return pickMostAppropriateFrom(extensionCandidates);
+    }
+
+    if (options.hasDefaultHttpServerFactory() && !isJetty11) {
+      final List<HttpServerFactory> serviceLoadedCandidates = serviceLoader.get();
+      return pickMostAppropriateFrom(serviceLoadedCandidates);
+    }
+
+    return options.httpServerFactory();
+  }
+
+  private static HttpServerFactory pickMostAppropriateFrom(List<HttpServerFactory> candidates) {
+    return candidates.size() > 1
+        ? candidates.stream()
+            .filter(factory -> !DefaultFactory.class.isAssignableFrom(factory.getClass()))
+            .findFirst()
+            .orElseThrow(HttpServerFactoryLoader::couldNotFindSuitableServerException)
+        : candidates.get(0);
+  }
+
+  private static FatalStartupException couldNotFindSuitableServerException() {
+    return new FatalStartupException(
+        "Jetty 11 is not present and no suitable HttpServerFactory extension was found. Please ensure that the classpath includes a WireMock extension that provides an HttpServerFactory implementation. See http://wiremock.org/docs/extending-wiremock/ for more information.");
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactoryLoader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactoryLoader.java
@@ -15,12 +15,15 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toUnmodifiableList;
 
 import com.github.tomakehurst.wiremock.common.FatalStartupException;
 import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.extension.Extensions;
 import java.util.List;
+import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
 public class HttpServerFactoryLoader {
@@ -54,6 +57,14 @@ public class HttpServerFactoryLoader {
     }
 
     return options.httpServerFactory();
+  }
+
+  public static Supplier<List<HttpServerFactory>> systemServiceLoader() {
+    return () ->
+        ServiceLoader.load(Extension.class).stream()
+            .filter(extension -> HttpServerFactory.class.isAssignableFrom(extension.type()))
+            .map(e -> (HttpServerFactory) e.get())
+            .collect(toList());
   }
 
   private static HttpServerFactory pickMostAppropriateFrom(List<HttpServerFactory> candidates) {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactoryLoader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactoryLoader.java
@@ -22,11 +22,10 @@ import com.github.tomakehurst.wiremock.common.FatalStartupException;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.extension.Extensions;
-import org.eclipse.jetty.util.Jetty;
-
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
+import org.eclipse.jetty.util.Jetty;
 
 public class HttpServerFactoryLoader {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServer.java
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.core.WireMockApp;
 import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
 import com.github.tomakehurst.wiremock.http.HttpServer;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
+import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.servlet.*;
 import java.io.IOException;
@@ -117,7 +118,11 @@ public abstract class JettyHttpServer implements HttpServer {
   }
 
   protected Server createServer(Options options) {
-    final Server server = new Server(options.threadPoolFactory().buildThreadPool(options));
+    final ThreadPoolFactory threadPoolFactory =
+        options.threadPoolFactory() != null
+            ? options.threadPoolFactory()
+            : new QueuedThreadPoolFactory();
+    final Server server = new Server(threadPoolFactory.buildThreadPool(options));
     final JettySettings jettySettings = options.jettySettings();
     final Optional<Long> stopTimeout = jettySettings.getStopTimeout();
     stopTimeout.ifPresent(server::setStopTimeout);

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServerFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServerFactory.java
@@ -16,13 +16,10 @@
 package com.github.tomakehurst.wiremock.jetty;
 
 import com.github.tomakehurst.wiremock.core.Options;
-import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
-import com.github.tomakehurst.wiremock.http.HttpServer;
-import com.github.tomakehurst.wiremock.http.HttpServerFactory;
-import com.github.tomakehurst.wiremock.http.StubRequestHandler;
+import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.jetty11.Jetty11HttpServer;
 
-public class JettyHttpServerFactory implements HttpServerFactory {
+public class JettyHttpServerFactory implements HttpServerFactory, DefaultFactory {
   @Override
   public HttpServer buildHttpServer(
       Options options,

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -172,6 +172,11 @@ public class WarConfiguration implements Options {
   }
 
   @Override
+  public boolean hasDefaultHttpServerFactory() {
+    return false;
+  }
+
+  @Override
   public HttpClientFactory httpClientFactory() {
     return new ApacheHttpClientFactory();
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -526,6 +526,11 @@ public class CommandLineOptions implements Options {
   }
 
   @Override
+  public boolean hasDefaultHttpServerFactory() {
+    return true;
+  }
+
+  @Override
   public HttpClientFactory httpClientFactory() {
     return new ApacheHttpClientFactory();
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/StubRequestLoggingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubRequestLoggingAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Thomas Akehurst
+ * Copyright (C) 2020-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ public class StubRequestLoggingAcceptanceTest extends AcceptanceTestBase {
     wm.start();
     testClient = new WireMockTestClient(wm.port());
 
+    notifier.infoMessages.clear();
+
     wm.stubFor(get("/log-me").willReturn(ok("body text")));
 
     testClient.get("/log-me");
@@ -56,6 +58,8 @@ public class StubRequestLoggingAcceptanceTest extends AcceptanceTestBase {
             wireMockConfig().dynamicPort().stubRequestLoggingDisabled(true).notifier(notifier));
     wm.start();
     testClient = new WireMockTestClient(wm.port());
+
+    notifier.infoMessages.clear();
 
     wm.stubFor(get("/log-me").willReturn(ok("body")));
 

--- a/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.Optional;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.Test;
 
 public class WireMockConfigurationTest {
@@ -60,19 +59,6 @@ public class WireMockConfigurationTest {
     WireMockConfiguration wireMockConfiguration = WireMockConfiguration.wireMockConfig();
     Optional<Long> jettyIdleTimeout = wireMockConfiguration.jettySettings().getIdleTimeout();
     assertThat(jettyIdleTimeout.isPresent(), is(false));
-  }
-
-  @Test
-  public void shouldUseQueuedThreadPoolByDefault() {
-    int maxThreads = 20;
-    WireMockConfiguration wireMockConfiguration =
-        WireMockConfiguration.wireMockConfig().containerThreads(maxThreads);
-
-    QueuedThreadPool threadPool =
-        (QueuedThreadPool)
-            wireMockConfiguration.threadPoolFactory().buildThreadPool(wireMockConfiguration);
-
-    assertThat(threadPool.getMaxThreads(), is(maxThreads));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/ExtensionLifeCycleAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/ExtensionLifeCycleAcceptanceTest.java
@@ -18,8 +18,7 @@ package com.github.tomakehurst.wiremock.extension;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.apache.hc.core5.http.ContentType.TEXT_PLAIN;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 import com.github.tomakehurst.wiremock.AcceptanceTestBase;
 import com.github.tomakehurst.wiremock.common.Notifier;
@@ -38,8 +37,8 @@ public class ExtensionLifeCycleAcceptanceTest extends AcceptanceTestBase {
             .dynamicPort()
             .notifier(notifier)
             .extensions(new StartStopLoggingExtension(notifier)));
-    assertThat(notifier.infoMessages.size(), is(1));
-    assertThat(notifier.infoMessages.get(0), containsString("Extension started"));
+    assertThat(notifier.infoMessages.size(), greaterThanOrEqualTo(1));
+    assertThat(notifier.infoMessages, hasItem(containsString("Extension started")));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpServerFactoryLoaderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpServerFactoryLoaderTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.extension.Extensions;
+import com.github.tomakehurst.wiremock.jetty.JettyHttpServerFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+public class HttpServerFactoryLoaderTest {
+
+  Options options = wireMockConfig();
+  Extensions extensions = mock(Extensions.class);
+  Supplier<List<HttpServerFactory>> serviceLoader = mock(Supplier.class);
+
+  HttpServerFactoryLoader loader;
+
+  @Test
+  void loadsExtensionWhenOneIsPresentAndJettyVersionIs11() {
+    loader = new HttpServerFactoryLoader(options, extensions, serviceLoader, true);
+
+    serverFactoriesAsExtensions(List.of(new CustomHttpServerFactory()));
+    serverFactoriesFromServiceLoader(List.of(new CustomHttpServerFactory2()));
+
+    HttpServerFactory result = loader.load();
+
+    assertThat(result, instanceOf(CustomHttpServerFactory.class));
+  }
+
+  @Test
+  void loadsExtensionWhenOneIsPresentAndJettyVersionIsNot11() {
+    loader = new HttpServerFactoryLoader(options, extensions, serviceLoader, false);
+    serverFactoriesAsExtensions(List.of(new CustomHttpServerFactory()));
+    serverFactoriesFromServiceLoader(List.of(new CustomHttpServerFactory2()));
+
+    HttpServerFactory result = loader.load();
+
+    assertThat(result, instanceOf(CustomHttpServerFactory.class));
+  }
+
+  @Test
+  void loadsTheNonStandardExtensionWhenMoreThanOneIsPresent() {
+    options = wireMockConfig().extensionScanningEnabled(false);
+    loader = new HttpServerFactoryLoader(options, extensions, serviceLoader, false);
+
+    serverFactoriesAsExtensions(
+        List.of(new DefaultHttpServerFactory(), new CustomHttpServerFactory()));
+
+    HttpServerFactory result = loader.load();
+
+    assertThat(result, instanceOf(CustomHttpServerFactory.class));
+  }
+
+  @Test
+  void usesTheServiceLoaderWhenNoExtensionsArePresentAndJettyVersionIsNot11() {
+    loader = new HttpServerFactoryLoader(options, extensions, serviceLoader, false);
+    serverFactoriesFromServiceLoader(List.of(new CustomHttpServerFactory()));
+
+    HttpServerFactory result = loader.load();
+
+    assertThat(result, instanceOf(CustomHttpServerFactory.class));
+  }
+
+  @Test
+  void usesTheDefaultFactoryWhenNoExtensionsArePresentAndJettyVersionIs11() {
+    loader = new HttpServerFactoryLoader(options, extensions, serviceLoader, true);
+    serverFactoriesFromServiceLoader(List.of(new CustomHttpServerFactory()));
+
+    HttpServerFactory result = loader.load();
+
+    assertThat(result, instanceOf(JettyHttpServerFactory.class));
+  }
+
+  @Test
+  void loadsTheNonStandardFactoryViaTheServiceLoaderWhenMoreThanOneIsPresent() {
+    loader = new HttpServerFactoryLoader(options, extensions, serviceLoader, false);
+    serverFactoriesFromServiceLoader(
+        List.of(new DefaultHttpServerFactory(), new CustomHttpServerFactory()));
+
+    HttpServerFactory result = loader.load();
+
+    assertThat(result, instanceOf(CustomHttpServerFactory.class));
+  }
+
+  @Test
+  void usesTheFactoryFromTheOptionsObjectWhenNoExtensionsPresentAndJettyVersionIs11() {
+    Options config = wireMockConfig().httpServerFactory(new CustomHttpServerFactory());
+    loader = new HttpServerFactoryLoader(config, extensions, serviceLoader, true);
+    serverFactoriesAsExtensions(List.of(new CustomHttpServerFactory()));
+    serverFactoriesFromServiceLoader(List.of(new CustomHttpServerFactory2()));
+
+    HttpServerFactory result = loader.load();
+
+    assertThat(result, instanceOf(CustomHttpServerFactory.class));
+  }
+
+  @Test
+  void usesTheFactoryFromTheOptionsObjectWhenNoExtensionsPresentAndJettyVersionIsNot11() {
+    Options config = wireMockConfig().httpServerFactory(new CustomHttpServerFactory());
+    loader = new HttpServerFactoryLoader(config, extensions, serviceLoader, false);
+    serverFactoriesAsExtensions(List.of(new CustomHttpServerFactory()));
+    serverFactoriesFromServiceLoader(List.of(new CustomHttpServerFactory2()));
+
+    HttpServerFactory result = loader.load();
+
+    assertThat(result, instanceOf(CustomHttpServerFactory.class));
+  }
+
+  private void serverFactoriesAsExtensions(List<HttpServerFactory> extensionList) {
+    final Map<String, HttpServerFactory> extensionMap =
+        extensionList.stream()
+            .collect(Collectors.toMap(HttpServerFactory::getName, factory -> factory));
+    when(extensions.ofType(HttpServerFactory.class)).thenReturn(extensionMap);
+  }
+
+  private void serverFactoriesFromServiceLoader(List<HttpServerFactory> factories) {
+    when(serviceLoader.get()).thenReturn(factories);
+  }
+
+  public static class CustomHttpServerFactory implements HttpServerFactory {
+
+    @Override
+    public HttpServer buildHttpServer(
+        Options options,
+        AdminRequestHandler adminRequestHandler,
+        StubRequestHandler stubRequestHandler) {
+      return null;
+    }
+  }
+
+  public static class CustomHttpServerFactory2 implements HttpServerFactory {
+    @Override
+    public HttpServer buildHttpServer(
+        Options options,
+        AdminRequestHandler adminRequestHandler,
+        StubRequestHandler stubRequestHandler) {
+      return null;
+    }
+  }
+
+  public static class DefaultHttpServerFactory implements HttpServerFactory, DefaultFactory {
+    @Override
+    public HttpServer buildHttpServer(
+        Options options,
+        AdminRequestHandler adminRequestHandler,
+        StubRequestHandler stubRequestHandler) {
+      return null;
+    }
+  }
+}

--- a/wiremock-jetty12/build.gradle
+++ b/wiremock-jetty12/build.gradle
@@ -36,13 +36,14 @@ project.ext {
 
 dependencies {
 
+  api platform("org.eclipse.jetty:jetty-bom:$versions.jetty")
+  api platform("org.eclipse.jetty.ee10:jetty-ee10-bom:$versions.jetty")
+
   api project(':'), {
     exclude group: 'org.eclipse.jetty'
     exclude group: 'org.eclipse.jetty.http2'
   }
 
-  api platform("org.eclipse.jetty:jetty-bom:$versions.jetty")
-  api platform("org.eclipse.jetty.ee10:jetty-ee10-bom:$versions.jetty")
   api "org.eclipse.jetty:jetty-server"
   api "org.eclipse.jetty:jetty-proxy"
   api "org.eclipse.jetty:jetty-alpn-server"

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2AcceptanceTest.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2AcceptanceTest.java
@@ -15,24 +15,27 @@
  */
 package com.github.tomakehurst.wiremock.jetty12;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.eclipse.jetty.http.HttpVersion.HTTP_2;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
 import com.github.tomakehurst.wiremock.http.HttpClientFactory;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.eclipse.jetty.http.HttpVersion.HTTP_2;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
 public class Http2AcceptanceTest {
+
+  static TestNotifier notifier = new TestNotifier();
 
   @RegisterExtension
   public WireMockExtension wm =
@@ -42,8 +45,18 @@ public class Http2AcceptanceTest {
                   .extensionScanningEnabled(true)
                   .dynamicPort()
                   .dynamicHttpsPort()
-                  .httpServerFactory(new Jetty12HttpServerFactory()))
+                  .notifier(notifier))
           .build();
+
+  @BeforeAll
+  static void init() {
+    notifier.reset();
+  }
+
+  @AfterAll
+  static void checkCorrectImpl() {
+    assertThat(notifier.getInfoMessages(), hasItem("Using HTTP server impl: Jetty12HttpServer"));
+  }
 
   @Test
   public void supportsHttp2Connections() throws Exception {

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2AcceptanceTest.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2AcceptanceTest.java
@@ -15,6 +15,13 @@
  */
 package com.github.tomakehurst.wiremock.jetty12;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.eclipse.jetty.http.HttpVersion.HTTP_2;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
 import com.github.tomakehurst.wiremock.http.HttpClientFactory;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
@@ -25,13 +32,6 @@ import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.eclipse.jetty.http.HttpVersion.HTTP_2;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
 
 public class Http2AcceptanceTest {
 

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/ProgrammaticHttpServerAcceptanceTest.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/ProgrammaticHttpServerAcceptanceTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019-2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12;
+
+import com.github.tomakehurst.wiremock.jetty12.server.CustomHttpServerFactory;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+public class ProgrammaticHttpServerAcceptanceTest {
+
+  static TestNotifier notifier = new TestNotifier();
+
+  @RegisterExtension
+  public WireMockExtension wm =
+      WireMockExtension.newInstance()
+          .options(
+              wireMockConfig()
+                  .dynamicPort()
+                  .dynamicHttpsPort()
+                  .httpServerFactory(new CustomHttpServerFactory())
+                  .notifier(notifier))
+          .build();
+
+  @BeforeAll
+  static void init() {
+    notifier.reset();
+  }
+
+  @Test
+  public void correctServerLoaded() {
+    assertThat(notifier.getInfoMessages(), hasItem("Using HTTP server impl: CustomHttpServer"));
+  }
+}

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/ProgrammaticHttpServerAcceptanceTest.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/ProgrammaticHttpServerAcceptanceTest.java
@@ -15,16 +15,16 @@
  */
 package com.github.tomakehurst.wiremock.jetty12;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
 import com.github.tomakehurst.wiremock.jetty12.server.CustomHttpServerFactory;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 public class ProgrammaticHttpServerAcceptanceTest {
 

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/server/CustomHttpServer.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/server/CustomHttpServer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.tomakehurst.wiremock.jetty12.server;
 
 import com.github.tomakehurst.wiremock.core.Options;
@@ -6,7 +21,10 @@ import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.github.tomakehurst.wiremock.jetty12.Jetty12HttpServer;
 
 public class CustomHttpServer extends Jetty12HttpServer {
-    public CustomHttpServer(Options options, AdminRequestHandler adminRequestHandler, StubRequestHandler stubRequestHandler) {
-        super(options, adminRequestHandler, stubRequestHandler);
-    }
+  public CustomHttpServer(
+      Options options,
+      AdminRequestHandler adminRequestHandler,
+      StubRequestHandler stubRequestHandler) {
+    super(options, adminRequestHandler, stubRequestHandler);
+  }
 }

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/server/CustomHttpServer.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/server/CustomHttpServer.java
@@ -1,0 +1,12 @@
+package com.github.tomakehurst.wiremock.jetty12.server;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
+import com.github.tomakehurst.wiremock.http.StubRequestHandler;
+import com.github.tomakehurst.wiremock.jetty12.Jetty12HttpServer;
+
+public class CustomHttpServer extends Jetty12HttpServer {
+    public CustomHttpServer(Options options, AdminRequestHandler adminRequestHandler, StubRequestHandler stubRequestHandler) {
+        super(options, adminRequestHandler, stubRequestHandler);
+    }
+}

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/server/CustomHttpServerFactory.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/server/CustomHttpServerFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.tomakehurst.wiremock.jetty12.server;
 
 import com.github.tomakehurst.wiremock.core.Options;
@@ -8,13 +23,16 @@ import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 
 public class CustomHttpServerFactory implements HttpServerFactory {
 
-    @Override
-    public String getName() {
-        return HttpServerFactory.super.getName();
-    }
+  @Override
+  public String getName() {
+    return HttpServerFactory.super.getName();
+  }
 
-    @Override
-    public HttpServer buildHttpServer(Options options, AdminRequestHandler adminRequestHandler, StubRequestHandler stubRequestHandler) {
-        return new CustomHttpServer(options, adminRequestHandler, stubRequestHandler);
-    }
+  @Override
+  public HttpServer buildHttpServer(
+      Options options,
+      AdminRequestHandler adminRequestHandler,
+      StubRequestHandler stubRequestHandler) {
+    return new CustomHttpServer(options, adminRequestHandler, stubRequestHandler);
+  }
 }

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/server/CustomHttpServerFactory.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/server/CustomHttpServerFactory.java
@@ -1,0 +1,20 @@
+package com.github.tomakehurst.wiremock.jetty12.server;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
+import com.github.tomakehurst.wiremock.http.HttpServer;
+import com.github.tomakehurst.wiremock.http.HttpServerFactory;
+import com.github.tomakehurst.wiremock.http.StubRequestHandler;
+
+public class CustomHttpServerFactory implements HttpServerFactory {
+
+    @Override
+    public String getName() {
+        return HttpServerFactory.super.getName();
+    }
+
+    @Override
+    public HttpServer buildHttpServer(Options options, AdminRequestHandler adminRequestHandler, StubRequestHandler stubRequestHandler) {
+        return new CustomHttpServer(options, adminRequestHandler, stubRequestHandler);
+    }
+}


### PR DESCRIPTION
This factors out the HTTP server factory loading logic so that it can be properly tested and and enhances it to better handle situations where multiple extensions are found.

This is largely in support of enabling the gRPC extension to support Jetty12.