### PR TITLE
GH-2931 Allow passing a custom HTTP client into the HttpAdminClient constructor 

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -92,6 +92,17 @@ public class HttpAdminClient implements Admin {
     this(scheme, host, port, urlPathPrefix, hostHeader, null, 0, noClientAuthenticator());
   }
 
+  public HttpAdminClient(String scheme, String host, int port, String hostHeader, CloseableHttpClient httpClient) {
+    this.scheme = scheme;
+    this.host = host;
+    this.port = port;
+    this.urlPathPrefix = "";
+    this.hostHeader = hostHeader;
+    this.authenticator = noClientAuthenticator();
+    this.httpClient = httpClient;
+    this.adminRoutes = AdminRoutes.forClient();
+  }
+
   public HttpAdminClient(
       String scheme,
       String host,

--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -92,11 +92,11 @@ public class HttpAdminClient implements Admin {
     this(scheme, host, port, urlPathPrefix, hostHeader, null, 0, noClientAuthenticator());
   }
 
-  public HttpAdminClient(String scheme, String host, int port, String hostHeader, CloseableHttpClient httpClient) {
+  public HttpAdminClient(String scheme, String host, int port, String urlPathPrefix, String hostHeader, CloseableHttpClient httpClient) {
     this.scheme = scheme;
     this.host = host;
     this.port = port;
-    this.urlPathPrefix = "";
+    this.urlPathPrefix = urlPathPrefix;
     this.hostHeader = hostHeader;
     this.authenticator = noClientAuthenticator();
     this.httpClient = httpClient;

--- a/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
@@ -15,115 +15,112 @@
  */
 package com.github.tomakehurst.wiremock.client;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.admin.model.GetScenariosResult;
 import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.List;
+
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.List;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-
 class HttpAdminClientTest {
-    private static final String ADMIN_TEST_PREFIX = "/admin-test";
+  private static final String ADMIN_TEST_PREFIX = "/admin-test";
 
-    @Test
-    public void shouldSetHttpClientInConstructor() {
-        CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-        HttpAdminClient adminClient = new HttpAdminClient(
-                "https", "localhost", 8080, "localhost", httpClient);
+  @Test 
+  void shouldSetHttpClientInConstructor() {
+    var httpClient = HttpClientBuilder.create().build();
+    HttpAdminClient adminClient = new HttpAdminClient("https", "localhost", 8080, "localhost", httpClient);
+    assertThat(adminClient).hasFieldOrProperty("httpClient");
+  }
 
-        assertThat(adminClient).hasFieldOrProperty("httpClient");
-    }
+  @Test
+  void returnsOptionsWhenCallingGetOptions() {
+    var client = new HttpAdminClient("localhost", 8080);
+    assertThat(client.getOptions().portNumber()).isEqualTo(8080);
+    assertThat(client.getOptions().bindAddress()).isEqualTo("localhost");
+  }
 
-    @Test
-    void returnsOptionsWhenCallingGetOptions() {
-        var client = new HttpAdminClient("localhost", 8080);
-        assertThat(client.getOptions().portNumber()).isEqualTo(8080);
-        assertThat(client.getOptions().bindAddress()).isEqualTo("localhost");
-    }
+  @Test
+  void shouldSendEmptyRequestForResetToDefaultMappings() {
+    var server = new WireMockServer(options().dynamicPort());
+    server.start();
+    server.stubFor(
+        post(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/mappings/reset"))
+            .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
+            .willReturn(ok()));
+    var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
 
-    @Test
-    void shouldSendEmptyRequestForResetToDefaultMappings() {
-        var server = new WireMockServer(options().dynamicPort());
-        server.start();
-        server.stubFor(
-                post(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/mappings/reset"))
-                        .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
-                        .willReturn(ok()));
-        var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
+    client.resetToDefaultMappings();
+  }
 
-        client.resetToDefaultMappings();
-    }
+  @Test
+  void shouldSendEmptyRequestForResetAll() {
+    var server = new WireMockServer(options().dynamicPort());
+    server.start();
+    server.stubFor(
+        post(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/reset"))
+            .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
+            .willReturn(ok()));
+    var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
 
-    @Test
-    void shouldSendEmptyRequestForResetAll() {
-        var server = new WireMockServer(options().dynamicPort());
-        server.start();
-        server.stubFor(
-                post(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/reset"))
-                        .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
-                        .willReturn(ok()));
-        var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
+    client.resetAll();
+  }
 
-        client.resetAll();
-    }
+  @Test
+  void shouldNotSendEntityForGetAllScenarios() {
+    var server = new WireMockServer(options().dynamicPort());
+    server.start();
+    var expectedResponse = new GetScenariosResult(List.of(Scenario.inStartedState("scn1")));
+    server.stubFor(
+        get(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/scenarios"))
+            .withHeader(HttpHeaders.CONTENT_LENGTH, absent())
+            .willReturn(jsonResponse(expectedResponse, HttpStatus.SC_OK)));
+    var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
 
-    @Test
-    void shouldNotSendEntityForGetAllScenarios() {
-        var server = new WireMockServer(options().dynamicPort());
-        server.start();
-        var expectedResponse = new GetScenariosResult(List.of(Scenario.inStartedState("scn1")));
-        server.stubFor(
-                get(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/scenarios"))
-                        .withHeader(HttpHeaders.CONTENT_LENGTH, absent())
-                        .willReturn(jsonResponse(expectedResponse, HttpStatus.SC_OK)));
-        var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
+    assertThat(client.getAllScenarios()).usingRecursiveComparison().isEqualTo(expectedResponse);
+  }
 
-        assertThat(client.getAllScenarios()).usingRecursiveComparison().isEqualTo(expectedResponse);
-    }
+  @Test
+  void reuseConnections() throws InterruptedException, IOException {
+    var server = new SingleConnectionServer();
+    server.start();
+    var client = new HttpAdminClient("localhost", server.getPort(), ADMIN_TEST_PREFIX);
 
-    @Test
-    void reuseConnections() throws InterruptedException, IOException {
-        var server = new SingleConnectionServer();
-        server.start();
-        var client = new HttpAdminClient("localhost", server.getPort(), ADMIN_TEST_PREFIX);
+    client.resetAll();
+    client.resetAll();
+    server.stop();
+  }
 
-        client.resetAll();
-        client.resetAll();
-        server.stop();
-    }
+  @Test
+  void shouldThrowExceptionWithUrlForStubMappingFromNonWireMockServerPort() throws IOException {
+    var nonWireMockServer = HttpServer.create(new InetSocketAddress(0), 0);
+    nonWireMockServer.start();
+    var serverPort = nonWireMockServer.getAddress().getPort();
+    var client = new HttpAdminClient("localhost", serverPort, ADMIN_TEST_PREFIX);
+    var mapping = post(urlPathMatching("/test")).willReturn(ok()).build();
+    var thrown = assertThrows(InvalidInputException.class, () -> client.addStubMapping(mapping));
+    assertThat(thrown.getErrors().getErrors()).hasSize(1);
+    var thrownError = thrown.getErrors().first();
+    assertThat(thrownError.getCode()).isEqualTo(10);
+    assertThat(thrownError.getTitle()).isEqualTo("Error parsing JSON");
+    assertThat(thrownError.getDetail())
+        .matches(
+            "Error parsing response body '(.|\n)*' with status code 404 for http://localhost:"
+                + serverPort
+                + "/admin-test/__admin/mappings. Error: (.|\n)*");
 
-    @Test
-    void shouldThrowExceptionWithUrlForStubMappingFromNonWireMockServerPort() throws IOException {
-        var nonWireMockServer = HttpServer.create(new InetSocketAddress(0), 0);
-        nonWireMockServer.start();
-        var serverPort = nonWireMockServer.getAddress().getPort();
-        var client = new HttpAdminClient("localhost", serverPort, ADMIN_TEST_PREFIX);
-        var mapping = post(urlPathMatching("/test")).willReturn(ok()).build();
-        var thrown = assertThrows(InvalidInputException.class, () -> client.addStubMapping(mapping));
-        assertThat(thrown.getErrors().getErrors()).hasSize(1);
-        var thrownError = thrown.getErrors().first();
-        assertThat(thrownError.getCode()).isEqualTo(10);
-        assertThat(thrownError.getTitle()).isEqualTo("Error parsing JSON");
-        assertThat(thrownError.getDetail())
-                .matches(
-                        "Error parsing response body '(.|\n)*' with status code 404 for http://localhost:"
-                                + serverPort
-                                + "/admin-test/__admin/mappings. Error: (.|\n)*");
-
-        nonWireMockServer.stop(0);
-    }
+    nonWireMockServer.stop(0);
+  }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
 
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpStatus;
@@ -38,11 +37,11 @@ import org.junit.jupiter.api.Test;
 class HttpAdminClientTest {
   private static final String ADMIN_TEST_PREFIX = "/admin-test";
 
-  @Test 
+  @Test
   void shouldSetHttpClientInConstructor() {
     var httpClient = HttpClientBuilder.create().build();
-    HttpAdminClient adminClient = new HttpAdminClient("https", "localhost", 8080, "localhost", httpClient);
-    assertThat(adminClient).hasFieldOrProperty("httpClient");
+    HttpAdminClient adminClient = new HttpAdminClient("https", "localhost", 8080, "","localhost", httpClient);
+    assertThat(adminClient).hasFieldOrPropertyWithValue("httpClient", adminClient);
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
@@ -15,102 +15,115 @@
  */
 package com.github.tomakehurst.wiremock.client;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.admin.model.GetScenariosResult;
 import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.sun.net.httpserver.HttpServer;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.List;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
 class HttpAdminClientTest {
-  private static final String ADMIN_TEST_PREFIX = "/admin-test";
+    private static final String ADMIN_TEST_PREFIX = "/admin-test";
 
-  @Test
-  void returnsOptionsWhenCallingGetOptions() {
-    var client = new HttpAdminClient("localhost", 8080);
-    assertThat(client.getOptions().portNumber()).isEqualTo(8080);
-    assertThat(client.getOptions().bindAddress()).isEqualTo("localhost");
-  }
+    @Test
+    public void shouldSetHttpClientInConstructor() {
+        CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+        HttpAdminClient adminClient = new HttpAdminClient(
+                "https", "localhost", 8080, "localhost", httpClient);
 
-  @Test
-  void shouldSendEmptyRequestForResetToDefaultMappings() {
-    var server = new WireMockServer(options().dynamicPort());
-    server.start();
-    server.stubFor(
-        post(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/mappings/reset"))
-            .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
-            .willReturn(ok()));
-    var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
+        assertThat(adminClient).hasFieldOrProperty("httpClient");
+    }
 
-    client.resetToDefaultMappings();
-  }
+    @Test
+    void returnsOptionsWhenCallingGetOptions() {
+        var client = new HttpAdminClient("localhost", 8080);
+        assertThat(client.getOptions().portNumber()).isEqualTo(8080);
+        assertThat(client.getOptions().bindAddress()).isEqualTo("localhost");
+    }
 
-  @Test
-  void shouldSendEmptyRequestForResetAll() {
-    var server = new WireMockServer(options().dynamicPort());
-    server.start();
-    server.stubFor(
-        post(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/reset"))
-            .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
-            .willReturn(ok()));
-    var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
+    @Test
+    void shouldSendEmptyRequestForResetToDefaultMappings() {
+        var server = new WireMockServer(options().dynamicPort());
+        server.start();
+        server.stubFor(
+                post(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/mappings/reset"))
+                        .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
+                        .willReturn(ok()));
+        var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
 
-    client.resetAll();
-  }
+        client.resetToDefaultMappings();
+    }
 
-  @Test
-  void shouldNotSendEntityForGetAllScenarios() {
-    var server = new WireMockServer(options().dynamicPort());
-    server.start();
-    var expectedResponse = new GetScenariosResult(List.of(Scenario.inStartedState("scn1")));
-    server.stubFor(
-        get(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/scenarios"))
-            .withHeader(HttpHeaders.CONTENT_LENGTH, absent())
-            .willReturn(jsonResponse(expectedResponse, HttpStatus.SC_OK)));
-    var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
+    @Test
+    void shouldSendEmptyRequestForResetAll() {
+        var server = new WireMockServer(options().dynamicPort());
+        server.start();
+        server.stubFor(
+                post(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/reset"))
+                        .withHeader(HttpHeaders.CONTENT_LENGTH, equalTo("0"))
+                        .willReturn(ok()));
+        var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
 
-    assertThat(client.getAllScenarios()).usingRecursiveComparison().isEqualTo(expectedResponse);
-  }
+        client.resetAll();
+    }
 
-  @Test
-  void reuseConnections() throws InterruptedException, IOException {
-    var server = new SingleConnectionServer();
-    server.start();
-    var client = new HttpAdminClient("localhost", server.getPort(), ADMIN_TEST_PREFIX);
+    @Test
+    void shouldNotSendEntityForGetAllScenarios() {
+        var server = new WireMockServer(options().dynamicPort());
+        server.start();
+        var expectedResponse = new GetScenariosResult(List.of(Scenario.inStartedState("scn1")));
+        server.stubFor(
+                get(urlPathEqualTo(ADMIN_TEST_PREFIX + "/__admin/scenarios"))
+                        .withHeader(HttpHeaders.CONTENT_LENGTH, absent())
+                        .willReturn(jsonResponse(expectedResponse, HttpStatus.SC_OK)));
+        var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
 
-    client.resetAll();
-    client.resetAll();
-    server.stop();
-  }
+        assertThat(client.getAllScenarios()).usingRecursiveComparison().isEqualTo(expectedResponse);
+    }
 
-  @Test
-  void shouldThrowExceptionWithUrlForStubMappingFromNonWireMockServerPort() throws IOException {
-    var nonWireMockServer = HttpServer.create(new InetSocketAddress(0), 0);
-    nonWireMockServer.start();
-    var serverPort = nonWireMockServer.getAddress().getPort();
-    var client = new HttpAdminClient("localhost", serverPort, ADMIN_TEST_PREFIX);
-    var mapping = post(urlPathMatching("/test")).willReturn(ok()).build();
-    var thrown = assertThrows(InvalidInputException.class, () -> client.addStubMapping(mapping));
-    assertThat(thrown.getErrors().getErrors()).hasSize(1);
-    var thrownError = thrown.getErrors().first();
-    assertThat(thrownError.getCode()).isEqualTo(10);
-    assertThat(thrownError.getTitle()).isEqualTo("Error parsing JSON");
-    assertThat(thrownError.getDetail())
-        .matches(
-            "Error parsing response body '(.|\n)*' with status code 404 for http://localhost:"
-                + serverPort
-                + "/admin-test/__admin/mappings. Error: (.|\n)*");
+    @Test
+    void reuseConnections() throws InterruptedException, IOException {
+        var server = new SingleConnectionServer();
+        server.start();
+        var client = new HttpAdminClient("localhost", server.getPort(), ADMIN_TEST_PREFIX);
 
-    nonWireMockServer.stop(0);
-  }
+        client.resetAll();
+        client.resetAll();
+        server.stop();
+    }
+
+    @Test
+    void shouldThrowExceptionWithUrlForStubMappingFromNonWireMockServerPort() throws IOException {
+        var nonWireMockServer = HttpServer.create(new InetSocketAddress(0), 0);
+        nonWireMockServer.start();
+        var serverPort = nonWireMockServer.getAddress().getPort();
+        var client = new HttpAdminClient("localhost", serverPort, ADMIN_TEST_PREFIX);
+        var mapping = post(urlPathMatching("/test")).willReturn(ok()).build();
+        var thrown = assertThrows(InvalidInputException.class, () -> client.addStubMapping(mapping));
+        assertThat(thrown.getErrors().getErrors()).hasSize(1);
+        var thrownError = thrown.getErrors().first();
+        assertThat(thrownError.getCode()).isEqualTo(10);
+        assertThat(thrownError.getTitle()).isEqualTo("Error parsing JSON");
+        assertThat(thrownError.getDetail())
+                .matches(
+                        "Error parsing response body '(.|\n)*' with status code 404 for http://localhost:"
+                                + serverPort
+                                + "/admin-test/__admin/mappings. Error: (.|\n)*");
+
+        nonWireMockServer.stop(0);
+    }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

Fixes GH-2931

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [x] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
