### PR TITLE
Introducing WireMock Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![a](https://img.shields.io/badge/slack-Join%20us-brightgreen?style=flat&logo=slack)](https://slack.wiremock.org/)
 [![Participate](https://img.shields.io/static/v1?label=Contributing&message=guide&color=orange)](./CONTRIBUTING.md)
 [![Maven Central](https://img.shields.io/maven-central/v/org.wiremock/wiremock.svg)](https://search.maven.org/artifact/org.wiremock/wiremock)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20WireMock%20Guru-006BFF)](https://gurubase.io/g/wiremock)
 
 WireMock is a popular open-source tool for API mock testing with over 5 million downloads per month.
 It can help you to create stable test and development environments,


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [WireMock Guru](https://gurubase.io/g/wiremock) to Gurubase. WireMock Guru uses the data from this repo and data from the [docs](https://wiremock.org/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "WireMock Guru", which highlights that WireMock now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable WireMock Guru in Gurubase, just let me know that's totally fine.
