### PR TITLE
Allow loading a stub for a single file instead of a directory #2776

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,123 @@
+{
+  "persona": {
+    "role": "Expert Java Developer",
+    "principles": [
+      "SOLID Principles",
+      "Hexagonal Architecture",
+      "Clean Code",
+      "Test-Driven Development"
+    ],
+    "expertise": [
+      "Domain-Driven Design",
+      "Design Patterns",
+      "Microservices Architecture",
+      "Test Automation"
+    ]
+  },
+  "formatter": {
+    "indentSize": 2,
+    "lineLength": 100,
+    "formatOnSave": true,
+    "useGoogleStyle": true
+  },
+  "codeQuality": {
+    "methods": {
+      "maxLines": 20,
+      "maxParameters": 3,
+      "maxCyclomaticComplexity": 5
+    },
+    "classes": {
+      "maxLines": 400,
+      "maxMethods": 20,
+      "requireInterfaceSegregation": true
+    },
+    "packages": {
+      "enforceLayeredArchitecture": true,
+      "domainLayerDependencies": ["domain"],
+      "applicationLayerDependencies": ["domain", "application"],
+      "infrastructureLayerDependencies": ["domain", "application", "infrastructure"]
+    }
+  },
+  "architecture": {
+    "enforceHexagonal": {
+      "enabled": true,
+      "layers": {
+        "domain": {
+          "allowed": [],
+          "pattern": "com.github.tomakehurst.wiremock.domain.**"
+        },
+        "application": {
+          "allowed": ["domain"],
+          "pattern": "com.github.tomakehurst.wiremock.application.**"
+        },
+        "infrastructure": {
+          "allowed": ["domain", "application"],
+          "pattern": "com.github.tomakehurst.wiremock.infrastructure.**"
+        }
+      }
+    },
+    "enforceArchUnit": true,
+    "archUnitRules": [
+      "noStandardStreams",
+      "noGenericExceptions",
+      "noJavaUtilLogging",
+      "noJodaTime",
+      "noUnusedClasses"
+    ]
+  },
+  "testing": {
+    "requireTests": true,
+    "coverage": {
+      "minimum": 80,
+      "excludePatterns": ["**/*Configuration.java", "**/*Exception.java"]
+    },
+    "unitTests": {
+      "namingPattern": "*Test.java",
+      "location": "src/test/java"
+    },
+    "acceptanceTests": {
+      "required": true,
+      "namingPattern": "*AcceptanceTest.java"
+    }
+  },
+  "solid": {
+    "singleResponsibility": {
+      "enabled": true,
+      "maxPublicMethods": 5
+    },
+    "openClosed": {
+      "enabled": true,
+      "preferInterfaces": true
+    },
+    "liskovSubstitution": {
+      "enabled": true,
+      "enforceInvariants": true
+    },
+    "interfaceSegregation": {
+      "enabled": true,
+      "maxInterfaceMethods": 5
+    },
+    "dependencyInversion": {
+      "enabled": true,
+      "requireDependencyInjection": true
+    }
+  },
+  "documentation": {
+    "requireJavadoc": {
+      "public": true,
+      "protected": true,
+      "package": false,
+      "private": false
+    },
+    "licenseHeader": {
+      "required": true,
+      "template": "/*\n * Copyright (C) {YEAR} Thomas Akehurst\n *\n * Licensed under the Apache License, Version 2.0\n */"
+    }
+  },
+  "review": {
+    "requireApproval": true,
+    "maxReviewSize": 500,
+    "requireTests": true,
+    "requireDocumentation": true
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -43,12 +43,16 @@ import com.github.tomakehurst.wiremock.recording.RecordSpecBuilder;
 import com.github.tomakehurst.wiremock.recording.RecordingStatusResult;
 import com.github.tomakehurst.wiremock.recording.SnapshotRecordResult;
 import com.github.tomakehurst.wiremock.standalone.MappingsLoader;
+import com.github.tomakehurst.wiremock.standalone.SingleFileMappingsSource;
 import com.github.tomakehurst.wiremock.store.files.FileSourceBlobStore;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubImport;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.stubbing.StubMappingJsonRecorder;
 import com.github.tomakehurst.wiremock.verification.*;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -77,9 +81,8 @@ public class WireMockServer implements Container, Stubbing, Admin {
 
     HttpServerFactory httpServerFactory = getHttpServerFactory();
 
-    httpServer =
-        httpServerFactory.buildHttpServer(
-            options, wireMockApp.buildAdminRequestHandler(), stubRequestHandler);
+    httpServer = httpServerFactory.buildHttpServer(
+        options, wireMockApp.buildAdminRequestHandler(), stubRequestHandler);
 
     client = new WireMock(wireMockApp);
   }
@@ -91,9 +94,8 @@ public class WireMockServer implements Container, Stubbing, Admin {
           .findFirst()
           .map(e -> (HttpServerFactory) e.get())
           .orElseThrow(
-              () ->
-                  new FatalStartupException(
-                      "Jetty 11 is not present and no suitable HttpServerFactory extension was found. Please ensure that the classpath includes a WireMock extension that provides an HttpServerFactory implementation. See http://wiremock.org/docs/extending-wiremock/ for more information."));
+              () -> new FatalStartupException(
+                  "Jetty 11 is not present and no suitable HttpServerFactory extension was found. Please ensure that the classpath includes a WireMock extension that provides an HttpServerFactory implementation. See http://wiremock.org/docs/extending-wiremock/ for more information."));
     }
 
     return wireMockApp.getExtensions().ofType(HttpServerFactory.class).values().stream()
@@ -183,7 +185,8 @@ public class WireMockServer implements Container, Stubbing, Admin {
   }
 
   public void start() {
-    // Try to ensure this is warmed up on the main thread so that it's inherited by worker threads
+    // Try to ensure this is warmed up on the main thread so that it's inherited by
+    // worker threads
     Json.getObjectMapper();
     try {
       httpServer.start();
@@ -195,25 +198,27 @@ public class WireMockServer implements Container, Stubbing, Admin {
   /**
    * Gracefully shutdown the server.
    *
-   * <p>This method assumes it is being called as the result of an incoming HTTP request.
+   * <p>
+   * This method assumes it is being called as the result of an incoming HTTP
+   * request.
    */
   @Override
   public void shutdown() {
     final WireMockServer server = this;
-    Thread shutdownThread =
-        new Thread(
-            () -> {
-              try {
-                // We have to sleep briefly to finish serving the shutdown request before stopping
-                // the server, as
-                // there's no support in Jetty for shutting down after the current request.
-                // See http://stackoverflow.com/questions/4650713
-                Thread.sleep(100);
-              } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-              }
-              server.stop();
-            });
+    Thread shutdownThread = new Thread(
+        () -> {
+          try {
+            // We have to sleep briefly to finish serving the shutdown request before
+            // stopping
+            // the server, as
+            // there's no support in Jetty for shutting down after the current request.
+            // See http://stackoverflow.com/questions/4650713
+            Thread.sleep(100);
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+          server.stop();
+        });
     shutdownThread.start();
   }
 
@@ -585,5 +590,17 @@ public class WireMockServer implements Container, Stubbing, Admin {
 
   public Set<String> getLoadedExtensionNames() {
     return wireMockApp.getLoadedExtensionNames();
+  }
+
+  public void loadStubFromResource(String resourcePath) {
+    try {
+      URL resource = getClass().getResource(resourcePath);
+      if (resource == null) {
+        throw new IllegalArgumentException("Resource not found: " + resourcePath);
+      }
+      loadMappingsUsing(new SingleFileMappingsSource(Path.of(resource.toURI())));
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Invalid resource path: " + resourcePath, e);
+    }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -43,12 +43,17 @@ import com.github.tomakehurst.wiremock.recording.RecordSpecBuilder;
 import com.github.tomakehurst.wiremock.recording.RecordingStatusResult;
 import com.github.tomakehurst.wiremock.recording.SnapshotRecordResult;
 import com.github.tomakehurst.wiremock.standalone.MappingsLoader;
+import com.github.tomakehurst.wiremock.standalone.SingleFileMappingsSource;
 import com.github.tomakehurst.wiremock.store.files.FileSourceBlobStore;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubImport;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.stubbing.StubMappingJsonRecorder;
 import com.github.tomakehurst.wiremock.verification.*;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -585,5 +590,17 @@ public class WireMockServer implements Container, Stubbing, Admin {
 
   public Set<String> getLoadedExtensionNames() {
     return wireMockApp.getLoadedExtensionNames();
+  }
+
+   public void loadStubFromResource(String resourcePath) {
+    try {
+      URL resource = getClass().getResource(resourcePath);
+      if (resource == null) {
+        throw new IllegalArgumentException("Resource not found: " + resourcePath);
+      }
+      loadMappingsUsing(new SingleFileMappingsSource(Path.of(resource.toURI())));
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Invalid resource path: " + resourcePath, e);
+    }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -43,22 +43,16 @@ import com.github.tomakehurst.wiremock.recording.RecordSpecBuilder;
 import com.github.tomakehurst.wiremock.recording.RecordingStatusResult;
 import com.github.tomakehurst.wiremock.recording.SnapshotRecordResult;
 import com.github.tomakehurst.wiremock.standalone.MappingsLoader;
-import com.github.tomakehurst.wiremock.standalone.SingleFileMappingsSource;
 import com.github.tomakehurst.wiremock.store.files.FileSourceBlobStore;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubImport;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.stubbing.StubMappingJsonRecorder;
 import com.github.tomakehurst.wiremock.verification.*;
-
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.UUID;
-
 import org.eclipse.jetty.util.Jetty;
 
 public class WireMockServer implements Container, Stubbing, Admin {
@@ -83,8 +77,9 @@ public class WireMockServer implements Container, Stubbing, Admin {
 
     HttpServerFactory httpServerFactory = getHttpServerFactory();
 
-    httpServer = httpServerFactory.buildHttpServer(
-        options, wireMockApp.buildAdminRequestHandler(), stubRequestHandler);
+    httpServer =
+        httpServerFactory.buildHttpServer(
+            options, wireMockApp.buildAdminRequestHandler(), stubRequestHandler);
 
     client = new WireMock(wireMockApp);
   }
@@ -96,8 +91,9 @@ public class WireMockServer implements Container, Stubbing, Admin {
           .findFirst()
           .map(e -> (HttpServerFactory) e.get())
           .orElseThrow(
-              () -> new FatalStartupException(
-                  "Jetty 11 is not present and no suitable HttpServerFactory extension was found. Please ensure that the classpath includes a WireMock extension that provides an HttpServerFactory implementation. See http://wiremock.org/docs/extending-wiremock/ for more information."));
+              () ->
+                  new FatalStartupException(
+                      "Jetty 11 is not present and no suitable HttpServerFactory extension was found. Please ensure that the classpath includes a WireMock extension that provides an HttpServerFactory implementation. See http://wiremock.org/docs/extending-wiremock/ for more information."));
     }
 
     return wireMockApp.getExtensions().ofType(HttpServerFactory.class).values().stream()
@@ -187,8 +183,7 @@ public class WireMockServer implements Container, Stubbing, Admin {
   }
 
   public void start() {
-    // Try to ensure this is warmed up on the main thread so that it's inherited by
-    // worker threads
+    // Try to ensure this is warmed up on the main thread so that it's inherited by worker threads
     Json.getObjectMapper();
     try {
       httpServer.start();
@@ -200,27 +195,25 @@ public class WireMockServer implements Container, Stubbing, Admin {
   /**
    * Gracefully shutdown the server.
    *
-   * <p>
-   * This method assumes it is being called as the result of an incoming HTTP
-   * request.
+   * <p>This method assumes it is being called as the result of an incoming HTTP request.
    */
   @Override
   public void shutdown() {
     final WireMockServer server = this;
-    Thread shutdownThread = new Thread(
-        () -> {
-          try {
-            // We have to sleep briefly to finish serving the shutdown request before
-            // stopping
-            // the server, as
-            // there's no support in Jetty for shutting down after the current request.
-            // See http://stackoverflow.com/questions/4650713
-            Thread.sleep(100);
-          } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-          }
-          server.stop();
-        });
+    Thread shutdownThread =
+        new Thread(
+            () -> {
+              try {
+                // We have to sleep briefly to finish serving the shutdown request before stopping
+                // the server, as
+                // there's no support in Jetty for shutting down after the current request.
+                // See http://stackoverflow.com/questions/4650713
+                Thread.sleep(100);
+              } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+              }
+              server.stop();
+            });
     shutdownThread.start();
   }
 
@@ -592,17 +585,5 @@ public class WireMockServer implements Container, Stubbing, Admin {
 
   public Set<String> getLoadedExtensionNames() {
     return wireMockApp.getLoadedExtensionNames();
-  }
-
-  public void loadStubFromResource(String resourcePath) {
-    try {
-      URL resource = getClass().getResource(resourcePath);
-      if (resource == null) {
-        throw new IllegalArgumentException("Resource not found: " + resourcePath);
-      }
-      loadMappingsUsing(new SingleFileMappingsSource(Path.of(resource.toURI())));
-    } catch (URISyntaxException e) {
-      throw new IllegalArgumentException("Invalid resource path: " + resourcePath, e);
-    }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -43,16 +43,22 @@ import com.github.tomakehurst.wiremock.recording.RecordSpecBuilder;
 import com.github.tomakehurst.wiremock.recording.RecordingStatusResult;
 import com.github.tomakehurst.wiremock.recording.SnapshotRecordResult;
 import com.github.tomakehurst.wiremock.standalone.MappingsLoader;
+import com.github.tomakehurst.wiremock.standalone.SingleFileMappingsSource;
 import com.github.tomakehurst.wiremock.store.files.FileSourceBlobStore;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubImport;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.stubbing.StubMappingJsonRecorder;
 import com.github.tomakehurst.wiremock.verification.*;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.UUID;
+
 import org.eclipse.jetty.util.Jetty;
 
 public class WireMockServer implements Container, Stubbing, Admin {
@@ -77,9 +83,8 @@ public class WireMockServer implements Container, Stubbing, Admin {
 
     HttpServerFactory httpServerFactory = getHttpServerFactory();
 
-    httpServer =
-        httpServerFactory.buildHttpServer(
-            options, wireMockApp.buildAdminRequestHandler(), stubRequestHandler);
+    httpServer = httpServerFactory.buildHttpServer(
+        options, wireMockApp.buildAdminRequestHandler(), stubRequestHandler);
 
     client = new WireMock(wireMockApp);
   }
@@ -91,9 +96,8 @@ public class WireMockServer implements Container, Stubbing, Admin {
           .findFirst()
           .map(e -> (HttpServerFactory) e.get())
           .orElseThrow(
-              () ->
-                  new FatalStartupException(
-                      "Jetty 11 is not present and no suitable HttpServerFactory extension was found. Please ensure that the classpath includes a WireMock extension that provides an HttpServerFactory implementation. See http://wiremock.org/docs/extending-wiremock/ for more information."));
+              () -> new FatalStartupException(
+                  "Jetty 11 is not present and no suitable HttpServerFactory extension was found. Please ensure that the classpath includes a WireMock extension that provides an HttpServerFactory implementation. See http://wiremock.org/docs/extending-wiremock/ for more information."));
     }
 
     return wireMockApp.getExtensions().ofType(HttpServerFactory.class).values().stream()
@@ -183,7 +187,8 @@ public class WireMockServer implements Container, Stubbing, Admin {
   }
 
   public void start() {
-    // Try to ensure this is warmed up on the main thread so that it's inherited by worker threads
+    // Try to ensure this is warmed up on the main thread so that it's inherited by
+    // worker threads
     Json.getObjectMapper();
     try {
       httpServer.start();
@@ -195,25 +200,27 @@ public class WireMockServer implements Container, Stubbing, Admin {
   /**
    * Gracefully shutdown the server.
    *
-   * <p>This method assumes it is being called as the result of an incoming HTTP request.
+   * <p>
+   * This method assumes it is being called as the result of an incoming HTTP
+   * request.
    */
   @Override
   public void shutdown() {
     final WireMockServer server = this;
-    Thread shutdownThread =
-        new Thread(
-            () -> {
-              try {
-                // We have to sleep briefly to finish serving the shutdown request before stopping
-                // the server, as
-                // there's no support in Jetty for shutting down after the current request.
-                // See http://stackoverflow.com/questions/4650713
-                Thread.sleep(100);
-              } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-              }
-              server.stop();
-            });
+    Thread shutdownThread = new Thread(
+        () -> {
+          try {
+            // We have to sleep briefly to finish serving the shutdown request before
+            // stopping
+            // the server, as
+            // there's no support in Jetty for shutting down after the current request.
+            // See http://stackoverflow.com/questions/4650713
+            Thread.sleep(100);
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+          server.stop();
+        });
     shutdownThread.start();
   }
 
@@ -585,5 +592,17 @@ public class WireMockServer implements Container, Stubbing, Admin {
 
   public Set<String> getLoadedExtensionNames() {
     return wireMockApp.getLoadedExtensionNames();
+  }
+
+  public void loadStubFromResource(String resourcePath) {
+    try {
+      URL resource = getClass().getResource(resourcePath);
+      if (resource == null) {
+        throw new IllegalArgumentException("Resource not found: " + resourcePath);
+      }
+      loadMappingsUsing(new SingleFileMappingsSource(Path.of(resource.toURI())));
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Invalid resource path: " + resourcePath, e);
+    }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -43,16 +43,12 @@ import com.github.tomakehurst.wiremock.recording.RecordSpecBuilder;
 import com.github.tomakehurst.wiremock.recording.RecordingStatusResult;
 import com.github.tomakehurst.wiremock.recording.SnapshotRecordResult;
 import com.github.tomakehurst.wiremock.standalone.MappingsLoader;
-import com.github.tomakehurst.wiremock.standalone.SingleFileMappingsSource;
 import com.github.tomakehurst.wiremock.store.files.FileSourceBlobStore;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubImport;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.stubbing.StubMappingJsonRecorder;
 import com.github.tomakehurst.wiremock.verification.*;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -81,8 +77,9 @@ public class WireMockServer implements Container, Stubbing, Admin {
 
     HttpServerFactory httpServerFactory = getHttpServerFactory();
 
-    httpServer = httpServerFactory.buildHttpServer(
-        options, wireMockApp.buildAdminRequestHandler(), stubRequestHandler);
+    httpServer =
+        httpServerFactory.buildHttpServer(
+            options, wireMockApp.buildAdminRequestHandler(), stubRequestHandler);
 
     client = new WireMock(wireMockApp);
   }
@@ -94,8 +91,9 @@ public class WireMockServer implements Container, Stubbing, Admin {
           .findFirst()
           .map(e -> (HttpServerFactory) e.get())
           .orElseThrow(
-              () -> new FatalStartupException(
-                  "Jetty 11 is not present and no suitable HttpServerFactory extension was found. Please ensure that the classpath includes a WireMock extension that provides an HttpServerFactory implementation. See http://wiremock.org/docs/extending-wiremock/ for more information."));
+              () ->
+                  new FatalStartupException(
+                      "Jetty 11 is not present and no suitable HttpServerFactory extension was found. Please ensure that the classpath includes a WireMock extension that provides an HttpServerFactory implementation. See http://wiremock.org/docs/extending-wiremock/ for more information."));
     }
 
     return wireMockApp.getExtensions().ofType(HttpServerFactory.class).values().stream()
@@ -185,8 +183,7 @@ public class WireMockServer implements Container, Stubbing, Admin {
   }
 
   public void start() {
-    // Try to ensure this is warmed up on the main thread so that it's inherited by
-    // worker threads
+    // Try to ensure this is warmed up on the main thread so that it's inherited by worker threads
     Json.getObjectMapper();
     try {
       httpServer.start();
@@ -198,27 +195,25 @@ public class WireMockServer implements Container, Stubbing, Admin {
   /**
    * Gracefully shutdown the server.
    *
-   * <p>
-   * This method assumes it is being called as the result of an incoming HTTP
-   * request.
+   * <p>This method assumes it is being called as the result of an incoming HTTP request.
    */
   @Override
   public void shutdown() {
     final WireMockServer server = this;
-    Thread shutdownThread = new Thread(
-        () -> {
-          try {
-            // We have to sleep briefly to finish serving the shutdown request before
-            // stopping
-            // the server, as
-            // there's no support in Jetty for shutting down after the current request.
-            // See http://stackoverflow.com/questions/4650713
-            Thread.sleep(100);
-          } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-          }
-          server.stop();
-        });
+    Thread shutdownThread =
+        new Thread(
+            () -> {
+              try {
+                // We have to sleep briefly to finish serving the shutdown request before stopping
+                // the server, as
+                // there's no support in Jetty for shutting down after the current request.
+                // See http://stackoverflow.com/questions/4650713
+                Thread.sleep(100);
+              } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+              }
+              server.stop();
+            });
     shutdownThread.start();
   }
 
@@ -590,17 +585,5 @@ public class WireMockServer implements Container, Stubbing, Admin {
 
   public Set<String> getLoadedExtensionNames() {
     return wireMockApp.getLoadedExtensionNames();
-  }
-
-  public void loadStubFromResource(String resourcePath) {
-    try {
-      URL resource = getClass().getResource(resourcePath);
-      if (resource == null) {
-        throw new IllegalArgumentException("Resource not found: " + resourcePath);
-      }
-      loadMappingsUsing(new SingleFileMappingsSource(Path.of(resource.toURI())));
-    } catch (URISyntaxException e) {
-      throw new IllegalArgumentException("Invalid resource path: " + resourcePath, e);
-    }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/MappingFileException.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/MappingFileException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.common;
+
+/**
+ * Exception thrown when there is an error loading a mapping file.
+ */
+public class MappingFileException extends RuntimeException {
+    public MappingFileException(String path, Exception cause) {
+        super("Error loading mapping file " + path + ": " + cause.getMessage(), cause);
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -26,18 +26,22 @@ import org.junit.jupiter.api.extension.*;
 import org.junit.platform.commons.support.AnnotationSupport;
 
 /**
- * JUnit Jupiter extension that manages a WireMock server instance's lifecycle and configuration.
+ * JUnit Jupiter extension that manages a WireMock server instance's lifecycle
+ * and configuration.
  *
- * <p>See <a
- * href="http://wiremock.org/docs/junit-jupiter/">http://wiremock.org/docs/junit-jupiter/</a> for
+ * <p>
+ * See <a
+ * href=
+ * "http://wiremock.org/docs/junit-jupiter/">http://wiremock.org/docs/junit-jupiter/</a>
+ * for
  * full documentation.
  */
 public class WireMockExtension extends DslWrapper
     implements ParameterResolver,
-        BeforeEachCallback,
-        BeforeAllCallback,
-        AfterEachCallback,
-        AfterAllCallback {
+    BeforeEachCallback,
+    BeforeAllCallback,
+    AfterEachCallback,
+    AfterAllCallback {
 
   private final boolean configureStaticDsl;
   private final boolean failOnUnmatchedRequests;
@@ -59,11 +63,14 @@ public class WireMockExtension extends DslWrapper
   /**
    * Constructor intended for subclasses.
    *
-   * <p>The parameter is a builder so that we can avoid a constructor explosion or
+   * <p>
+   * The parameter is a builder so that we can avoid a constructor explosion or
    * backwards-incompatible changes when new options are added.
    *
-   * @param builder a {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
-   *     instance holding the initialisation parameters for the extension.
+   * @param builder a
+   *                {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *                instance holding the initialisation parameters for the
+   *                extension.
    */
   protected WireMockExtension(Builder builder) {
     this.options = builder.options;
@@ -86,11 +93,13 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * Alias for {@link #newInstance()} for use with custom subclasses, with a more relevant name for
+   * Alias for {@link #newInstance()} for use with custom subclasses, with a more
+   * relevant name for
    * that use.
    *
-   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
-   *     instance.
+   * @return a new
+   *         {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *         instance.
    */
   public static Builder extensionOptions() {
     return newInstance();
@@ -99,27 +108,33 @@ public class WireMockExtension extends DslWrapper
   /**
    * Create a new builder for the extension.
    *
-   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
-   *     instance.
+   * @return a new
+   *         {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *         instance.
    */
   public static Builder newInstance() {
     return new Builder();
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-class WireMock setup.
+   * To be overridden in subclasses in order to run code immediately after
+   * per-class WireMock setup.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
-  protected void onBeforeAll(WireMockRuntimeInfo wireMockRuntimeInfo) {}
+  protected void onBeforeAll(WireMockRuntimeInfo wireMockRuntimeInfo) {
+  }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-class WireMock setup.
+   * To be overridden in subclasses in order to run code immediately after
+   * per-class WireMock setup.
    *
-   * @param extensionContext the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param extensionContext    the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
   protected void onBeforeAll(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -127,20 +142,25 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-test WireMock setup.
+   * To be overridden in subclasses in order to run code immediately after
+   * per-test WireMock setup.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
-  protected void onBeforeEach(WireMockRuntimeInfo wireMockRuntimeInfo) {}
+  protected void onBeforeEach(WireMockRuntimeInfo wireMockRuntimeInfo) {
+  }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-test cleanup of
+   * To be overridden in subclasses in order to run code immediately after
+   * per-test cleanup of
    * WireMock and its associated resources.
    *
-   * @param extensionContext the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param extensionContext    the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
   protected void onBeforeEach(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -148,21 +168,26 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-test cleanup of
+   * To be overridden in subclasses in order to run code immediately after
+   * per-test cleanup of
    * WireMock and its associated resources.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
-  protected void onAfterEach(WireMockRuntimeInfo wireMockRuntimeInfo) {}
+  protected void onAfterEach(WireMockRuntimeInfo wireMockRuntimeInfo) {
+  }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
+   * To be overridden in subclasses in order to run code immediately after
+   * per-class cleanup of
    * WireMock.
    *
-   * @param extensionContext the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param extensionContext    the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
   protected void onAfterEach(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -170,21 +195,26 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
+   * To be overridden in subclasses in order to run code immediately after
+   * per-class cleanup of
    * WireMock.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
-  protected void onAfterAll(WireMockRuntimeInfo wireMockRuntimeInfo) {}
+  protected void onAfterAll(WireMockRuntimeInfo wireMockRuntimeInfo) {
+  }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
+   * To be overridden in subclasses in order to run code immediately after
+   * per-class cleanup of
    * WireMock.
    *
-   * @param extensionContext the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param extensionContext    the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
   protected void onAfterAll(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -228,14 +258,12 @@ public class WireMockExtension extends DslWrapper
 
   private void setAdditionalOptions(ExtensionContext extensionContext) {
     if (proxyMode == null) {
-      proxyMode =
-          extensionContext
-              .getElement()
-              .flatMap(
-                  annotatedElement ->
-                      AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class))
-              .map(WireMockTest::proxyMode)
-              .orElse(false);
+      proxyMode = extensionContext
+          .getElement()
+          .flatMap(
+              annotatedElement -> AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class))
+          .map(WireMockTest::proxyMode)
+          .orElse(false);
     }
   }
 
@@ -244,20 +272,18 @@ public class WireMockExtension extends DslWrapper
     return extensionContext
         .getElement()
         .flatMap(
-            annotatedElement ->
-                this.isDeclarative
-                    ? AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class)
-                    : Optional.empty())
+            annotatedElement -> this.isDeclarative
+                ? AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class)
+                : Optional.empty())
         .map(this::buildOptionsFromWireMockTestAnnotation)
         .orElseGet(() -> Optional.ofNullable(this.options).orElse(defaultOptions));
   }
 
   private Options buildOptionsFromWireMockTestAnnotation(WireMockTest annotation) {
-    WireMockConfiguration options =
-        WireMockConfiguration.options()
-            .port(annotation.httpPort())
-            .extensionScanningEnabled(annotation.extensionScanningEnabled())
-            .enableBrowserProxying(annotation.proxyMode());
+    WireMockConfiguration options = WireMockConfiguration.options()
+        .port(annotation.httpPort())
+        .extensionScanningEnabled(annotation.extensionScanningEnabled())
+        .enableBrowserProxying(annotation.proxyMode());
 
     if (annotation.httpsEnabled()) {
       options.httpsPort(annotation.httpsPort());
@@ -296,11 +322,22 @@ public class WireMockExtension extends DslWrapper
 
     setAdditionalOptions(context);
 
+    loadStubsFromAnnotation(context);
+
     if (proxyMode) {
       JvmProxyConfigurer.configureFor(wireMockServer);
     }
 
     onBeforeEach(context, runtimeInfo);
+  }
+
+  private void loadStubsFromAnnotation(ExtensionContext context) {
+    WireMockStub annotation = context.getRequiredTestMethod()
+        .getAnnotation(WireMockStub.class);
+
+    if (annotation != null) {
+      wireMockServer.loadStubFromResource(annotation.value());
+    }
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -26,18 +26,22 @@ import org.junit.jupiter.api.extension.*;
 import org.junit.platform.commons.support.AnnotationSupport;
 
 /**
- * JUnit Jupiter extension that manages a WireMock server instance's lifecycle and configuration.
+ * JUnit Jupiter extension that manages a WireMock server instance's lifecycle
+ * and configuration.
  *
- * <p>See <a
- * href="http://wiremock.org/docs/junit-jupiter/">http://wiremock.org/docs/junit-jupiter/</a> for
+ * <p>
+ * See <a
+ * href=
+ * "http://wiremock.org/docs/junit-jupiter/">http://wiremock.org/docs/junit-jupiter/</a>
+ * for
  * full documentation.
  */
 public class WireMockExtension extends DslWrapper
     implements ParameterResolver,
-        BeforeEachCallback,
-        BeforeAllCallback,
-        AfterEachCallback,
-        AfterAllCallback {
+    BeforeEachCallback,
+    BeforeAllCallback,
+    AfterEachCallback,
+    AfterAllCallback {
 
   private final boolean configureStaticDsl;
   private final boolean failOnUnmatchedRequests;
@@ -59,11 +63,14 @@ public class WireMockExtension extends DslWrapper
   /**
    * Constructor intended for subclasses.
    *
-   * <p>The parameter is a builder so that we can avoid a constructor explosion or
+   * <p>
+   * The parameter is a builder so that we can avoid a constructor explosion or
    * backwards-incompatible changes when new options are added.
    *
-   * @param builder a {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
-   *     instance holding the initialisation parameters for the extension.
+   * @param builder a
+   *                {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *                instance holding the initialisation parameters for the
+   *                extension.
    */
   protected WireMockExtension(Builder builder) {
     this.options = builder.options;
@@ -86,11 +93,13 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * Alias for {@link #newInstance()} for use with custom subclasses, with a more relevant name for
+   * Alias for {@link #newInstance()} for use with custom subclasses, with a more
+   * relevant name for
    * that use.
    *
-   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
-   *     instance.
+   * @return a new
+   *         {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *         instance.
    */
   public static Builder extensionOptions() {
     return newInstance();
@@ -99,27 +108,33 @@ public class WireMockExtension extends DslWrapper
   /**
    * Create a new builder for the extension.
    *
-   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
-   *     instance.
+   * @return a new
+   *         {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *         instance.
    */
   public static Builder newInstance() {
     return new Builder();
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-class WireMock setup.
+   * To be overridden in subclasses in order to run code immediately after
+   * per-class WireMock setup.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
-  protected void onBeforeAll(WireMockRuntimeInfo wireMockRuntimeInfo) {}
+  protected void onBeforeAll(WireMockRuntimeInfo wireMockRuntimeInfo) {
+  }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-class WireMock setup.
+   * To be overridden in subclasses in order to run code immediately after
+   * per-class WireMock setup.
    *
-   * @param extensionContext the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param extensionContext    the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
   protected void onBeforeAll(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -127,20 +142,25 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-test WireMock setup.
+   * To be overridden in subclasses in order to run code immediately after
+   * per-test WireMock setup.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
-  protected void onBeforeEach(WireMockRuntimeInfo wireMockRuntimeInfo) {}
+  protected void onBeforeEach(WireMockRuntimeInfo wireMockRuntimeInfo) {
+  }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-test cleanup of
+   * To be overridden in subclasses in order to run code immediately after
+   * per-test cleanup of
    * WireMock and its associated resources.
    *
-   * @param extensionContext the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param extensionContext    the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
   protected void onBeforeEach(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -148,21 +168,26 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-test cleanup of
+   * To be overridden in subclasses in order to run code immediately after
+   * per-test cleanup of
    * WireMock and its associated resources.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
-  protected void onAfterEach(WireMockRuntimeInfo wireMockRuntimeInfo) {}
+  protected void onAfterEach(WireMockRuntimeInfo wireMockRuntimeInfo) {
+  }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
+   * To be overridden in subclasses in order to run code immediately after
+   * per-class cleanup of
    * WireMock.
    *
-   * @param extensionContext the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param extensionContext    the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
   protected void onAfterEach(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -170,21 +195,26 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
+   * To be overridden in subclasses in order to run code immediately after
+   * per-class cleanup of
    * WireMock.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
-  protected void onAfterAll(WireMockRuntimeInfo wireMockRuntimeInfo) {}
+  protected void onAfterAll(WireMockRuntimeInfo wireMockRuntimeInfo) {
+  }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
+   * To be overridden in subclasses in order to run code immediately after
+   * per-class cleanup of
    * WireMock.
    *
-   * @param extensionContext the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
-   *     instance/
+   * @param extensionContext    the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
+   *                            running WireMock
+   *                            instance/
    */
   protected void onAfterAll(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -228,14 +258,12 @@ public class WireMockExtension extends DslWrapper
 
   private void setAdditionalOptions(ExtensionContext extensionContext) {
     if (proxyMode == null) {
-      proxyMode =
-          extensionContext
-              .getElement()
-              .flatMap(
-                  annotatedElement ->
-                      AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class))
-              .map(WireMockTest::proxyMode)
-              .orElse(false);
+      proxyMode = extensionContext
+          .getElement()
+          .flatMap(
+              annotatedElement -> AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class))
+          .map(WireMockTest::proxyMode)
+          .orElse(false);
     }
   }
 
@@ -244,20 +272,18 @@ public class WireMockExtension extends DslWrapper
     return extensionContext
         .getElement()
         .flatMap(
-            annotatedElement ->
-                this.isDeclarative
-                    ? AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class)
-                    : Optional.empty())
+            annotatedElement -> this.isDeclarative
+                ? AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class)
+                : Optional.empty())
         .map(this::buildOptionsFromWireMockTestAnnotation)
         .orElseGet(() -> Optional.ofNullable(this.options).orElse(defaultOptions));
   }
 
   private Options buildOptionsFromWireMockTestAnnotation(WireMockTest annotation) {
-    WireMockConfiguration options =
-        WireMockConfiguration.options()
-            .port(annotation.httpPort())
-            .extensionScanningEnabled(annotation.extensionScanningEnabled())
-            .enableBrowserProxying(annotation.proxyMode());
+    WireMockConfiguration options = WireMockConfiguration.options()
+        .port(annotation.httpPort())
+        .extensionScanningEnabled(annotation.extensionScanningEnabled())
+        .enableBrowserProxying(annotation.proxyMode());
 
     if (annotation.httpsEnabled()) {
       options.httpsPort(annotation.httpsPort());
@@ -296,11 +322,22 @@ public class WireMockExtension extends DslWrapper
 
     setAdditionalOptions(context);
 
+    loadTestStub(context);
+
     if (proxyMode) {
       JvmProxyConfigurer.configureFor(wireMockServer);
     }
 
     onBeforeEach(context, runtimeInfo);
+  }
+
+  private void loadTestStub(ExtensionContext context) {
+    WireMockStub annotation = context.getRequiredTestMethod()
+        .getAnnotation(WireMockStub.class);
+
+    if (annotation != null) {
+      wireMockServer.loadStubFromResource(annotation.value());
+    }
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -296,11 +296,22 @@ public class WireMockExtension extends DslWrapper
 
     setAdditionalOptions(context);
 
+    loadTestStub(context);
+
     if (proxyMode) {
       JvmProxyConfigurer.configureFor(wireMockServer);
     }
 
     onBeforeEach(context, runtimeInfo);
+  }
+
+  private void loadTestStub(ExtensionContext context) {
+    WireMockStub annotation = context.getRequiredTestMethod()
+        .getAnnotation(WireMockStub.class);
+
+    if (annotation != null) {
+      wireMockServer.loadStubFromResource(annotation.value());
+    }
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -21,7 +21,10 @@ import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.http.JvmProxyConfigurer;
 import com.github.tomakehurst.wiremock.junit.DslWrapper;
+
+import java.lang.reflect.Method;
 import java.util.Optional;
+
 import org.junit.jupiter.api.extension.*;
 import org.junit.platform.commons.support.AnnotationSupport;
 
@@ -306,10 +309,9 @@ public class WireMockExtension extends DslWrapper
   }
 
   private void loadTestStub(ExtensionContext context) {
-    WireMockStub annotation = context.getRequiredTestMethod()
-        .getAnnotation(WireMockStub.class);
-
-    if (annotation != null) {
+    Method testMethod = context.getRequiredTestMethod();
+    if (testMethod != null && testMethod.isAnnotationPresent(WireMockStub.class)) {
+      WireMockStub annotation = testMethod.getAnnotation(WireMockStub.class);
       wireMockServer.loadStubFromResource(annotation.value());
     }
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -26,22 +26,18 @@ import org.junit.jupiter.api.extension.*;
 import org.junit.platform.commons.support.AnnotationSupport;
 
 /**
- * JUnit Jupiter extension that manages a WireMock server instance's lifecycle
- * and configuration.
+ * JUnit Jupiter extension that manages a WireMock server instance's lifecycle and configuration.
  *
- * <p>
- * See <a
- * href=
- * "http://wiremock.org/docs/junit-jupiter/">http://wiremock.org/docs/junit-jupiter/</a>
- * for
+ * <p>See <a
+ * href="http://wiremock.org/docs/junit-jupiter/">http://wiremock.org/docs/junit-jupiter/</a> for
  * full documentation.
  */
 public class WireMockExtension extends DslWrapper
     implements ParameterResolver,
-    BeforeEachCallback,
-    BeforeAllCallback,
-    AfterEachCallback,
-    AfterAllCallback {
+        BeforeEachCallback,
+        BeforeAllCallback,
+        AfterEachCallback,
+        AfterAllCallback {
 
   private final boolean configureStaticDsl;
   private final boolean failOnUnmatchedRequests;
@@ -63,14 +59,11 @@ public class WireMockExtension extends DslWrapper
   /**
    * Constructor intended for subclasses.
    *
-   * <p>
-   * The parameter is a builder so that we can avoid a constructor explosion or
+   * <p>The parameter is a builder so that we can avoid a constructor explosion or
    * backwards-incompatible changes when new options are added.
    *
-   * @param builder a
-   *                {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
-   *                instance holding the initialisation parameters for the
-   *                extension.
+   * @param builder a {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *     instance holding the initialisation parameters for the extension.
    */
   protected WireMockExtension(Builder builder) {
     this.options = builder.options;
@@ -93,13 +86,11 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * Alias for {@link #newInstance()} for use with custom subclasses, with a more
-   * relevant name for
+   * Alias for {@link #newInstance()} for use with custom subclasses, with a more relevant name for
    * that use.
    *
-   * @return a new
-   *         {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
-   *         instance.
+   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *     instance.
    */
   public static Builder extensionOptions() {
     return newInstance();
@@ -108,33 +99,27 @@ public class WireMockExtension extends DslWrapper
   /**
    * Create a new builder for the extension.
    *
-   * @return a new
-   *         {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
-   *         instance.
+   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *     instance.
    */
   public static Builder newInstance() {
     return new Builder();
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-class WireMock setup.
+   * To be overridden in subclasses in order to run code immediately after per-class WireMock setup.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
-  protected void onBeforeAll(WireMockRuntimeInfo wireMockRuntimeInfo) {
-  }
+  protected void onBeforeAll(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-class WireMock setup.
+   * To be overridden in subclasses in order to run code immediately after per-class WireMock setup.
    *
-   * @param extensionContext    the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param extensionContext the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onBeforeAll(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -142,25 +127,20 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-test WireMock setup.
+   * To be overridden in subclasses in order to run code immediately after per-test WireMock setup.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
-  protected void onBeforeEach(WireMockRuntimeInfo wireMockRuntimeInfo) {
-  }
+  protected void onBeforeEach(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-test cleanup of
+   * To be overridden in subclasses in order to run code immediately after per-test cleanup of
    * WireMock and its associated resources.
    *
-   * @param extensionContext    the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param extensionContext the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onBeforeEach(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -168,26 +148,21 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-test cleanup of
+   * To be overridden in subclasses in order to run code immediately after per-test cleanup of
    * WireMock and its associated resources.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
-  protected void onAfterEach(WireMockRuntimeInfo wireMockRuntimeInfo) {
-  }
+  protected void onAfterEach(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-class cleanup of
+   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
    * WireMock.
    *
-   * @param extensionContext    the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param extensionContext the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onAfterEach(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -195,26 +170,21 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-class cleanup of
+   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
    * WireMock.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
-  protected void onAfterAll(WireMockRuntimeInfo wireMockRuntimeInfo) {
-  }
+  protected void onAfterAll(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-class cleanup of
+   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
    * WireMock.
    *
-   * @param extensionContext    the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param extensionContext the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onAfterAll(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -258,12 +228,14 @@ public class WireMockExtension extends DslWrapper
 
   private void setAdditionalOptions(ExtensionContext extensionContext) {
     if (proxyMode == null) {
-      proxyMode = extensionContext
-          .getElement()
-          .flatMap(
-              annotatedElement -> AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class))
-          .map(WireMockTest::proxyMode)
-          .orElse(false);
+      proxyMode =
+          extensionContext
+              .getElement()
+              .flatMap(
+                  annotatedElement ->
+                      AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class))
+              .map(WireMockTest::proxyMode)
+              .orElse(false);
     }
   }
 
@@ -272,18 +244,20 @@ public class WireMockExtension extends DslWrapper
     return extensionContext
         .getElement()
         .flatMap(
-            annotatedElement -> this.isDeclarative
-                ? AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class)
-                : Optional.empty())
+            annotatedElement ->
+                this.isDeclarative
+                    ? AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class)
+                    : Optional.empty())
         .map(this::buildOptionsFromWireMockTestAnnotation)
         .orElseGet(() -> Optional.ofNullable(this.options).orElse(defaultOptions));
   }
 
   private Options buildOptionsFromWireMockTestAnnotation(WireMockTest annotation) {
-    WireMockConfiguration options = WireMockConfiguration.options()
-        .port(annotation.httpPort())
-        .extensionScanningEnabled(annotation.extensionScanningEnabled())
-        .enableBrowserProxying(annotation.proxyMode());
+    WireMockConfiguration options =
+        WireMockConfiguration.options()
+            .port(annotation.httpPort())
+            .extensionScanningEnabled(annotation.extensionScanningEnabled())
+            .enableBrowserProxying(annotation.proxyMode());
 
     if (annotation.httpsEnabled()) {
       options.httpsPort(annotation.httpsPort());
@@ -322,22 +296,11 @@ public class WireMockExtension extends DslWrapper
 
     setAdditionalOptions(context);
 
-    loadTestStub(context);
-
     if (proxyMode) {
       JvmProxyConfigurer.configureFor(wireMockServer);
     }
 
     onBeforeEach(context, runtimeInfo);
-  }
-
-  private void loadTestStub(ExtensionContext context) {
-    WireMockStub annotation = context.getRequiredTestMethod()
-        .getAnnotation(WireMockStub.class);
-
-    if (annotation != null) {
-      wireMockServer.loadStubFromResource(annotation.value());
-    }
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -26,22 +26,18 @@ import org.junit.jupiter.api.extension.*;
 import org.junit.platform.commons.support.AnnotationSupport;
 
 /**
- * JUnit Jupiter extension that manages a WireMock server instance's lifecycle
- * and configuration.
+ * JUnit Jupiter extension that manages a WireMock server instance's lifecycle and configuration.
  *
- * <p>
- * See <a
- * href=
- * "http://wiremock.org/docs/junit-jupiter/">http://wiremock.org/docs/junit-jupiter/</a>
- * for
+ * <p>See <a
+ * href="http://wiremock.org/docs/junit-jupiter/">http://wiremock.org/docs/junit-jupiter/</a> for
  * full documentation.
  */
 public class WireMockExtension extends DslWrapper
     implements ParameterResolver,
-    BeforeEachCallback,
-    BeforeAllCallback,
-    AfterEachCallback,
-    AfterAllCallback {
+        BeforeEachCallback,
+        BeforeAllCallback,
+        AfterEachCallback,
+        AfterAllCallback {
 
   private final boolean configureStaticDsl;
   private final boolean failOnUnmatchedRequests;
@@ -63,14 +59,11 @@ public class WireMockExtension extends DslWrapper
   /**
    * Constructor intended for subclasses.
    *
-   * <p>
-   * The parameter is a builder so that we can avoid a constructor explosion or
+   * <p>The parameter is a builder so that we can avoid a constructor explosion or
    * backwards-incompatible changes when new options are added.
    *
-   * @param builder a
-   *                {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
-   *                instance holding the initialisation parameters for the
-   *                extension.
+   * @param builder a {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *     instance holding the initialisation parameters for the extension.
    */
   protected WireMockExtension(Builder builder) {
     this.options = builder.options;
@@ -93,13 +86,11 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * Alias for {@link #newInstance()} for use with custom subclasses, with a more
-   * relevant name for
+   * Alias for {@link #newInstance()} for use with custom subclasses, with a more relevant name for
    * that use.
    *
-   * @return a new
-   *         {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
-   *         instance.
+   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *     instance.
    */
   public static Builder extensionOptions() {
     return newInstance();
@@ -108,33 +99,27 @@ public class WireMockExtension extends DslWrapper
   /**
    * Create a new builder for the extension.
    *
-   * @return a new
-   *         {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
-   *         instance.
+   * @return a new {@link com.github.tomakehurst.wiremock.junit5.WireMockExtension.Builder}
+   *     instance.
    */
   public static Builder newInstance() {
     return new Builder();
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-class WireMock setup.
+   * To be overridden in subclasses in order to run code immediately after per-class WireMock setup.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
-  protected void onBeforeAll(WireMockRuntimeInfo wireMockRuntimeInfo) {
-  }
+  protected void onBeforeAll(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-class WireMock setup.
+   * To be overridden in subclasses in order to run code immediately after per-class WireMock setup.
    *
-   * @param extensionContext    the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param extensionContext the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onBeforeAll(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -142,25 +127,20 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-test WireMock setup.
+   * To be overridden in subclasses in order to run code immediately after per-test WireMock setup.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
-  protected void onBeforeEach(WireMockRuntimeInfo wireMockRuntimeInfo) {
-  }
+  protected void onBeforeEach(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-test cleanup of
+   * To be overridden in subclasses in order to run code immediately after per-test cleanup of
    * WireMock and its associated resources.
    *
-   * @param extensionContext    the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param extensionContext the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onBeforeEach(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -168,26 +148,21 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-test cleanup of
+   * To be overridden in subclasses in order to run code immediately after per-test cleanup of
    * WireMock and its associated resources.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
-  protected void onAfterEach(WireMockRuntimeInfo wireMockRuntimeInfo) {
-  }
+  protected void onAfterEach(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-class cleanup of
+   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
    * WireMock.
    *
-   * @param extensionContext    the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param extensionContext the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onAfterEach(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -195,26 +170,21 @@ public class WireMockExtension extends DslWrapper
   }
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-class cleanup of
+   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
    * WireMock.
    *
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
-  protected void onAfterAll(WireMockRuntimeInfo wireMockRuntimeInfo) {
-  }
+  protected void onAfterAll(WireMockRuntimeInfo wireMockRuntimeInfo) {}
 
   /**
-   * To be overridden in subclasses in order to run code immediately after
-   * per-class cleanup of
+   * To be overridden in subclasses in order to run code immediately after per-class cleanup of
    * WireMock.
    *
-   * @param extensionContext    the current extension context; never {@code null}
-   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the
-   *                            running WireMock
-   *                            instance/
+   * @param extensionContext the current extension context; never {@code null}
+   * @param wireMockRuntimeInfo port numbers, base URLs and HTTPS info for the running WireMock
+   *     instance/
    */
   protected void onAfterAll(
       ExtensionContext extensionContext, WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -258,12 +228,14 @@ public class WireMockExtension extends DslWrapper
 
   private void setAdditionalOptions(ExtensionContext extensionContext) {
     if (proxyMode == null) {
-      proxyMode = extensionContext
-          .getElement()
-          .flatMap(
-              annotatedElement -> AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class))
-          .map(WireMockTest::proxyMode)
-          .orElse(false);
+      proxyMode =
+          extensionContext
+              .getElement()
+              .flatMap(
+                  annotatedElement ->
+                      AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class))
+              .map(WireMockTest::proxyMode)
+              .orElse(false);
     }
   }
 
@@ -272,18 +244,20 @@ public class WireMockExtension extends DslWrapper
     return extensionContext
         .getElement()
         .flatMap(
-            annotatedElement -> this.isDeclarative
-                ? AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class)
-                : Optional.empty())
+            annotatedElement ->
+                this.isDeclarative
+                    ? AnnotationSupport.findAnnotation(annotatedElement, WireMockTest.class)
+                    : Optional.empty())
         .map(this::buildOptionsFromWireMockTestAnnotation)
         .orElseGet(() -> Optional.ofNullable(this.options).orElse(defaultOptions));
   }
 
   private Options buildOptionsFromWireMockTestAnnotation(WireMockTest annotation) {
-    WireMockConfiguration options = WireMockConfiguration.options()
-        .port(annotation.httpPort())
-        .extensionScanningEnabled(annotation.extensionScanningEnabled())
-        .enableBrowserProxying(annotation.proxyMode());
+    WireMockConfiguration options =
+        WireMockConfiguration.options()
+            .port(annotation.httpPort())
+            .extensionScanningEnabled(annotation.extensionScanningEnabled())
+            .enableBrowserProxying(annotation.proxyMode());
 
     if (annotation.httpsEnabled()) {
       options.httpsPort(annotation.httpsPort());
@@ -322,22 +296,11 @@ public class WireMockExtension extends DslWrapper
 
     setAdditionalOptions(context);
 
-    loadStubsFromAnnotation(context);
-
     if (proxyMode) {
       JvmProxyConfigurer.configureFor(wireMockServer);
     }
 
     onBeforeEach(context, runtimeInfo);
-  }
-
-  private void loadStubsFromAnnotation(ExtensionContext context) {
-    WireMockStub annotation = context.getRequiredTestMethod()
-        .getAnnotation(WireMockStub.class);
-
-    if (annotation != null) {
-      wireMockServer.loadStubFromResource(annotation.value());
-    }
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockStub.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockStub.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to specify a JSON resource file containing stub mappings to be
+ * loaded
+ * for a specific test method.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface WireMockStub {
+    String value();
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/SingleFileMappingsSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/SingleFileMappingsSource.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.standalone;
+
+import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.common.MappingFileException;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import com.github.tomakehurst.wiremock.stubbing.StubMappings;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A MappingsLoader implementation that loads stub mappings from a single JSON
+ * file.
+ * This differs from the default JsonFileMappingsSource which loads from a
+ * directory.
+ * 
+ * The file can contain either:
+ * - A single stub mapping as a JSON object
+ * - Multiple stub mappings as a JSON array
+ */
+public class SingleFileMappingsSource implements MappingsLoader {
+    private final Path mappingsFile;
+
+    public SingleFileMappingsSource(Path mappingsFile) {
+        this.mappingsFile = validateFile(mappingsFile);
+    }
+
+    private Path validateFile(Path file) {
+        if (!Files.exists(file)) {
+            throw new IllegalArgumentException("File does not exist: " + file);
+        }
+        if (!Files.isRegularFile(file)) {
+            throw new IllegalArgumentException("Not a regular file: " + file);
+        }
+        return file;
+    }
+
+    @Override
+    public void loadMappingsInto(StubMappings stubMappings) {
+        try {
+            byte[] content = Files.readAllBytes(mappingsFile);
+            Object parsed = Json.read(content, Object.class);
+
+            List<StubMapping> mappings;
+            if (parsed instanceof List) {
+                mappings = Json.getObjectMapper().readValue(
+                    content, 
+                    Json.getObjectMapper().getTypeFactory().constructCollectionType(
+                        List.class, 
+                        StubMapping.class
+                    )
+                );
+            } else {
+                mappings = Collections.singletonList(Json.read(content, StubMapping.class));
+            }
+
+            for (StubMapping mapping : mappings) {
+                mapping.setDirty(false);
+                stubMappings.addMapping(mapping);
+            }
+        } catch (Exception e) {
+            throw new MappingFileException(mappingsFile.toString(), e);
+        }
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/WireMockStubLoadingTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/WireMockStubLoadingTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.junit5;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import org.junit.jupiter.api.Test;
+
+@WireMockTest
+class WireMockStubLoadingTest {
+
+    @Test
+    @WireMockStub("/wiremock/stubs/simple-get.json")
+    void shouldReturnExpectedResponseWhenStubMatches(WireMockRuntimeInfo runtimeInfo) {
+        // Given
+        WireMockTestClient client = new WireMockTestClient(runtimeInfo.getHttpPort());
+
+        // When
+        WireMockResponse response = client.get("/test");
+
+        // Then
+        assertThat(response.statusCode(), is(200));
+        assertThat(response.content(), is("Hello World"));
+    }
+
+    @Test
+    @WireMockStub("/wiremock/stubs/multiple-stubs.json")
+    void shouldHandleMultipleEndpoints(WireMockRuntimeInfo runtimeInfo) {
+        // Given
+        WireMockTestClient client = new WireMockTestClient(runtimeInfo.getHttpPort());
+
+        // When/Then
+        WireMockResponse response1 = client.get("/test1");
+        assertThat(response1.statusCode(), is(200));
+        assertThat(response1.content(), is("Test 1"));
+
+        WireMockResponse response2 = client.get("/test2");
+        assertThat(response2.statusCode(), is(200));
+        assertThat(response2.content(), is("Test 2"));
+    }
+
+    @Test
+    @WireMockStub("/wiremock/stubs/simple-get.json")
+    void shouldReturn404WhenUrlDoesNotMatch(WireMockRuntimeInfo runtimeInfo) {
+        // Given
+        WireMockTestClient client = new WireMockTestClient(runtimeInfo.getHttpPort());
+
+        // When
+        WireMockResponse response = client.get("/non-existent");
+
+        // Then
+        assertThat(response.statusCode(), is(404));
+    }
+
+    @Test
+    @WireMockStub("/wiremock/stubs/simple-get.json")
+    void shouldAllowVerificationOfRequests(WireMockRuntimeInfo runtimeInfo) {
+        // Given
+        WireMockTestClient client = new WireMockTestClient(runtimeInfo.getHttpPort());
+
+        // When
+        client.get("/test");
+
+        // Then
+        verify(getRequestedFor(urlEqualTo("/test")));
+    }
+}

--- a/src/test/resources/wiremock/stubs/malformed.json
+++ b/src/test/resources/wiremock/stubs/malformed.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/test"
+  },
+  "response": {
+    "status": 200,
+    "body": "Hello World"
+  }
+} 

--- a/src/test/resources/wiremock/stubs/multiple-stubs.json
+++ b/src/test/resources/wiremock/stubs/multiple-stubs.json
@@ -1,0 +1,22 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "url": "/test1"
+    },
+    "response": {
+      "status": 200,
+      "body": "Test 1"
+    }
+  },
+  {
+    "request": {
+      "method": "GET",
+      "url": "/test2"
+    },
+    "response": {
+      "status": 200,
+      "body": "Test 2"
+    }
+  }
+] 

--- a/src/test/resources/wiremock/stubs/simple-get.json
+++ b/src/test/resources/wiremock/stubs/simple-get.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/test"
+  },
+  "response": {
+    "status": 200,
+    "body": "Hello World"
+  }
+} 


### PR DESCRIPTION
## References

https://github.com/wiremock/wiremock/issues/2776

Note - I did this as an experiment using Cursor IDE's "composer" feature to have it build the solution for me. 

Happy to share my experience of this. Definitely helpful, but also definitely not a magic bullet. That said, it enabled
me to get this built in just over a day, and that was with me not having used Cursor before.

Documentation is needed, I will do that as a separate PR.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

