### PR TITLE
feat: add `originalResponse` to be available in the templating

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateModel.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating;
+
+import com.github.tomakehurst.wiremock.common.ListOrSingle;
+import com.github.tomakehurst.wiremock.http.Body;
+import java.util.Map;
+
+public class ResponseTemplateModel {
+
+  private final Body body;
+  private final Map<String, ListOrSingle<String>> headers;
+
+  public ResponseTemplateModel(Map<String, ListOrSingle<String>> headers, Body body) {
+    this.body = body;
+    this.headers = headers;
+  }
+
+  public String getBody() {
+    return body.asString();
+  }
+
+  public Map<String, ListOrSingle<String>> getHeaders() {
+    return headers;
+  }
+}

--- a/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Thomas Akehurst
+ * Copyright (C) 2021-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,6 +145,8 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
             : Collections.<String, Object>emptyMap());
     model.put("originalRequest", model.get("request"));
     model.remove("request");
+    model.put("originalResponse", model.get("response"));
+    model.remove("response");
 
     WebhookDefinition renderedWebhookDefinition =
         webhookDefinition

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Thomas Akehurst
+ * Copyright (C) 2021-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -286,7 +286,13 @@ public class WebhooksAcceptanceViaServeEventTest extends WebhooksAcceptanceTest 
   public void appliesTemplatingToUrlMethodHeadersAndBodyViaDSL() throws Exception {
     rule.stubFor(
         post(urlPathEqualTo("/templating"))
-            .willReturn(ok())
+            .willReturn(
+                ok(
+                    "{\n"
+                        + "  \"eventId\": \"7412\",\n"
+                        + "  \"messageId\": \"2318\",\n"
+                        + "  \"status\": \"success\"\n"
+                        + "}"))
             .withServeEventListener(
                 "webhook",
                 webhook()
@@ -296,7 +302,8 @@ public class WebhooksAcceptanceViaServeEventTest extends WebhooksAcceptanceTest 
                             + "{{{jsonPath originalRequest.body '$.callbackPath'}}}")
                     .withHeader("X-Single", "{{math 1 '+' 2}}")
                     .withHeader("X-Multi", "{{math 3 'x' 2}}", "{{parameters.one}}")
-                    .withBody("{{jsonPath originalRequest.body '$.name'}}")
+                    .withBody(
+                        "{{jsonPath originalRequest.body '$.name'}} - {{jsonPath originalResponse.body '$.status'}}")
                     .withExtraParameter("one", "param-one-value")));
 
     verify(0, postRequestedFor(anyUrl()));
@@ -319,7 +326,7 @@ public class WebhooksAcceptanceViaServeEventTest extends WebhooksAcceptanceTest 
 
     assertThat(request.header("X-Single").firstValue(), is("3"));
     assertThat(request.header("X-Multi").values(), hasItems("6", "param-one-value"));
-    assertThat(request.getBodyAsString(), is("Tom"));
+    assertThat(request.getBodyAsString(), is("Tom - success"));
   }
 
   @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- Implements functionality for #2359

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
