### PR TITLE
Add method to MappingBuilder to add multiple form params

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,6 +132,14 @@ class BasicMappingBuilder implements ScenarioMappingBuilder {
   @Override
   public ScenarioMappingBuilder withFormParam(String key, MultiValuePattern formParamPattern) {
     requestPatternBuilder.withFormParam(key, formParamPattern);
+    return this;
+  }
+
+  @Override
+  public BasicMappingBuilder withFormParams(Map<String, MultiValuePattern> formParams) {
+    for (Map.Entry<String, MultiValuePattern> formParam : formParams.entrySet()) {
+      requestPatternBuilder.withFormParam(formParam.getKey(), formParam.getValue());
+    }
     return this;
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,8 @@ public interface MappingBuilder {
   MappingBuilder withFormParam(String key, StringValuePattern formParamPattern);
 
   MappingBuilder withFormParam(String key, MultiValuePattern multiValueFormParamPattern);
+
+  MappingBuilder withFormParams(Map<String, MultiValuePattern> formParams);
 
   MappingBuilder withQueryParams(Map<String, StringValuePattern> queryParams);
 

--- a/src/main/java/com/github/tomakehurst/wiremock/client/ScenarioMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ScenarioMappingBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,8 @@ public interface ScenarioMappingBuilder extends MappingBuilder {
   ScenarioMappingBuilder withFormParam(String key, StringValuePattern formParamPattern);
 
   ScenarioMappingBuilder withFormParam(String key, MultiValuePattern formParamPattern);
+
+  ScenarioMappingBuilder withFormParams(Map<String, MultiValuePattern> formParams);
 
   ScenarioMappingBuilder withQueryParams(Map<String, StringValuePattern> queryParams);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.*;
 import com.github.tomakehurst.wiremock.admin.model.ListStubMappingsResult;
 import com.github.tomakehurst.wiremock.common.ClientError;
 import com.github.tomakehurst.wiremock.junit5.EnabledIfJettyVersion;
+import com.github.tomakehurst.wiremock.matching.MultiValuePattern;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.TestHttpHeader;
@@ -638,6 +639,32 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
     assertThat(response.statusCode(), is(200));
 
     response = testClient.delete("/form");
+    assertThat(response.statusCode(), is(404));
+  }
+
+  @Test
+  void matchesWithMultipleFormParams() {
+    stubFor(
+        put(urlPathEqualTo("/form"))
+            .withFormParams(
+                Map.of(
+                    "key1", MultiValuePattern.of(equalTo("value1")),
+                    "key2", MultiValuePattern.of(equalTo("value2")))));
+
+    WireMockResponse response =
+        testClient.putWithBody(
+            "/form",
+            "key1=value1&key2=value2",
+            "application/x-www-form-urlencoded",
+            TestHttpHeader.withHeader("Content-Type", "application/x-www-form-urlencoded"));
+    assertThat(response.statusCode(), is(200));
+
+    response =
+        testClient.putWithBody(
+            "/form",
+            "key1=value1",
+            "application/x-www-form-urlencoded",
+            TestHttpHeader.withHeader("Content-Type", "application/x-www-form-urlencoded"));
     assertThat(response.statusCode(), is(404));
   }
 


### PR DESCRIPTION
Existing methods in `MappingBuilder` only allow adding form param patterns for one key at a time by using one of
`withFormParam(String key, StringValuePattern formParamPattern)` or `withFormParam(String key, MultiValuePattern multiValueFormParamPattern)`.

In case of having a map with the form params (for example as the input from a `@ParameterizedTest` in a JUnit test) the current API requires to create a variable for the mapping builder and iterate over the map adding the patterns for each key individually, _**breaking the method chaining**_ that the builder is meant for:

```
Map<String, MultiValuePattern> formParamsMap; // given

MappingBuilder mappingBuilder = put(urlEqualTo("/form-params"));
formParamsMap.forEach(mappingBuilder::withFormParam);
stubFor(mappingBuilder);
```

This new method allows using method chaining, therefore eliminates the need of defining a variable:

```
Map<String, MultiValuePattern> formParamsMap; // given

stubFor(put(urlEqualTo("/form-params")).withFormParams(formParamsMap));
```

Note that there are already some similar methods for queryParams and metadata: `withQueryParams(Map<String, StringValuePattern> queryParams)` and `withMetadata(Map<String, ?> metadata)`, respectively.


<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
