### PR TITLE
Always use the system default `TransformerFactory` in `FormatXmlHelper`

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Thomas Akehurst
+ * Copyright (C) 2024-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ public class FormatXmlHelper extends AbstractFormattingHelper {
   private final TransformerFactory transformerFactory;
 
   public FormatXmlHelper() {
-    TransformerFactory factory = TransformerFactory.newInstance();
+    TransformerFactory factory = TransformerFactory.newDefaultInstance();
     factory.setAttribute("indent-number", 2);
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/FaultsTest.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/FaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Thomas Akehurst
+ * Copyright (C) 2024-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2AcceptanceTest.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2AcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Thomas Akehurst
+ * Copyright (C) 2019-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2ClientFactory.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2ClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Thomas Akehurst
+ * Copyright (C) 2019-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2DisabledAcceptanceTest.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Http2DisabledAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Thomas Akehurst
+ * Copyright (C) 2024-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Jetty12MultipartParser.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Jetty12MultipartParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 Thomas Akehurst
+ * Copyright (C) 2018-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Jetty12MultipartParserLoader.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/Jetty12MultipartParserLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 Thomas Akehurst
+ * Copyright (C) 2018-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/ProgrammaticHttpServerAcceptanceTest.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/ProgrammaticHttpServerAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Thomas Akehurst
+ * Copyright (C) 2019-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/server/CustomHttpServer.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/server/CustomHttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Thomas Akehurst
+ * Copyright (C) 2024-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/server/CustomHttpServerFactory.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/server/CustomHttpServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Thomas Akehurst
+ * Copyright (C) 2024-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/servlet/AltHttpServerFactory.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/servlet/AltHttpServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/servlet/AlternativeServletContainerTest.java
+++ b/wiremock-jetty12/src/test/java/com/github/tomakehurst/wiremock/jetty12/servlet/AlternativeServletContainerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Closes #2911
Closes #2913

The implementation of `FormatXmlHelper` relies on a non-standard `TransformerFactory` attribute, `indent-number`, which is not supported by all implementations. By using `TransformerFactory.newDefaultInstance` instead of `TransformerFactory.newInstance`, the system default implementation (`com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl` on OpenJDK-derived JDKs) will be used regardless of any other implementations which might be present on the classpath.

---

Unfortunately, I don't see any way to add or update any tests for this change without introducing a dependency on another XML library. To ensure this change has the expected behavior, I used the same reproduction steps as in #2911 (include Saxon-HE in a small test project): the exception thrown when invoking the `WireMockServer` constructor no longer appears when using a version with this change installed to my local Maven repository.

Another possible approach would be to try to unify this logic with https://github.com/wiremock/wiremock/blob/00d0329c4f224e0c6412fd7f4be6efc976abe021/src/main/java/com/github/tomakehurst/wiremock/common/xml/XmlNode.java#L44-L57, which appears to serve a similar purpose, but was written before Java 11 was the baseline (`TransformerFactory.newDefaultInstance` was introduced in Java 9). Let me know if you'd like me to try to consider that in this PR as well.

## References

- #2904
- #2911
- #2913

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
