### PR TITLE
Throw descriptive exception when no suitable HttpServerFactory extension was found

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactoryLoader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactoryLoader.java
@@ -69,6 +69,10 @@ public class HttpServerFactoryLoader {
   }
 
   private static HttpServerFactory pickMostAppropriateFrom(List<HttpServerFactory> candidates) {
+    if (candidates.isEmpty()) {
+      throw couldNotFindSuitableServerException();
+    }
+
     return candidates.size() > 1
         ? candidates.stream()
             .filter(factory -> !DefaultFactory.class.isAssignableFrom(factory.getClass()))


### PR DESCRIPTION
Due to a misconfiguration on my side, I had no HttpServerFactory available. Unfortunately the IndexOutOfBoundsException that was thrown (see below) for this, was not very helpful in figuring out what the issue was.

This is the originally thrown exception + stack trace:
```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
	at java.base/java.util.Objects.checkIndex(Objects.java:385)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at com.github.tomakehurst.wiremock.http.HttpServerFactoryLoader.pickMostAppropriateFrom(HttpServerFactoryLoader.java:77)
	at com.github.tomakehurst.wiremock.http.HttpServerFactoryLoader.load(HttpServerFactoryLoader.java:57)
	at com.github.tomakehurst.wiremock.WireMockServer.getHttpServerFactory(WireMockServer.java:89)
	at com.github.tomakehurst.wiremock.WireMockServer.<init>(WireMockServer.java:72)
	at com.github.tomakehurst.wiremock.junit5.WireMockExtension.startServerIfRequired(WireMockExtension.java:215)
	at com.github.tomakehurst.wiremock.junit5.WireMockExtension.beforeAll(WireMockExtension.java:282)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

And this afterwards:
```
com.github.tomakehurst.wiremock.common.FatalStartupException: Jetty 11 is not present and no suitable HttpServerFactory extension was found. Please ensure that the classpath includes a WireMock extension that provides an HttpServerFactory implementation. See http://wiremock.org/docs/extending-wiremock/ for more information.
	at com.github.tomakehurst.wiremock.http.HttpServerFactoryLoader.couldNotFindSuitableServerException(HttpServerFactoryLoader.java:85)
	at com.github.tomakehurst.wiremock.http.HttpServerFactoryLoader.pickMostAppropriateFrom(HttpServerFactoryLoader.java:73)
	at com.github.tomakehurst.wiremock.http.HttpServerFactoryLoader.load(HttpServerFactoryLoader.java:57)
	at com.github.tomakehurst.wiremock.http.HttpServerFactoryLoaderTest.throwsDescriptiveExceptionWhenNoSuitableServerFactoryIsFound(HttpServerFactoryLoaderTest.java:142)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

<!-- Please describe your pull request here. -->

## References


<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
