### PR TITLE
fix serialization of ignoreOrderOfSameNode for equalToXml

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
@@ -60,7 +60,7 @@ public class EqualToXmlPattern extends StringValuePattern {
   private final Document expectedXmlDoc;
 
   public EqualToXmlPattern(@JsonProperty("equalToXml") String expectedValue) {
-    this(expectedValue, null, null, null, null, false);
+    this(expectedValue, null, null, null, null, null);
   }
 
   public EqualToXmlPattern(
@@ -110,6 +110,10 @@ public class EqualToXmlPattern extends StringValuePattern {
 
   public Boolean isEnablePlaceholders() {
     return enablePlaceholders;
+  }
+
+  public Boolean isIgnoreOrderOfSameNode() {
+    return ignoreOrderOfSameNode;
   }
 
   public String getPlaceholderOpeningDelimiterRegex() {

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -369,6 +369,7 @@ public class EqualToXmlPatternTest {
   @Test
   public void deserializesEqualToXmlWithAllParameters() {
     Boolean enablePlaceholders = Boolean.TRUE;
+    Boolean ignoreOrderOfSameNode = Boolean.TRUE;
     String placeholderOpeningDelimiterRegex = "theOpeningDelimiterRegex";
     String placeholderClosingDelimiterRegex = "theClosingDelimiterRegex";
     String patternJson =
@@ -376,6 +377,9 @@ public class EqualToXmlPatternTest {
             + "\"equalToXml\" : \"<a/>\", "
             + "\"enablePlaceholders\" : "
             + enablePlaceholders
+            + ", "
+            + "\"ignoreOrderOfSameNode\" : "
+            + ignoreOrderOfSameNode
             + ", "
             + "\"placeholderOpeningDelimiterRegex\" : \""
             + placeholderOpeningDelimiterRegex
@@ -389,6 +393,7 @@ public class EqualToXmlPatternTest {
     assertTrue(stringValuePattern instanceof EqualToXmlPattern);
     EqualToXmlPattern equalToXmlPattern = (EqualToXmlPattern) stringValuePattern;
     assertEquals(enablePlaceholders, equalToXmlPattern.isEnablePlaceholders());
+    assertEquals(ignoreOrderOfSameNode, equalToXmlPattern.isIgnoreOrderOfSameNode());
     assertEquals(
         placeholderOpeningDelimiterRegex, equalToXmlPattern.getPlaceholderOpeningDelimiterRegex());
     assertEquals(
@@ -402,6 +407,7 @@ public class EqualToXmlPatternTest {
   public void serializesEqualToXmlWithAllParameters() {
     String xml = "<stuff />";
     Boolean enablePlaceholders = Boolean.TRUE;
+    Boolean ignoreOrderOfSameNode = Boolean.TRUE;
     String placeholderOpeningDelimiterRegex = "[";
     String placeholderClosingDelimiterRegex = "]";
 
@@ -412,7 +418,7 @@ public class EqualToXmlPatternTest {
             placeholderOpeningDelimiterRegex,
             placeholderClosingDelimiterRegex,
             Set.of(SCHEMA_LOCATION, NAMESPACE_URI, ATTR_VALUE),
-            false);
+            ignoreOrderOfSameNode);
 
     String json = Json.write(pattern);
 
@@ -422,6 +428,7 @@ public class EqualToXmlPatternTest {
             "{\n"
                 + "  \"equalToXml\": \"<stuff />\",\n"
                 + "  \"enablePlaceholders\": true,\n"
+                + "  \"ignoreOrderOfSameNode\": true,\n"
                 + "  \"placeholderOpeningDelimiterRegex\": \"[\",\n"
                 + "  \"placeholderClosingDelimiterRegex\": \"]\",\n"
                 + "  \"exemptedComparisons\": [\"SCHEMA_LOCATION\", \"ATTR_VALUE\", \"NAMESPACE_URI\"]\n"


### PR DESCRIPTION
Fixes serialization of `ignoreOrderOfSameNode` property for the `equalToXml` body. Property was not serialized because getter was missing hence was never applied

## References

https://github.com/wiremock/wiremock/pull/2747

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
