### PR TITLE
New JSON and XML handlebars helpers

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/AbstractFormattingHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/AbstractFormattingHelper.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.TagType;
+import java.io.IOException;
+import java.util.Arrays;
+
+public abstract class AbstractFormattingHelper extends HandlebarsHelper<Object> {
+
+  abstract String getName();
+
+  abstract String getDataFormat();
+
+  @Override
+  public Object apply(Object context, Options options) throws IOException {
+    // get the trimmed contents and make sure it isn't empty
+    String bodyText;
+    if (options.tagType == TagType.SECTION) {
+      bodyText = options.fn().toString().trim();
+    } else if (context instanceof CharSequence) {
+      bodyText = context.toString().trim();
+    } else {
+      bodyText = "";
+    }
+
+    if (bodyText.isEmpty()) {
+      return handleError(
+          String.format(
+              "%s should take a block of %s to format or a single parameter of type String",
+              getName(), getDataFormat()));
+    }
+
+    // get the format field and default to pretty
+    Object formatOption = options.hash.get("format");
+    Format format;
+    if (formatOption == null) {
+      format = Format.pretty;
+    } else if (formatOption instanceof Format) {
+      format = (Format) formatOption;
+    } else if (formatOption instanceof CharSequence) {
+      try {
+        format = Format.valueOf(formatOption.toString());
+      } catch (IllegalArgumentException e) {
+        return handleError(
+            String.format(
+                "%s: format [%s] should be one of %s",
+                getName(), formatOption, Arrays.toString(Format.values())));
+      }
+    } else {
+      return handleError(
+          String.format(
+              "%s: format [%s] of type [%s should be a %s or a String and one of %s]",
+              getName(),
+              formatOption,
+              formatOption.getClass().getName(),
+              Format.class.getSimpleName(),
+              Arrays.toString(Format.values())));
+    }
+
+    return apply(bodyText, format);
+  }
+
+  protected abstract String apply(String bodyText, Format format);
+
+  public enum Format {
+    pretty,
+    compact,
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatJsonHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatJsonHelper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.common.JsonException;
+
+/**
+ * Handlebars helper to allow JSON to be formatted:
+ *
+ * <p>```handlebars {{#formatJson format='pretty'}} // Badly formatted JSON {{/formatJson}}```
+ * `format` can be `pretty` or `compact` and defaults to `pretty`
+ */
+public class FormatJsonHelper extends AbstractFormattingHelper {
+
+  @Override
+  String getName() {
+    return "formatJson";
+  }
+
+  @Override
+  String getDataFormat() {
+    return "JSON";
+  }
+
+  @Override
+  protected String apply(String bodyText, Format format) {
+    try {
+      switch (format) {
+        case pretty:
+          return Json.prettyPrint(bodyText);
+        case compact:
+          return Json.node(bodyText).toString();
+        default:
+          throw new IllegalStateException();
+      }
+    } catch (JsonException e) {
+      return handleError(
+          "There was an error parsing the json. Please make sure the json is valid", e);
+    }
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelper.java
@@ -42,7 +42,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 /**
- * Handlebars helper to allow json to be formatted :
+ * Handlebars helper to allow xml to be formatted :
  *
  * <p>```handlebars {{#formatXml format='pretty'}} // Badly formatted XML {{/formatXml}} ```
  * `format` can be `pretty` or `compact` and defaults to `pretty`

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelper.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import static javax.xml.transform.OutputKeys.INDENT;
+import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
+
+import com.github.tomakehurst.wiremock.common.xml.Xml;
+import com.github.tomakehurst.wiremock.common.xml.XmlException;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.Text;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * Handlebars helper to allow json to be formatted :
+ *
+ * <p>```handlebars {{#formatXml format='pretty'}} // Badly formatted XML {{/formatXml}} ```
+ * `format` can be `pretty` or `compact` and defaults to `pretty`
+ */
+public class FormatXmlHelper extends AbstractFormattingHelper {
+
+  @Override
+  String getName() {
+    return "formatXml";
+  }
+
+  @Override
+  String getDataFormat() {
+    return "XML";
+  }
+
+  private final DocumentBuilderFactory documentBuilderFactory = Xml.newDocumentBuilderFactory();
+
+  private final TransformerFactory transformerFactory;
+
+  public FormatXmlHelper() {
+    TransformerFactory factory = TransformerFactory.newInstance();
+    factory.setAttribute("indent-number", 2);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+    transformerFactory = factory;
+  }
+
+  @Override
+  protected String apply(String bodyText, Format format) {
+    try {
+      var xml = read(bodyText);
+      switch (format) {
+        case pretty:
+          return print(xml, "yes");
+        case compact:
+          return print(xml, "no");
+        default:
+          throw new IllegalStateException();
+      }
+    } catch (XmlException
+        | ParserConfigurationException
+        | IOException
+        | SAXException
+        | TransformerException e) {
+      return handleError("Input is not valid XML", e);
+    }
+  }
+
+  private Document read(String xml) throws ParserConfigurationException, IOException, SAXException {
+    try {
+      DocumentBuilder db = documentBuilderFactory.newDocumentBuilder();
+      Document doc = db.parse(new InputSource(new StringReader(xml)));
+      return removeBlankTextNodes(doc);
+    } catch (SAXException e) {
+      throw XmlException.fromSaxException(e);
+    }
+  }
+
+  private <T extends Node> T removeBlankTextNodes(T node) {
+    List<Node> toRemove = new ArrayList<>();
+    if (!(node instanceof Attr)) {
+      for (int i = 0; i < node.getChildNodes().getLength(); i++) {
+        Node child = node.getChildNodes().item(i);
+        if (isBlankTextNode(child)) {
+          toRemove.add(child);
+        } else {
+          removeBlankTextNodes(child);
+        }
+      }
+      for (Node child : toRemove) {
+        node.removeChild(child);
+      }
+    }
+    return node;
+  }
+
+  private boolean isBlankTextNode(Node node) {
+    return (node instanceof Text) && node.getNodeValue().isBlank();
+  }
+
+  private String print(Document doc, String indent) throws TransformerException {
+    Transformer transformer = transformerFactory.newTransformer();
+    transformer.setOutputProperty(INDENT, indent);
+    transformer.setOutputProperty(OMIT_XML_DECLARATION, "yes");
+    return writeToString(doc, transformer);
+  }
+
+  private String writeToString(Document doc, Transformer transformer) throws TransformerException {
+    StringWriter writer = new StringWriter();
+    transformer.transform(new DOMSource(doc), new StreamResult(writer));
+    return writer.toString();
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HelperUtils.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HelperUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Thomas Akehurst
+ * Copyright (C) 2021-2024 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.github.tomakehurst.wiremock.common.Json;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 
 public class HelperUtils {
 
@@ -48,4 +53,12 @@ public class HelperUtils {
 
     return null;
   }
+
+  static final Configuration jsonPathConfig =
+      Configuration.defaultConfiguration()
+          .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL)
+          // Explicitly use Jackson for JSON parsing because the default provider allows invalid
+          // JSON to be parsed as a JSON string in certain circumstances, which, in my opinion,
+          // creates a confusing user experience.
+          .jsonProvider(new JacksonJsonProvider(Json.getObjectMapper()));
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonArrayAddHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonArrayAddHelper.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.TagType;
+import com.github.tomakehurst.wiremock.common.Json;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.InvalidPathException;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.ParseContext;
+import com.jayway.jsonpath.PathNotFoundException;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+class JsonArrayAddHelper extends HandlebarsHelper<Object> {
+
+  private final ParseContext parseContext = JsonPath.using(HelperUtils.jsonPathConfig);
+
+  @Override
+  public String apply(Object inputJson, Options options) throws IOException {
+    if (!(inputJson instanceof String)) {
+      return handleError("Base JSON must be a string");
+    }
+
+    DocumentContext root;
+    try {
+      root = parseContext.parse((String) inputJson);
+    } catch (Exception e) {
+      return handleError("Base JSON is not valid JSON ('" + inputJson + "')", e);
+    }
+
+    Object jsonPathString = options.hash.get("jsonPath");
+    if (jsonPathString != null && !(jsonPathString instanceof String))
+      return handleError("jsonPath option must be a string");
+
+    Object currentList;
+    if (jsonPathString == null) {
+      currentList = root.json();
+    } else {
+      try {
+        if (((String) jsonPathString).isEmpty())
+          throw new InvalidPathException("JSONPath expression is empty");
+        currentList = root.read((String) jsonPathString);
+      } catch (PathNotFoundException e) {
+        currentList = null;
+      } catch (InvalidPathException e) {
+        return handleError(
+            "jsonPath option is not valid JSONPath expression ('" + jsonPathString + "')");
+      }
+    }
+    if (!(currentList instanceof List)) {
+      String detail;
+      if (jsonPathString == null) {
+        detail = "'" + inputJson + "'";
+      } else {
+        detail = "root: '" + inputJson + "', jsonPath: '" + jsonPathString + "'";
+      }
+      return handleError("Target JSON is not a JSON array (" + detail + ")");
+    }
+
+    Object itemToAddString;
+    if (options.tagType == TagType.SECTION) {
+      itemToAddString = options.fn().toString();
+    } else {
+      itemToAddString = options.params.length > 0 ? options.params[0] : null;
+    }
+    if (!(itemToAddString instanceof String)) {
+      return handleError("Item-to-add JSON must be a string");
+    }
+
+    Object toAdd;
+    try {
+      toAdd = Json.read((String) itemToAddString, Object.class);
+    } catch (Exception e) {
+      return handleError("Item-to-add JSON is not valid JSON ('" + itemToAddString + "')", e);
+    }
+    boolean flatten;
+    {
+      Object flatten0 = options.hash.get("flatten");
+      if (flatten0 instanceof Boolean) {
+        flatten = (boolean) flatten0;
+      } else if (flatten0 == null) {
+        flatten = false;
+      } else {
+        return handleError("flatten option must be a boolean");
+      }
+    }
+    if (flatten && toAdd instanceof Collection) {
+      //noinspection rawtypes,unchecked
+      ((List) currentList).addAll((Collection) toAdd);
+    } else {
+      //noinspection rawtypes,unchecked
+      ((List) currentList).add(toAdd);
+    }
+
+    Object maxItems = options.hash.get("maxItems");
+    if (maxItems != null) {
+      if (!(maxItems instanceof Integer)) return handleError("maxItems option must be an integer");
+      if ((int) maxItems < 0) return handleError("maxItems option integer must be positive");
+      if (((List<?>) currentList).size() - (int) maxItems > 0) {
+        ((List<?>) currentList).subList(0, ((List<?>) currentList).size() - (int) maxItems).clear();
+      }
+    }
+
+    return root.jsonString();
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonMergeHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonMergeHelper.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.TagType;
+import com.github.tomakehurst.wiremock.common.Json;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+class JsonMergeHelper extends HandlebarsHelper<Object> {
+
+  @Override
+  public String apply(Object baseJsonString, Options options) throws IOException {
+    if (!(baseJsonString instanceof String))
+      return handleError("Base JSON parameter must be a string");
+
+    JsonNode baseJson;
+    try {
+      baseJson = Json.read((String) baseJsonString, JsonNode.class);
+    } catch (Exception e) {
+      return handleError("Base JSON is not valid JSON ('" + baseJsonString + "')", e);
+    }
+    if (!(baseJson instanceof ObjectNode)) {
+      return handleError("Base JSON is not a JSON object ('" + baseJsonString + "')");
+    }
+
+    Object jsonToMergeString;
+    if (options.tagType == TagType.SECTION) {
+      jsonToMergeString = options.fn().toString();
+    } else {
+      jsonToMergeString = options.params.length > 0 ? options.params[0] : null;
+    }
+    if (!(jsonToMergeString instanceof String))
+      return handleError("JSON to merge must be a string");
+
+    JsonNode jsonToMerge;
+    try {
+      jsonToMerge = Json.read((String) jsonToMergeString, JsonNode.class);
+    } catch (Exception e) {
+      return handleError("JSON to merge is not valid JSON ('" + jsonToMergeString + "')", e);
+    }
+    if (!(jsonToMerge instanceof ObjectNode)) {
+      return handleError("JSON to merge is not a JSON object ('" + jsonToMergeString + "')");
+    }
+
+    merge((ObjectNode) baseJson, (ObjectNode) jsonToMerge);
+    return Json.getObjectMapper().writeValueAsString(baseJson);
+  }
+
+  private void merge(ObjectNode base, ObjectNode other) {
+    for (Iterator<Map.Entry<String, JsonNode>> it = other.fields(); it.hasNext(); ) {
+      Map.Entry<String, JsonNode> child = it.next();
+      String fieldName = child.getKey();
+      JsonNode childNodeToMerge = child.getValue();
+      if (childNodeToMerge instanceof ObjectNode) {
+        JsonNode baseChildNode = base.get(fieldName);
+        if (baseChildNode instanceof ObjectNode) {
+          merge((ObjectNode) baseChildNode, (ObjectNode) childNodeToMerge);
+        } else {
+          base.replace(fieldName, childNodeToMerge);
+        }
+      } else {
+        base.replace(fieldName, childNodeToMerge);
+      }
+    }
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonRemoveHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonRemoveHelper.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.github.jknack.handlebars.Options;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.InvalidModificationException;
+import com.jayway.jsonpath.InvalidPathException;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.ParseContext;
+import com.jayway.jsonpath.PathNotFoundException;
+
+class JsonRemoveHelper extends HandlebarsHelper<Object> {
+
+  private final ParseContext parseContext = JsonPath.using(HelperUtils.jsonPathConfig);
+
+  @Override
+  public String apply(Object inputJson, Options options) {
+    if (!(inputJson instanceof String)) {
+      return handleError("Input JSON must be a string");
+    }
+    if (inputJson.equals("null")) {
+      // No op
+      return (String) inputJson;
+    }
+    if (options.params.length != 1) {
+      return handleError("A single JSONPath expression parameter must be supplied");
+    }
+    Object jsonPathString = options.param(0);
+    if (!(jsonPathString instanceof String)) {
+      return handleError("JSONPath parameter must be a string");
+    }
+    DocumentContext jsonDocument;
+    try {
+      jsonDocument = parseContext.parse((String) inputJson);
+    } catch (Exception e) {
+      return handleError("Input JSON string is not valid JSON ('" + inputJson + "')", e);
+    }
+    try {
+      if (((String) jsonPathString).isEmpty())
+        throw new InvalidPathException("JSONPath expression is empty");
+      return jsonDocument.delete((String) jsonPathString).jsonString();
+    } catch (PathNotFoundException e) {
+      return (String) inputJson;
+    } catch (InvalidPathException e) {
+      String message =
+          "JSONPath parameter is not a valid JSONPath expression ('" + jsonPathString + "')";
+      return handleError(message, e);
+    } catch (InvalidModificationException e) {
+      String message =
+          "Delete operation cannot be applied to JSONPath expression ('" + jsonPathString + "')";
+      return handleError(message, e);
+    }
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ToJsonHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ToJsonHelper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.github.jknack.handlebars.Options;
+import com.github.tomakehurst.wiremock.common.Json;
+
+class ToJsonHelper extends HandlebarsHelper<Object> {
+  @Override
+  public String apply(Object obj, Options options) {
+    if (obj == null) {
+      return "";
+    } else {
+      return Json.write(obj);
+    }
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
@@ -269,5 +269,14 @@ public enum WireMockHelpers implements Helper<Object> {
     public Object apply(Object context, Options options) throws IOException {
       return helper.apply(context, options);
     }
+  },
+
+  formatJson {
+    private final FormatJsonHelper helper = new FormatJsonHelper();
+
+    @Override
+    public Object apply(Object context, Options options) throws IOException {
+      return helper.apply(context, options);
+    }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
@@ -314,5 +314,14 @@ public enum WireMockHelpers implements Helper<Object> {
     public Object apply(Object context, Options options) throws IOException {
       return helper.apply(context, options);
     }
+  },
+
+  jsonArrayAdd {
+    private final JsonArrayAddHelper helper = new JsonArrayAddHelper();
+
+    @Override
+    public Object apply(Object context, Options options) throws IOException {
+      return helper.apply(context, options);
+    }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
@@ -305,5 +305,14 @@ public enum WireMockHelpers implements Helper<Object> {
     public Object apply(Object context, Options options) throws IOException {
       return helper.apply(context, options);
     }
+  },
+
+  jsonRemove {
+    private final JsonRemoveHelper helper = new JsonRemoveHelper();
+
+    @Override
+    public Object apply(Object context, Options options) throws IOException {
+      return helper.apply(context, options);
+    }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
@@ -278,5 +278,14 @@ public enum WireMockHelpers implements Helper<Object> {
     public Object apply(Object context, Options options) throws IOException {
       return helper.apply(context, options);
     }
+  },
+
+  formatXml {
+    private final FormatXmlHelper helper = new FormatXmlHelper();
+
+    @Override
+    public Object apply(Object context, Options options) throws IOException {
+      return helper.apply(context, options);
+    }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
@@ -296,5 +296,14 @@ public enum WireMockHelpers implements Helper<Object> {
     public Object apply(Object context, Options options) throws IOException {
       return helper.apply(context, options);
     }
+  },
+
+  jsonMerge {
+    private final JsonMergeHelper helper = new JsonMergeHelper();
+
+    @Override
+    public Object apply(Object context, Options options) throws IOException {
+      return helper.apply(context, options);
+    }
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WireMockHelpers.java
@@ -287,5 +287,14 @@ public enum WireMockHelpers implements Helper<Object> {
     public Object apply(Object context, Options options) throws IOException {
       return helper.apply(context, options);
     }
+  },
+
+  toJson {
+    private final ToJsonHelper helper = new ToJsonHelper();
+
+    @Override
+    public Object apply(Object context, Options options) throws IOException {
+      return helper.apply(context, options);
+    }
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -303,18 +303,6 @@ public class ResponseTemplateTransformerTest {
   }
 
   @Test
-  public void escapingIsTheDefault() {
-    final ResponseDefinition responseDefinition =
-        transform(
-            mockRequest().url("/json").body("{\"a\": {\"test\": \"look at my 'single quotes'\"}}"),
-            aResponse().withBody("{\"test\": \"{{jsonPath request.body '$.a.test'}}\"}"),
-            Parameters.empty());
-
-    assertThat(
-        responseDefinition.getBody(), is("{\"test\": \"look at my &#x27;single quotes&#x27;\"}"));
-  }
-
-  @Test
   public void jsonPathValueDefaultsToEmptyString() {
     final ResponseDefinition responseDefinition =
         transform(

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatJsonHelperTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import org.junit.jupiter.api.Test;
+
+public class FormatJsonHelperTest extends HandlebarsHelperTestBase {
+
+  static String compactJson = "{\"foo\":true,\"bar\":{\"baz\":false}}";
+
+  static String prettyJson = "{\n  \"foo\" : true,\n  \"bar\" : {\n    \"baz\" : false\n  }\n}";
+
+  @Test
+  void formatJsonDefaultsToPrettyFormatWhenNoFormatSpecified() {
+    String responseTemplate = "{{#formatJson}} " + compactJson + " {{/formatJson}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is(prettyJson));
+  }
+
+  @Test
+  void formatJsonPrettyFormatReturnsJsonPrettyPrinted() {
+    String responseTemplate = "{{#formatJson format='pretty'}} " + compactJson + " {{/formatJson}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is(prettyJson));
+  }
+
+  @Test
+  void formatJsonCompactFormatReturnsJsonInCompactFormat() {
+    String responseTemplate = "{{#formatJson format='compact'}} " + prettyJson + " {{/formatJson}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is(compactJson));
+  }
+
+  @Test
+  void formatJsonFormatsJsonInAVariable() {
+    String responseTemplate =
+        "{{~#assign 'someJson'~}} "
+            + prettyJson
+            + " {{/assign}}{{formatJson someJson format='compact'}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is(compactJson));
+  }
+
+  @Test
+  void anInvalidFormatFieldResultsInAnError() {
+    String responseTemplate = "{{#formatJson format='foo'}} " + compactJson + " {{/formatJson}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is("[ERROR: formatJson: format [foo] should be one of [pretty, compact]]"));
+  }
+
+  @Test
+  void formatJsonReturnsAnErrorWhenJsonIsInvalid() {
+    String responseTemplate = "{{#formatJson format=\"compact\"}} {\"foo\":true,} {{/formatJson}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is("[ERROR: There was an error parsing the json. Please make sure the json is valid]"));
+  }
+
+  @Test
+  void emptyJsonPassedIntoTheFormatJsonHelper() {
+    String responseTemplate = "{{#formatJson}}{{/formatJson}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is(
+            "[ERROR: formatJson should take a block of JSON to format or a single parameter of type String]"));
+  }
+
+  @Test
+  void noContentPassedIntoTheFormatJsonHelper() {
+    String responseTemplate = "{{formatJson}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is(
+            "[ERROR: formatJson should take a block of JSON to format or a single parameter of type String]"));
+  }
+
+  @Test
+  void nullVariablePassedToTheFormatJsonHelper() {
+    String responseTemplate = "{{formatJson nullVariable}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is(
+            "[ERROR: formatJson should take a block of JSON to format or a single parameter of type String]"));
+  }
+
+  @Test
+  void whitespacePassedIntoTheFormatJsonHelper() {
+    String responseTemplate = "{{#formatJson}}                  {{/formatJson}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is(
+            "[ERROR: formatJson should take a block of JSON to format or a single parameter of type String]"));
+  }
+
+  @Test
+  void invalidFormatType() {
+    String responseTemplate = "{{#formatJson format=1}} " + prettyJson + " {{/formatJson}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is(
+            "[ERROR: formatJson: format [1] of type [java.lang.Integer should be a Format or a String and one of [pretty, compact]]]"));
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatJsonHelperTest.java
@@ -22,14 +22,20 @@ import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 public class FormatJsonHelperTest extends HandlebarsHelperTestBase {
 
   static String compactJson = "{\"foo\":true,\"bar\":{\"baz\":false}}";
 
   static String prettyJson = "{\n  \"foo\" : true,\n  \"bar\" : {\n    \"baz\" : false\n  }\n}";
+  static String prettyJsonWindows =
+      "{\r\n  \"foo\" : true,\r\n  \"bar\" : {\r\n    \"baz\" : false\r\n  }\r\n}";
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
   void formatJsonDefaultsToPrettyFormatWhenNoFormatSpecified() {
     String responseTemplate = "{{#formatJson}} " + compactJson + " {{/formatJson}}";
     final ResponseDefinition responseDefinition =
@@ -39,12 +45,33 @@ public class FormatJsonHelperTest extends HandlebarsHelperTestBase {
   }
 
   @Test
+  @EnabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
+  void formatJsonDefaultsToPrettyFormatWhenNoFormatSpecifiedWindows() {
+    String responseTemplate = "{{#formatJson}} " + compactJson + " {{/formatJson}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is(prettyJsonWindows));
+  }
+
+  @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
   void formatJsonPrettyFormatReturnsJsonPrettyPrinted() {
     String responseTemplate = "{{#formatJson format='pretty'}} " + compactJson + " {{/formatJson}}";
     final ResponseDefinition responseDefinition =
         transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
 
     assertThat(responseDefinition.getBody(), is(prettyJson));
+  }
+
+  @Test
+  @EnabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
+  void formatJsonPrettyFormatReturnsJsonPrettyPrintedWindows() {
+    String responseTemplate = "{{#formatJson format='pretty'}} " + compactJson + " {{/formatJson}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is(prettyJsonWindows));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelperTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import org.junit.jupiter.api.Test;
+
+public class FormatXmlHelperTest extends HandlebarsHelperTestBase {
+
+  @Test
+  void formatXmlHelperFormatsXmlPrettilyByDefault() {
+    String responseTemplate =
+        "{{#formatXml}}\n<foo><bar\n    >wh</bar></foo\n    >\n{{/formatXml}}";
+    ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("<foo>\n  <bar>wh</bar>\n</foo>\n"));
+  }
+
+  @Test
+  void formatXmlHelperFormatsXmlInAVariable() {
+    String responseTemplate =
+        "{{~#assign 'someXml'~}}\n"
+            + "<foo><bar\n"
+            + "    >wh</bar></foo\n"
+            + "    >\n"
+            + "{{/assign}}\n"
+            + "{{~formatXml someXml format='pretty'~}}";
+    ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("<foo>\n  <bar>wh</bar>\n</foo>\n"));
+  }
+
+  @Test
+  void formatXmlHelperFormatsXmlPrettily() {
+    String responseTemplate =
+        "{{#formatXml format='pretty'}}\n"
+            + "  <foo><bar\n"
+            + ">wh</bar></foo\n"
+            + ">\n"
+            + "{{/formatXml}}";
+    ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("<foo>\n  <bar>wh</bar>\n</foo>\n"));
+  }
+
+  @Test
+  void formatXmlHelperGivesGoodErrorOnUnknownFormat() {
+    String responseTemplate =
+        "{{#formatXml format='traditional'}}\n"
+            + "<foo><bar\n"
+            + "    >wh</bar></foo\n"
+            + "    >\n"
+            + "{{/formatXml}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is("[ERROR: formatXml: format [traditional] should be one of [pretty, compact]]"));
+  }
+
+  @Test
+  void formatXmlHelperGivesGoodErrorOnNoInput() {
+    String responseTemplate = "{{formatXml}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is(
+            "[ERROR: formatXml should take a block of XML to format or a single parameter of type String]"));
+  }
+
+  @Test
+  void formatXmlHelperGivesGoodErrorOnInvalidXml() {
+    String responseTemplate = "{{#formatXml}}<foo>Not well formed!</bar>{{/formatXml}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("[ERROR: Input is not valid XML]"));
+  }
+
+  @Test
+  void formatXmlHelperFormatsXmlCompact() {
+    String responseTemplate =
+        "{{#formatXml format='compact'}}\n"
+            + "<foo><bar\n"
+            + "    >wh</bar></foo\n"
+            + "    >\n"
+            + "{{/formatXml}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("<foo><bar>wh</bar></foo>"));
+  }
+
+  @Test
+  void formatXmlHelperFormatsPrettyXmlCompact() {
+    String responseTemplate =
+        "{{#formatXml format='compact'}}\n"
+            + "<foo>\n"
+            + "  <bar>wh</bar>\n"
+            + "</foo>\n"
+            + "{{/formatXml}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("<foo><bar>wh</bar></foo>"));
+  }
+
+  @Test
+  void invalidFormatType() {
+    String responseTemplate =
+        "{{#formatXml format=1}}\n"
+            + "<foo>\n"
+            + "  <bar>wh</bar>\n"
+            + "</foo>\n"
+            + "{{/formatXml}}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is(
+            "[ERROR: formatXml: format [1] of type [java.lang.Integer should be a Format or a String and one of [pretty, compact]]]"));
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelperTest.java
@@ -22,10 +22,14 @@ import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 public class FormatXmlHelperTest extends HandlebarsHelperTestBase {
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
   void formatXmlHelperFormatsXmlPrettilyByDefault() {
     String responseTemplate =
         "{{#formatXml}}\n<foo><bar\n    >wh</bar></foo\n    >\n{{/formatXml}}";
@@ -36,6 +40,18 @@ public class FormatXmlHelperTest extends HandlebarsHelperTestBase {
   }
 
   @Test
+  @EnabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
+  void formatXmlHelperFormatsXmlPrettilyByDefaultWindows() {
+    String responseTemplate =
+        "{{#formatXml}}\n<foo><bar\n    >wh</bar></foo\n    >\n{{/formatXml}}";
+    ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("<foo>\r\n  <bar>wh</bar>\r\n</foo>\r\n"));
+  }
+
+  @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
   void formatXmlHelperFormatsXmlInAVariable() {
     String responseTemplate =
         "{{~#assign 'someXml'~}}\n"
@@ -51,6 +67,23 @@ public class FormatXmlHelperTest extends HandlebarsHelperTestBase {
   }
 
   @Test
+  @EnabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
+  void formatXmlHelperFormatsXmlInAVariableWindows() {
+    String responseTemplate =
+        "{{~#assign 'someXml'~}}\n"
+            + "<foo><bar\n"
+            + "    >wh</bar></foo\n"
+            + "    >\n"
+            + "{{/assign}}\n"
+            + "{{~formatXml someXml format='pretty'~}}";
+    ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("<foo>\r\n  <bar>wh</bar>\r\n</foo>\r\n"));
+  }
+
+  @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
   void formatXmlHelperFormatsXmlPrettily() {
     String responseTemplate =
         "{{#formatXml format='pretty'}}\n"
@@ -62,6 +95,21 @@ public class FormatXmlHelperTest extends HandlebarsHelperTestBase {
         transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
 
     assertThat(responseDefinition.getBody(), is("<foo>\n  <bar>wh</bar>\n</foo>\n"));
+  }
+
+  @Test
+  @EnabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
+  void formatXmlHelperFormatsXmlPrettilyWindows() {
+    String responseTemplate =
+        "{{#formatXml format='pretty'}}\n"
+            + "  <foo><bar\n"
+            + ">wh</bar></foo\n"
+            + ">\n"
+            + "{{/formatXml}}";
+    ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("<foo>\r\n  <bar>wh</bar>\r\n</foo>\r\n"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonArrayAddHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonArrayAddHelperTest.java
@@ -1,0 +1,528 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.jknack.handlebars.EscapingStrategy;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.json.JsonSource;
+
+public class JsonArrayAddHelperTest extends HandlebarsHelperTestBase {
+
+  @Test
+  void helperIsAccessibleFromResponseBody() {
+    String responseTemplate =
+        "{{ jsonArrayAdd '[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]' '{\"id\":321,\"name\":\"sam\"}' }}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is(
+            "[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},{\"id\":321,\"name\":\"sam\"}]"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]',"
+        + "'{\"id\":321,\"name\":\"sam\"}',"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},{\"id\":321,\"name\":\"sam\"}]'",
+    "'[]'," + "'{\"id\":321,\"name\":\"sam\"}'," + "'[{\"id\":321,\"name\":\"sam\"}]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]',"
+        + "'\"name\"',"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},\"name\"]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]',"
+        + "'true',"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},true]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]',"
+        + "'null',"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},null]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]',"
+        + "'123',"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},123]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]',"
+        + "'[{\"id\":321,\"name\":\"sam\"},{\"id\":666,\"name\":\"jason\"}]',"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},[{\"id\":321,\"name\":\"sam\"},{\"id\":666,\"name\":\"jason\"}]]'",
+  })
+  void addsAnItemToAnArrayAndReturnsString(
+      String inputArray, String itemToAdd, String expectedOutput) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonArrayAdd array item }}")
+            .apply(Map.of("array", inputArray, "item", itemToAdd));
+    assertThat(output, is(expectedOutput));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]',"
+        + "'[{\"id\":321,\"name\":\"sam\"},{\"id\":666,\"name\":\"jason\"}]',"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},{\"id\":321,\"name\":\"sam\"},{\"id\":666,\"name\":\"jason\"}]'",
+    "'[]',"
+        + "'[{\"id\":321,\"name\":\"sam\"},{\"id\":666,\"name\":\"jason\"}]',"
+        + "'[{\"id\":321,\"name\":\"sam\"},{\"id\":666,\"name\":\"jason\"}]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]',"
+        + "'[{\"id\":321,\"name\":\"sam\"}]',"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},{\"id\":321,\"name\":\"sam\"}]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]',"
+        + "'[]',"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]'",
+    "'[]'," + "'[]'," + "'[]'",
+    "'[]'," + "'[null]'," + "'[null]'",
+  })
+  void addsMultipleItemsToAnArrayAndReturnsString(
+      String inputArray, String itemToAdd, String expectedOutput) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonArrayAdd array item flatten=true }}")
+            .apply(Map.of("array", inputArray, "item", itemToAdd));
+    assertThat(output, is(expectedOutput));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'[{\"id\":456,\"name\":\"bob\"}]',"
+        + "'{\"id\":321,\"name\":\"sam\"}',"
+        + "false,"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":321,\"name\":\"sam\"}]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]',"
+        + "'{\"id\":321,\"name\":\"sam\"}',"
+        + "false,"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},{\"id\":321,\"name\":\"sam\"}]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},{\"id\":666,\"name\":\"jason\"}]',"
+        + "'{\"id\":321,\"name\":\"sam\"}',"
+        + "false,"
+        + "'[{\"id\":123,\"name\":\"alice\"},{\"id\":666,\"name\":\"jason\"},{\"id\":321,\"name\":\"sam\"}]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},{\"id\":666,\"name\":\"jason\"},{\"id\":789,\"name\":\"max\"}]',"
+        + "'{\"id\":321,\"name\":\"sam\"}',"
+        + "false,"
+        + "'[{\"id\":666,\"name\":\"jason\"},{\"id\":789,\"name\":\"max\"},{\"id\":321,\"name\":\"sam\"}]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]',"
+        + "'[{\"id\":321,\"name\":\"sam\"},{\"id\":666,\"name\":\"jason\"}]',"
+        + "true,"
+        + "'[{\"id\":123,\"name\":\"alice\"},{\"id\":321,\"name\":\"sam\"},{\"id\":666,\"name\":\"jason\"}]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]',"
+        + "'[{\"id\":321,\"name\":\"sam\"},{\"id\":666,\"name\":\"jason\"},{\"id\":789,\"name\":\"max\"}]',"
+        + "true,"
+        + "'[{\"id\":321,\"name\":\"sam\"},{\"id\":666,\"name\":\"jason\"},{\"id\":789,\"name\":\"max\"}]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]',"
+        + "'[{\"id\":321,\"name\":\"sam\"},{\"id\":666,\"name\":\"jason\"},{\"id\":789,\"name\":\"max\"},{\"id\":987,\"name\":\"sue\"}]',"
+        + "true,"
+        + "'[{\"id\":666,\"name\":\"jason\"},{\"id\":789,\"name\":\"max\"},{\"id\":987,\"name\":\"sue\"}]'",
+  })
+  void theNumberOfItemsInTheOutputArrayCanBeLimited(
+      String inputArray, String itemToAdd, String flatten, String expectedOutput)
+      throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonArrayAdd array item flatten=" + flatten + " maxItems=3 }}")
+            .apply(Map.of("array", inputArray, "item", itemToAdd));
+    assertThat(output, is(expectedOutput));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "{\"id\":321,\"name\":\"sam\"}",
+        "[{\"id\":321,\"name\":\"sam\"}]",
+      })
+  void theNumberOfItemsInTheOutputArrayCanBeLimitedTo0(String itemToAdd) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonArrayAdd array item maxItems=0 }}")
+            .apply(Map.of("array", "[{\"id\":456,\"name\":\"bob\"}]", "item", itemToAdd));
+    assertThat(output, is("[]"));
+  }
+
+  @ParameterizedTest
+  @JsonSource({
+    // have to double wrap arrays because @JsonSource unwraps them.
+    "[[ { id: 456, name: 'bob' }, { id: 123, name: 'alice' }, { id: 321, name: 'sam' } ]]",
+    "{ id: 456, name: 'bob' }",
+    "true",
+    "null",
+    "123",
+  })
+  void returnsAnErrorWhenInputJsonIsNotAString(Object inputJson) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    Map<String, Object> context = new HashMap<>();
+    context.put("array", inputJson);
+    context.put("item", "{\"id\":321,\"name\":\"sam\"}");
+    String output = handleBars.compileInline("{{ jsonArrayAdd array item }}").apply(context);
+    assertThat(output, is("[ERROR: Base JSON must be a string]"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "invalid json",
+        "[{\"id\":456}",
+        "",
+        " ",
+        // This is actually valid JSON but JSONPath library throws an exception and
+        // it's simpler to use that exception than handle the scenario ourselves.
+        "null",
+      })
+  void returnsAnErrorWhenInputJsonIsNotValidJson(String inputJson) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonArrayAdd array item }}")
+            .apply(Map.of("array", inputJson, "item", "{\"id\":321,\"name\":\"sam\"}"));
+    assertThat(output, is("[ERROR: Base JSON is not valid JSON ('" + inputJson + "')]"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "{\"id\":456,\"name\":\"bob\"}",
+        "\"name\"",
+        "true",
+        "123",
+      })
+  void returnsAnErrorWhenInputJsonIsNotJsonArray(String inputJson) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonArrayAdd array item }}")
+            .apply(Map.of("array", inputJson, "item", "{\"id\":321,\"name\":\"sam\"}"));
+    assertThat(output, is("[ERROR: Target JSON is not a JSON array ('" + inputJson + "')]"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'{\"id\":321,\"name\":\"sam\"}',"
+        + "false,"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},{\"id\":321,\"name\":\"sam\"}]'",
+    "'\"name\"',"
+        + "false,"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},\"name\"]'",
+    "'true'," + "false," + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},true]'",
+    "'null'," + "false," + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},null]'",
+    "'123'," + "false," + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},123]'",
+    "'[{\"id\":321,\"name\":\"sam\"},{\"id\":666,\"name\":\"jason\"}]',"
+        + "true,"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},{\"id\":321,\"name\":\"sam\"},{\"id\":666,\"name\":\"jason\"}]'",
+  })
+  void itemToAddCanBeSpecifiedInAHandlebarsBlock(
+      String block, boolean flatten, String expectedOutput) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline(
+                "{{#jsonArrayAdd array flatten=" + flatten + "}}" + block + "{{/jsonArrayAdd}}")
+            .apply(
+                Map.of("array", "[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]"));
+    assertThat(output, is(expectedOutput));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "invalid json",
+        "[ { \"id\": 456 }",
+        "",
+        " ",
+      })
+  void returnsAnErrorWhenItemToAddInAHandlebarsBlockDoesNotResolveToValidJson(String block)
+      throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{#jsonArrayAdd array}}" + block + "{{/jsonArrayAdd}}")
+            .apply(
+                Map.of("array", "[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]"));
+    assertThat(output, is("[ERROR: Item-to-add JSON is not valid JSON ('" + block + "')]"));
+  }
+
+  @ParameterizedTest
+  @JsonSource({
+    // have to double wrap arrays because @JsonSource unwraps them.
+    "[[ { id: 456, name: 'bob' } ]]",
+    "{ id: 456, name: 'bob' }",
+    "true",
+    "null",
+    "123",
+  })
+  void returnsAnErrorWhenItemToAddIsNotAString(Object item) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    Map<String, Object> context = new HashMap<>();
+    context.put("array", "[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]");
+    context.put("item", item);
+    String output = handleBars.compileInline("{{ jsonArrayAdd array item }}").apply(context);
+    assertThat(output, is("[ERROR: Item-to-add JSON must be a string]"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "invalid json",
+        "[ { \"id\": 456 }",
+        "",
+        " ",
+      })
+  void returnsAnErrorWhenItemToAddIsNotValidJson(String item) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonArrayAdd array item }}")
+            .apply(
+                Map.of(
+                    "array",
+                    "[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]",
+                    "item",
+                    item));
+    assertThat(output, is("[ERROR: Item-to-add JSON is not valid JSON ('" + item + "')]"));
+  }
+
+  @ParameterizedTest
+  @JsonSource({
+    "1.23",
+    "true",
+    "'not a number'",
+    "'1'",
+    "{}",
+    // have to double wrap arrays because @JsonSource unwraps them.
+    "[[]]",
+  })
+  void returnsAnErrorWhenMaxItemsIsNotAnInteger(Object maxItems) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonArrayAdd array item maxItems=max }}")
+            .apply(
+                Map.of(
+                    "array",
+                    "[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]",
+                    "item",
+                    "{\"id\":321,\"name\":\"sam\"}",
+                    "max",
+                    maxItems));
+    assertThat(output, is("[ERROR: maxItems option must be an integer]"));
+  }
+
+  @Test
+  void returnsAnErrorWhenMaxItemsIsANegativeInteger() throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonArrayAdd array item maxItems=-1 }}")
+            .apply(
+                Map.of(
+                    "array",
+                    "[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]",
+                    "item",
+                    "{\"id\":321,\"name\":\"sam\"}"));
+    assertThat(output, is("[ERROR: maxItems option integer must be positive]"));
+  }
+
+  @ParameterizedTest
+  @JsonSource({
+    "1.23",
+    "'true'",
+    "'not a number'",
+    "1",
+    "{}",
+    // have to double wrap arrays because @JsonSource unwraps them.
+    "[[]]",
+  })
+  void returnsAnErrorWhenFlattenOptionIsNotABoolean(Object flatten) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonArrayAdd array item flatten=flat }}")
+            .apply(
+                Map.of(
+                    "array",
+                    "[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]",
+                    "item",
+                    "{\"id\":321,\"name\":\"sam\"}",
+                    "flat",
+                    flatten));
+    assertThat(output, is("[ERROR: flatten option must be a boolean]"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'{\"expired\":false,\"users\":[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]}',"
+        + "'{\"id\":321,\"name\":\"sam\"}',"
+        + "'$.users',"
+        + "'{\"expired\":false,\"users\":[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},{\"id\":321,\"name\":\"sam\"}]}'",
+    "'[{\"id\":456,\"names\":[\"bob\",\"jason\"]},{\"id\":123,\"names\":[\"alice\"]}]',"
+        + "'\"sam\"',"
+        + "'$[0].names',"
+        + "'[{\"id\":456,\"names\":[\"bob\",\"jason\",\"sam\"]},{\"id\":123,\"names\":[\"alice\"]}]'",
+  })
+  void jsonPathCanBeProvidedToSspecifyANestedArrayToAddTheItemTo(
+      String inputJson, String itemToAdd, String jsonPath, String expectedOutput)
+      throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonArrayAdd inputJson item jsonPath=jPath }}")
+            .apply(Map.of("inputJson", inputJson, "item", itemToAdd, "jPath", jsonPath));
+    assertThat(output, is(expectedOutput));
+  }
+
+  @ParameterizedTest
+  @JsonSource({
+    "1",
+    "1.23",
+    "true",
+    "{}",
+    // have to double wrap arrays because @JsonSource unwraps them.
+    "[[]]",
+  })
+  void returnsAnErrorWhenJsonpathOptionIsNotAString(Object jsonPath) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonArrayAdd inputJson item jsonPath=jPath }}")
+            .apply(
+                Map.of(
+                    "inputJson",
+                    "[{\"id\":456,\"names\":[\"bob\",\"jason\"]},{\"id\":123,\"names\":[\"alice\"]}]",
+                    "item",
+                    "\"sam\"",
+                    "jPath",
+                    jsonPath));
+    assertThat(output, is("[ERROR: jsonPath option must be a string]"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "invalid jsonpath",
+        "$.[",
+        "",
+        " ",
+      })
+  void returnsAnErrorWhenJsonpathOptionIsNotValidExpression(String jsonPath) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{jsonArrayAdd inputJson item jsonPath=jPath}}")
+            .apply(
+                Map.of(
+                    "inputJson",
+                    "[{\"id\":456,\"names\":[\"bob\",\"jason\"]},{\"id\":123,\"names\":[\"alice\"]}]",
+                    "item",
+                    "\"sam\"",
+                    "jPath",
+                    jsonPath));
+    assertThat(
+        output,
+        is("[ERROR: jsonPath option is not valid JSONPath expression ('" + jsonPath + "')]"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'[{\"id\":456,\"names\":[\"bob\",\"jason\"]},{\"id\":123,\"names\":[\"alice\"]}]',"
+        + "'$[0].doesNotExist'",
+    "'[{\"id\":456,\"names\":[\"bob\",\"jason\"]},{\"id\":123,\"names\":[\"alice\"]}]',"
+        + "'$[0].doesNotExist.myArray'",
+    "'[{\"id\":456,\"names\":[\"bob\",\"jason\"]},{\"id\":123,\"names\":[\"alice\"]}]',"
+        + "'$[0].id'",
+    "'{\"id\":\"a string\"}'," + "'$.id'",
+    "'{\"nullable\":null}'," + "'$.nullable'",
+  })
+  void returnsAnErrorWhenJsonpathDoesNotResolveToAnArray(String inputJson, String jsonPath)
+      throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonArrayAdd", new JsonArrayAddHelper());
+    String output =
+        handleBars
+            .compileInline("{{jsonArrayAdd inputJson item jsonPath=jPath}}")
+            .apply(Map.of("inputJson", inputJson, "item", "\"sam\"", "jPath", jsonPath));
+    assertThat(
+        output,
+        is(
+            "[ERROR: Target JSON is not a JSON array (root: '"
+                + inputJson
+                + "', jsonPath: '"
+                + jsonPath
+                + "')]"));
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonMergeHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonMergeHelperTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.is;
+
+import com.github.jknack.handlebars.EscapingStrategy;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.json.JsonSource;
+
+public class JsonMergeHelperTest extends HandlebarsHelperTestBase {
+
+  private final Handlebars handlebars =
+      new Handlebars()
+          .with(EscapingStrategy.NOOP)
+          .registerHelper("jsonMerge", new JsonMergeHelper());
+
+  private String resolveInlineMerge(Object baseJson, Object jsonToMerge) throws IOException {
+    Map<String, Object> context = new HashMap<>();
+    context.put("baseJson", baseJson);
+    context.put("jsonToMerge", jsonToMerge);
+    return handlebars.compileInline("{{jsonMerge baseJson jsonToMerge}}").apply(context);
+  }
+
+  private String resolveBlockMerge(Object baseJson, String block) throws IOException {
+    return handlebars
+        .compileInline("{{#jsonMerge baseJson}}" + block + "{{/jsonMerge}}")
+        .apply(Map.of("baseJson", baseJson));
+  }
+
+  @Test
+  void helperIsAccessibleFromResponseBody() {
+    String responseTemplate =
+        "{{ jsonMerge '{\"id\":456,\"name\":\"bob\"}' '{\"roles\":[\"admin\",\"user\"],\"dob\":\"2024-06-18\"}' }}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is("{\"id\":456,\"name\":\"bob\",\"roles\":[\"admin\",\"user\"],\"dob\":\"2024-06-18\"}"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'{ \"id\": 456, \"name\": \"bob\" }',"
+        + "'{ \"roles\": [ \"admin\", \"user\" ], \"dob\": \"2024-06-18\" }',"
+        + "'{\"id\":456,\"name\":\"bob\",\"roles\":[\"admin\",\"user\"],\"dob\":\"2024-06-18\"}'",
+    "'{ \"id\": 456, \"name\": \"bob\", \"roles\": [ \"viewer\" ] }',"
+        + "'{ \"roles\": [ \"admin\", \"user\" ], \"dob\": \"2024-06-18\" }',"
+        + "'{\"id\":456,\"name\":\"bob\",\"roles\":[\"admin\",\"user\"],\"dob\":\"2024-06-18\"}'",
+    "'{}',"
+        + "'{ \"roles\": [ \"admin\", \"user\" ], \"dob\": \"2024-06-18\" }',"
+        + "'{\"roles\":[\"admin\",\"user\"],\"dob\":\"2024-06-18\"}'",
+    "'{ \"id\": 456, \"name\": \"bob\" }'," + "'{}'," + "'{\"id\":456,\"name\":\"bob\"}'",
+    "'{ \"id\": 456, \"name\": \"bob\", \"data\": { \"field\": \"value\" } }',"
+        + "'{ \"data\": [ 123, true ] }',"
+        + "'{\"id\":456,\"name\":\"bob\",\"data\":[123,true]}'",
+  })
+  void mergesJsonObjects(String baseJson, String jsonToMerge, String expectedOutput)
+      throws IOException {
+    assertThat(resolveInlineMerge(baseJson, jsonToMerge), is(expectedOutput));
+  }
+
+  @ParameterizedTest
+  @JsonSource({
+    // have to double wrap arrays because @JsonSource unwraps them.
+    "[[ { \"id\": 456, \"name\": \"bob\" }, { \"id\": 123, \"name\": \"alice\" }, { \"id\": 321, \"name\": \"sam\" } ]]",
+    "{ \"id\": 456, \"name\": \"bob\" }",
+    "true",
+    "null",
+    "123",
+  })
+  void returnsAnErrorWhenBaseJsonIsNotAString(Object baseJson) throws IOException {
+    assertThat(
+        resolveInlineMerge(baseJson, "{\"id\":321,\"name\":\"sam\"}"),
+        is("[ERROR: Base JSON parameter must be a string]"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "invalid json",
+        "[ { \"id\": 456 }",
+        "",
+        " ",
+      })
+  void returnsAnErrorWhenBaseJsonIsNotValidJson(String baseJson) throws IOException {
+    assertThat(
+        resolveInlineMerge(baseJson, "{\"id\":321,\"name\":\"sam\"}"),
+        is("[ERROR: Base JSON is not valid JSON ('" + baseJson + "')]"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "[ { \"id\": 123, \"name\": \"alice\" } ]",
+        "\"name\"",
+        "true",
+        "null",
+        "123",
+      })
+  void returnsAnErrorWhenBaseJsonIsNotJsonObject(Object baseJson) throws IOException {
+    assertThat(
+        resolveInlineMerge(baseJson, "{\"id\":321,\"name\":\"sam\"}"),
+        is("[ERROR: Base JSON is not a JSON object ('" + baseJson + "')]"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'{\"roles\":[\"admin\",\"user\"],\"dob\":\"2024-06-18\"}',"
+        + "'{\"id\":456,\"name\":\"bob\",\"roles\":[\"admin\",\"user\"],\"dob\":\"2024-06-18\"}'",
+    "'{}'," + "'{\"id\":456,\"name\":\"bob\",\"roles\":[\"viewer\"]}'",
+    "'{\"data\":[123, true]}',"
+        + "'{\"id\":456,\"name\":\"bob\",\"roles\":[\"viewer\"],\"data\":[123,true]}'",
+  })
+  void jsonToMergeCanBeSpecifiedInAHandlebarsBlock(String block, String expectedOutput)
+      throws IOException {
+    assertThat(
+        resolveBlockMerge("{\"id\":456,\"name\":\"bob\",\"roles\":[\"viewer\"]}", block),
+        is(expectedOutput));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "invalid json",
+        "[ { \"id\": 456 }",
+        "",
+        " ",
+      })
+  void returnsAnErrorWhenJsonToMergeInAHandlebarsBlockDoesNotResolveToValidJson(String block)
+      throws IOException {
+    assertThat(
+        resolveBlockMerge("{\"id\":456,\"name\":\"bob\"}", block),
+        is("[ERROR: JSON to merge is not valid JSON ('" + block + "')]"));
+  }
+
+  @ParameterizedTest
+  @JsonSource({
+    // have to double wrap arrays because @JsonSource unwraps them.
+    "[[ { id: 456, name: 'bob' } ]]",
+    "{ id: 456, name: 'bob' }",
+    "true",
+    "null",
+    "123",
+  })
+  void returnsAnErrorWhenJsonToMergeIsNotAString(Object jsonToMerge) throws IOException {
+    assertThat(
+        resolveInlineMerge("{\"id\":456,\"name\":\"bob\"}", jsonToMerge),
+        is("[ERROR: JSON to merge must be a string]"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "invalid json",
+        "[ { \"id\": 456 }",
+        "",
+        " ",
+      })
+  void returnsAnErrorWhenJsonToMergeIsNotValidJson(String jsonToMerge) throws IOException {
+    assertThat(
+        resolveInlineMerge("{\"id\":456,\"name\":\"bob\"}", jsonToMerge),
+        is("[ERROR: JSON to merge is not valid JSON ('" + jsonToMerge + "')]"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "[{\"id\":123,\"name\":\"alice\"}]",
+        "\"name\"",
+        "true",
+        "null",
+        "123",
+      })
+  void returnsAnErrorWhenJsonToMergeIsNotAnObject(String jsonToMerge) throws IOException {
+    assertThat(
+        resolveInlineMerge("{\"id\":456,\"name\":\"bob\"}", jsonToMerge),
+        is("[ERROR: JSON to merge is not a JSON object ('" + jsonToMerge + "')]"));
+  }
+
+  @Test
+  void jsonObjectsAreMergedRecursively() throws IOException {
+    String baseJson =
+        "{ \"id\": 456, \"name\": \"bob\", \"data\": { \"nestedObject\": { \"value\": \"my value\", \"veryNestedArray\": [ true, false, 123 ], \"anOldField\": \"with an old value\" }, \"someNumber\": 456 } }";
+    String jsonToMerge =
+        "{ \"data\": { \"nestedObject\": { \"value\": \"new value\", \"veryNestedArray\": [ \"newItem\" ], \"aNewField\": \"with a new value\" }, \"newNestedObject\": { \"someBoolean\": true } } }";
+    String output = resolveInlineMerge(baseJson, jsonToMerge);
+    String expectedOutput =
+        "{ \"id\": 456, \"name\": \"bob\", \"data\": { \"nestedObject\": { \"value\": \"new value\", \"veryNestedArray\": [ \"newItem\" ], \"anOldField\": \"with an old value\", \"aNewField\": \"with a new value\" }, \"someNumber\": 456, \"newNestedObject\": { \"someBoolean\": true } } }";
+    assertThat(output, jsonEquals(expectedOutput));
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonRemoveHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonRemoveHelperTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.jknack.handlebars.EscapingStrategy;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.json.JsonSource;
+
+public class JsonRemoveHelperTest extends HandlebarsHelperTestBase {
+
+  @Test
+  void helperIsAccessibleFromResponseBody() {
+    String responseTemplate = "{{ jsonRemove '{\"id\":456,\"name\":\"bob\"}' '$.name' }}";
+    final ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("{\"id\":456}"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},{\"id\":321,\"name\":\"sam\"}]',"
+        + "'$.[?(@.id == 123)]',"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":321,\"name\":\"sam\"}]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},{\"id\":123,\"name\":\"sam\"}]',"
+        + "'$[?(@.id == 123)]',"
+        + "'[{\"id\":456,\"name\":\"bob\"}]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"},{\"id\":321,\"name\":\"sam\"}]',"
+        + "'$.[?(@.id == 123)].name',"
+        + "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123},{\"id\":321,\"name\":\"sam\"}]'",
+    "'{\"id\":456,\"name\":\"bob\"}'," + "'$.name'," + "'{\"id\":456}'",
+    "'[{\"id\":456,\"name\":\"bob\",\"roles\":[\"admin\",\"user\"]},{\"id\":123,\"name\":\"alice\",\"roles\":[\"admin\",\"user\"]}]',"
+        + "'$.[?(@.name == \"alice\")].roles[?(@ == \"admin\")]',"
+        + "'[{\"id\":456,\"name\":\"bob\",\"roles\":[\"admin\",\"user\"]},{\"id\":123,\"name\":\"alice\",\"roles\":[\"user\"]}]'",
+  })
+  void removesElementsFromStringInputAndReturnsString(
+      String inputJson, String jsonPath, String expectedOutput) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonRemove", new JsonRemoveHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonRemove input '" + jsonPath + "' }}")
+            .apply(Map.of("input", inputJson));
+    assertThat(output, is(expectedOutput));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]'," + "'$.[?(@.id == 321)]'",
+    "'[{\"id\":456,\"name\":\"bob\"},{\"id\":123,\"name\":\"alice\"}]'," + "'$.name'",
+    "'{\"id\":456}'," + "'$.name'",
+    "'true'," + "'$.name'",
+    "'null'," + "'$.name'",
+    "'123'," + "'$.name'",
+  })
+  void noOpIfJsonpathResultIsNotFoundForInputJson(String inputJson, String jsonPath)
+      throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonRemove", new JsonRemoveHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonRemove input '" + jsonPath + "' }}")
+            .apply(Map.of("input", inputJson));
+    assertThat(output, is(inputJson));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "invalid json",
+        "[ { \"id\": 456 } ",
+        "",
+        " ",
+      })
+  void errorsIfInputJsonStringIsNotValidJson(String inputJson) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonRemove", new JsonRemoveHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonRemove input '$.name' }}")
+            .apply(Map.of("input", inputJson));
+    assertThat(output, is("[ERROR: Input JSON string is not valid JSON ('" + inputJson + "')]"));
+  }
+
+  @ParameterizedTest
+  @JsonSource({
+    // have to double wrap arrays because @JsonSource unwraps them.
+    "[[ { id: 456, name: 'bob' }, { id: 123, name: 'alice' }, { id: 321, name: 'sam' } ]]",
+    "{ id: 456, name: 'bob' }",
+    "true",
+    "null",
+    "123",
+  })
+  void errorsIfInputJsonIsNotAString(Object inputJson) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonRemove", new JsonRemoveHelper());
+    Map<String, Object> context = new HashMap<>();
+    context.put("input", inputJson);
+    String output = handleBars.compileInline("{{ jsonRemove input '$.name' }}").apply(context);
+    assertThat(output, is("[ERROR: Input JSON must be a string]"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "$name",
+        "not json path",
+        "",
+        " ",
+      })
+  void errorsIfJsonpathExpressionIsNotAValidJsonpath(String jsonPath) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonRemove", new JsonRemoveHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonRemove input '" + jsonPath + "' }}")
+            .apply(Map.of("input", "{\"id\":123,\"name\":\"bob\"}"));
+    assertThat(
+        output,
+        is("[ERROR: JSONPath parameter is not a valid JSONPath expression ('" + jsonPath + "')]"));
+  }
+
+  @ParameterizedTest
+  @JsonSource({
+    "{}",
+    // have to double wrap arrays because @JsonSource unwraps them.
+    "[[]]",
+    "true",
+    "null",
+    "123",
+  })
+  void errorsIfJsonpathExpressionIsNotAString(Object jsonPath) throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonRemove", new JsonRemoveHelper());
+    Map<String, Object> context = new HashMap<>();
+    context.put("input", "{\"id\":123,\"name\":\"bob\"}");
+    context.put("jsonPath", jsonPath);
+    String output = handleBars.compileInline("{{ jsonRemove input jsonPath }}").apply(context);
+    assertThat(output, is("[ERROR: JSONPath parameter must be a string]"));
+  }
+
+  @Test
+  void errorsIfJsonpathExpressionCannotBeAppliedToADeleteOperation() throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonRemove", new JsonRemoveHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonRemove input '$' }}")
+            .apply(Map.of("input", "{\"id\":123,\"name\":\"bob\"}"));
+    assertThat(
+        output, is("[ERROR: Delete operation cannot be applied to JSONPath expression ('$')]"));
+  }
+
+  @Test
+  void errorsIfJsonpathIsNotProvided() throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonRemove", new JsonRemoveHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonRemove input }}")
+            .apply(Map.of("input", "{\"id\":123,\"name\":\"bob\"}"));
+    assertThat(output, is("[ERROR: A single JSONPath expression parameter must be supplied]"));
+  }
+
+  @Test
+  void errorsIfMoreThanOneParameterIsProvided() throws IOException {
+    Handlebars handleBars =
+        new Handlebars()
+            .with(EscapingStrategy.NOOP)
+            .registerHelper("jsonRemove", new JsonRemoveHelper());
+    String output =
+        handleBars
+            .compileInline("{{ jsonRemove input '$.name' '$.name' }}")
+            .apply(Map.of("input", "{\"id\":123,\"name\":\"bob\"}"));
+    assertThat(output, is("[ERROR: A single JSONPath expression parameter must be supplied]"));
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ToJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ToJsonHelperTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import org.junit.jupiter.api.Test;
+
+public class ToJsonHelperTest extends HandlebarsHelperTestBase {
+
+  @Test
+  void convertArrayToJson() {
+    String responseTemplate = "{{ toJson (array 1 2 3) }}";
+    ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("[ 1, 2, 3 ]"));
+  }
+
+  @Test
+  void convertNullToJson() {
+    String responseTemplate = "{{ toJson null }}";
+    ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is(""));
+  }
+
+  @Test
+  void convertStringToJson() {
+    String responseTemplate = "{{ toJson 'null' }}";
+    ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("\"null\""));
+  }
+
+  @Test
+  void convertMapToJson() {
+    String responseTemplate = "{{ toJson request.headers }}";
+    ResponseDefinition responseDefinition =
+        transform(
+            transformer,
+            mockRequest().header("Authorization", "whatever").header("Content-Type", "text/plain"),
+            aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is("{\n  \"Authorization\" : \"whatever\",\n  \"Content-Type\" : \"text/plain\"\n}"));
+  }
+
+  @Test
+  void convertBooleanToJson() {
+    String responseTemplate = "{{ toJson true }}";
+    ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("true"));
+  }
+
+  @Test
+  void convertNumberToJson() {
+    String responseTemplate = "{{ toJson 123 }}";
+    ResponseDefinition responseDefinition =
+        transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
+
+    assertThat(responseDefinition.getBody(), is("123"));
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ToJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ToJsonHelperTest.java
@@ -22,6 +22,9 @@ import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 public class ToJsonHelperTest extends HandlebarsHelperTestBase {
 
@@ -53,6 +56,7 @@ public class ToJsonHelperTest extends HandlebarsHelperTestBase {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
   void convertMapToJson() {
     String responseTemplate = "{{ toJson request.headers }}";
     ResponseDefinition responseDefinition =
@@ -64,6 +68,21 @@ public class ToJsonHelperTest extends HandlebarsHelperTestBase {
     assertThat(
         responseDefinition.getBody(),
         is("{\n  \"Authorization\" : \"whatever\",\n  \"Content-Type\" : \"text/plain\"\n}"));
+  }
+
+  @Test
+  @EnabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
+  void convertMapToJsonWindows() {
+    String responseTemplate = "{{ toJson request.headers }}";
+    ResponseDefinition responseDefinition =
+        transform(
+            transformer,
+            mockRequest().header("Authorization", "whatever").header("Content-Type", "text/plain"),
+            aResponse().withBody(responseTemplate));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is("{\r\n  \"Authorization\" : \"whatever\",\r\n  \"Content-Type\" : \"text/plain\"\r\n}"));
   }
 
   @Test

--- a/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/MockWireMockServices.java
+++ b/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/MockWireMockServices.java
@@ -38,9 +38,9 @@ public class MockWireMockServices implements WireMockServices {
 
   private Map<String, Helper<?>> helpers = emptyMap();
   private Long maxCacheEntries = null;
-  private Supplier<TemplateEngine> templateEngine =
+  private final Supplier<TemplateEngine> templateEngine =
       Suppliers.memoize(
-          () -> new TemplateEngine(helpers, maxCacheEntries, null, false, emptyList()));
+          () -> new TemplateEngine(helpers, maxCacheEntries, null, true, emptyList()));
 
   @Override
   public Admin getAdmin() {


### PR DESCRIPTION
Add additional handlebars helpers for working with JSON and XML.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
