### PR TITLE
Use namespace-aware XML parser in EqualToXmlPattern

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -255,6 +255,114 @@ public class EqualToXmlPatternTest {
   }
 
   @Test
+  public void doesNotReturnExactMatchWhenActualHasMissingNamespaceUri() {
+    EqualToXmlPattern pattern = 
+        new EqualToXmlPattern(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+                + "<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                + "    <soap:Body>\n"
+                + "        <stuff xmlns=\"https://example.com/mynamespace\">\n"
+                + "            <things />\n"
+                + "        </stuff>\n"
+                + "    </soap:Body>\n"
+                + "</soap:Envelope>\n");
+
+    assertFalse(
+        pattern
+            .match(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+                    + "<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                    + "    <soap:Body>\n"
+                    + "        <stuff>\n"
+                    + "            <things />\n"
+                    + "        </stuff>\n"
+                    + "    </soap:Body>\n"
+                    + "</soap:Envelope>\n")
+            .isExactMatch());
+  }
+  
+  @Test
+  public void doesNotReturnExactMatchWhenActualHasAddedNamespaceUri() {
+    EqualToXmlPattern pattern = 
+        new EqualToXmlPattern(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+                + "<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                + "    <soap:Body>\n"
+                + "        <stuff>\n"
+                + "            <things />\n"
+                + "        </stuff>\n"
+                + "    </soap:Body>\n"
+                + "</soap:Envelope>\n");
+
+    assertFalse(
+        pattern
+            .match(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+                    + "<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                    + "    <soap:Body>\n"
+                    + "        <stuff xmlns=\"http://example.com/mynamespace\">\n"
+                    + "            <things />\n"
+                    + "        </stuff>\n"
+                    + "    </soap:Body>\n"
+                    + "</soap:Envelope>\n")
+            .isExactMatch());
+  }
+  
+  @Test
+  public void doesNotReturnExactMatchWhenActualHasMissingNamespacePrefix() {
+    EqualToXmlPattern pattern = 
+        new EqualToXmlPattern(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+                + "<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                + "    <soap:Body>\n"
+                + "        <soap:stuff>\n"
+                + "            <things />\n"
+                + "        </soap:stuff>\n"
+                + "    </soap:Body>\n"
+                + "</soap:Envelope>\n");
+
+    assertFalse(
+        pattern
+            .match(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+                    + "<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                    + "    <soap:Body>\n"
+                    + "        <stuff>\n"
+                    + "            <things />\n"
+                    + "        </stuff>\n"
+                    + "    </soap:Body>\n"
+                    + "</soap:Envelope>\n")
+            .isExactMatch());
+  }
+  
+  @Test
+  public void doesNotReturnExactMatchWhenActualHasAddedNamespacePrefix() {
+    EqualToXmlPattern pattern = 
+        new EqualToXmlPattern(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+                + "<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                + "    <soap:Body>\n"
+                + "        <stuff>\n"
+                + "            <things />\n"
+                + "        </stuff>\n"
+                + "    </soap:Body>\n"
+                + "</soap:Envelope>\n");
+
+    assertFalse(
+        pattern
+            .match(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+                    + "<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                    + "    <soap:Body>\n"
+                    + "        <soap:stuff>\n"
+                    + "            <things />\n"
+                    + "        </soap:stuff>\n"
+                    + "    </soap:Body>\n"
+                    + "</soap:Envelope>\n")
+            .isExactMatch());
+  }
+
+  @Test
   public void returnsExactMatchWhenAttributesAreInDifferentOrder() {
     EqualToXmlPattern pattern =
         new EqualToXmlPattern("<my-attribs one=\"1\" two=\"2\" three=\"3\"/>");

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -256,7 +256,7 @@ public class EqualToXmlPatternTest {
 
   @Test
   public void doesNotReturnExactMatchWhenActualHasMissingNamespaceUri() {
-    EqualToXmlPattern pattern = 
+    EqualToXmlPattern pattern =
         new EqualToXmlPattern(
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
                 + "<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
@@ -280,10 +280,10 @@ public class EqualToXmlPatternTest {
                     + "</soap:Envelope>\n")
             .isExactMatch());
   }
-  
+
   @Test
   public void doesNotReturnExactMatchWhenActualHasAddedNamespaceUri() {
-    EqualToXmlPattern pattern = 
+    EqualToXmlPattern pattern =
         new EqualToXmlPattern(
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
                 + "<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
@@ -307,10 +307,10 @@ public class EqualToXmlPatternTest {
                     + "</soap:Envelope>\n")
             .isExactMatch());
   }
-  
+
   @Test
   public void doesNotReturnExactMatchWhenActualHasMissingNamespacePrefix() {
-    EqualToXmlPattern pattern = 
+    EqualToXmlPattern pattern =
         new EqualToXmlPattern(
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
                 + "<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
@@ -334,10 +334,10 @@ public class EqualToXmlPatternTest {
                     + "</soap:Envelope>\n")
             .isExactMatch());
   }
-  
+
   @Test
   public void doesNotReturnExactMatchWhenActualHasAddedNamespacePrefix() {
-    EqualToXmlPattern pattern = 
+    EqualToXmlPattern pattern =
         new EqualToXmlPattern(
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
                 + "<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
@@ -558,7 +558,8 @@ public class EqualToXmlPatternTest {
             + "    <st:thing>Match this</st:thing>\n"
             + "</stuff>";
 
-    MatchResult matchResult = equalToXml(expected).match(actual);
+    MatchResult matchResult =
+        equalToXml(expected).exemptingComparisons(NAMESPACE_URI).match(actual);
 
     assertTrue(matchResult.isExactMatch());
   }


### PR DESCRIPTION
The `DocumentBuilderFactory` used by `EqualToXmlPattern` does not have its "namespace-aware" feature enabled, so certain combinations of missing or added namespaces in the XML documents being compared are being incorrectly ignored. (This is described in detail in issue #2936.)

The changes in this PR include creation of a subclass of `Xml.SkipResolvingEntitiesDocumentBuilderFactory` to maintain a separate namespace-aware `DocumentBuilderFactory`, following the same `ThreadLocal`-based caching as the original.

A contributing factor is the logic in `IgnoreUncountedDifferenceEvaluator.evaluate()`, which ignores any comparisons where the "control" value is `null`:
```java
      if (finalCountedComparisons.contains(comparison.getType())
          && comparison.getControlDetails().getValue() != null) {
        return outcome;
      }

      return ComparisonResult.EQUAL;
```

I've removed the second line, so the tests now pass, but I imagine that the logic was put in for a reason, so it would be good to hear about any edge cases from the past, for which we should add new test cases.

Overall, this change will make the `isEqualToXml` pattern more strict, and I'm aware that different people will have different requirements regarding just how strict the equality should be, so if there's a different approach you think we should take here just let me know. I will say that this bug caught my team by surprise: we expected that our tests would fail if the XML our app was writing was missing some namespaces, but that wasn't the case, and the bug in the app was only discovered later during integration testing.


## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [x] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
