### PR TITLE
Add null check in WireMockExtension.stopServerIfRunning()

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -267,7 +267,7 @@ public class WireMockExtension extends DslWrapper
   }
 
   private void stopServerIfRunning() {
-    if (wireMockServer.isRunning()) {
+    if (wireMockServer != null && wireMockServer.isRunning()) {
       wireMockServer.stop();
     }
   }


### PR DESCRIPTION
When using `WireMockExtension` alongside other JUnit 5 extensions, a failure in another extension can prevent the WireMock server from starting. However, JUnit still calls the `afterAll` method on all extensions, which leads to a `NullPointerException` in `WireMockExtension.stopServerIfRunning()` because `wireMockServer` was never initialized.

<!-- Please describe your pull request here. -->

## References

https://github.com/wiremock/wiremock/issues/2627
<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
