### PR TITLE
Bugfix: Fix list reference behavior in RequestPatternBuilder.like()

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -100,28 +100,28 @@ public class RequestPatternBuilder {
     builder.url = requestPattern.getUrlMatcher();
     builder.method = requestPattern.getMethod();
     if (requestPattern.getHeaders() != null) {
-      builder.headers = requestPattern.getHeaders();
+      builder.headers = new LinkedHashMap<>(requestPattern.getHeaders());
     }
     if (requestPattern.getPathParameters() != null) {
-      builder.pathParams = requestPattern.getPathParameters();
+      builder.pathParams = new LinkedHashMap<>(requestPattern.getPathParameters());
     }
     if (requestPattern.getQueryParameters() != null) {
-      builder.queryParams = requestPattern.getQueryParameters();
+      builder.queryParams = new LinkedHashMap<>(requestPattern.getQueryParameters());
     }
     if (requestPattern.getFormParameters() != null) {
-      builder.formParams = requestPattern.getFormParameters();
+      builder.formParams = new LinkedHashMap<>(requestPattern.getFormParameters());
     }
     if (requestPattern.getCookies() != null) {
-      builder.cookies = requestPattern.getCookies();
+      builder.cookies = new LinkedHashMap<>(requestPattern.getCookies());
     }
     if (requestPattern.getBodyPatterns() != null) {
-      builder.bodyPatterns = requestPattern.getBodyPatterns();
+      builder.bodyPatterns = new ArrayList<>(requestPattern.getBodyPatterns());
     }
     if (requestPattern.hasInlineCustomMatcher()) {
       builder.customMatcher = requestPattern.getMatcher();
     }
     if (requestPattern.getMultipartPatterns() != null) {
-      builder.multiparts = requestPattern.getMultipartPatterns();
+      builder.multiparts = new LinkedList<>(requestPattern.getMultipartPatterns());
     }
     builder.basicCredentials = requestPattern.getBasicAuthCredentials();
     builder.customMatcherDefinition = requestPattern.getCustomMatcher();

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
@@ -22,6 +22,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -152,5 +153,54 @@ class RequestPatternBuilderTest {
 
     RequestPattern newRequestPattern = RequestPatternBuilder.like(requestPattern).build();
     assertThat(newRequestPattern, is(requestPattern));
+  }
+
+  @Test
+  void likeRequestPatternCreatesIsolatedInstance() {
+    RequestPattern newRequestPattern =
+        RequestPatternBuilder.newRequestPattern()
+            .withUrl(new UrlPathTemplatePattern("/bar/*"))
+            .withScheme("https")
+            .withHost(WireMock.equalTo("bar"))
+            .withHeader("foo", WireMock.equalTo("bar"))
+            .withPathParam("foo", WireMock.equalTo("bar"))
+            .withQueryParam("foo", WireMock.equalTo("bar"))
+            .withFormParam("foo", WireMock.equalTo("bar"))
+            .withCookie("foo", WireMock.equalTo("bar"))
+            .withRequestBody(WireMock.equalTo("bar"))
+            .withAnyRequestBodyPart(new MultipartValuePatternBuilder("bar"))
+            .build();
+
+    RequestPattern newDerivedRequestPattern =
+        RequestPatternBuilder.like(newRequestPattern)
+            .withUrl(new UrlPathTemplatePattern("/baz/*"))
+            .withScheme("http")
+            .withHost(WireMock.equalTo("baz"))
+            .withHeader("foo", WireMock.equalTo("baz"))
+            .withPathParam("foo", WireMock.equalTo("baz"))
+            .withQueryParam("foo", WireMock.equalTo("baz"))
+            .withFormParam("foo", WireMock.equalTo("baz"))
+            .withCookie("foo", WireMock.equalTo("baz"))
+            .withRequestBody(WireMock.equalTo("baz"))
+            .withAnyRequestBodyPart(new MultipartValuePatternBuilder("baz"))
+            .build();
+
+    assertThat(
+        newRequestPattern.getUrlPathTemplate(), not(newDerivedRequestPattern.getUrlPathTemplate()));
+    assertThat(newRequestPattern.getScheme(), not(newDerivedRequestPattern.getScheme()));
+    assertThat(newRequestPattern.getHost(), not(newDerivedRequestPattern.getHost()));
+    assertThat(newRequestPattern.getHeaders(), not(newDerivedRequestPattern.getHeaders()));
+    assertThat(
+        newRequestPattern.getPathParameters(), not(newDerivedRequestPattern.getPathParameters()));
+    assertThat(
+        newRequestPattern.getQueryParameters(), not(newDerivedRequestPattern.getQueryParameters()));
+    assertThat(
+        newRequestPattern.getFormParameters(), not(newDerivedRequestPattern.getFormParameters()));
+    assertThat(newRequestPattern.getCookies(), not(newDerivedRequestPattern.getCookies()));
+    assertThat(
+        newRequestPattern.getBodyPatterns(), not(newDerivedRequestPattern.getBodyPatterns()));
+    assertThat(
+        newRequestPattern.getMultipartPatterns(),
+        not(newDerivedRequestPattern.getMultipartPatterns()));
   }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

I recently was very confused when I did this:

```java
RequestPattern requestPatternA =
    RequestPatternBuilder.newRequestPattern()
        .withRequestBody(WireMock.equalTo("foo"))
        .build();

RequestPattern requestPatternB =
  RequestPatternBuilder.like(requestPatternA)
    .withRequestBody(WireMock.equalTo("bar"))
    .build();
```

What happens is, is that now **both** `RequestPattern` instances contain the **same** `ContentPattern` instances. 

![image](https://github.com/user-attachments/assets/141a8782-ef63-45f9-a5d1-6665c3db82c8)

Now, I think this is counter intuitive - I would expect that any changes `requestPatternB` are not reflecting back to `requestPatternA` after using `like()`. Would you share that assumption?

This pull request changes the current behavior by making sure that new lists are created in `like()`, thus not referencing the lists in `requestPatternA` anymore.

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
