### PR TITLE
improve performance of EqualToXmlPattern.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
@@ -151,7 +151,6 @@ public class EqualToXmlPattern extends StringValuePattern {
                   .withTest(value)
                   .withComparisonController(ComparisonControllers.StopWhenDifferent)
                   .ignoreWhitespace()
-                  .ignoreComments()
                   .withDifferenceEvaluator(diffEvaluator)
                   .withNodeMatcher(new OrderInvariantNodeMatcher(ignoreOrderOfSameNode))
                   .withDocumentBuilderFactory(DOCUMENT_BUILDER_FACTORY)
@@ -188,7 +187,6 @@ public class EqualToXmlPattern extends StringValuePattern {
               DiffBuilder.compare(Input.from(expectedValue))
                   .withTest(value)
                   .ignoreWhitespace()
-                  .ignoreComments()
                   .withDifferenceEvaluator(diffEvaluator)
                   .withComparisonListeners(
                       (comparison, outcome) -> {
@@ -228,6 +226,7 @@ public class EqualToXmlPattern extends StringValuePattern {
   private static DocumentBuilderFactory newDocumentBuilderFactory() {
     DocumentBuilderFactory factory = Xml.newDocumentBuilderFactory();
     try {
+      factory.setFeature("http://apache.org/xml/features/include-comments", false);
       factory.setFeature("http://xml.org/sax/features/namespaces", true);
     } catch (ParserConfigurationException e) {
       throwUnchecked(e);

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -568,4 +568,12 @@ public class EqualToXmlPatternTest {
     MatchResult result = pattern.match("<body><entry/><entry/></body>");
     assertTrue(result.isExactMatch());
   }
+
+  @Test
+  void matchesIfCommentsDiffer() {
+    EqualToXmlPattern pattern =
+        new EqualToXmlPattern("<body><!-- Comment --><entry/><entry/></body>", false, true);
+    MatchResult result = pattern.match("<body><entry/><entry/><!-- A different comment --></body>");
+    assertTrue(result.isExactMatch());
+  }
 }


### PR DESCRIPTION
removes use of DiffBuilder.ignoreComments which performs an xslt transform on the provided XML documents which is very memory intensive. now comments are ignored at read/parse time.

as part of this change, the Xml utility class was also refactored to (hopefully) make it more reusable.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)