### PR TITLE
make EqualToXmlPattern namespace aware by default.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Thomas Akehurst
+ * Copyright (C) 2024-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,8 @@ public class FormatXmlHelper extends AbstractFormattingHelper {
     return "XML";
   }
 
-  private final DocumentBuilderFactory documentBuilderFactory = Xml.newDocumentBuilderFactory();
+  private final DocumentBuilderFactory documentBuilderFactory =
+      Xml.DEFAULT_DOCUMENT_BUILDER_FACTORY;
 
   private final TransformerFactory transformerFactory;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -450,7 +450,8 @@ public class EqualToXmlPatternTest {
             + "    <st:thing>Match this</st:thing>\n"
             + "</stuff>";
 
-    MatchResult matchResult = equalToXml(expected).match(actual);
+    MatchResult matchResult =
+        equalToXml(expected).exemptingComparisons(NAMESPACE_URI).match(actual);
 
     assertTrue(matchResult.isExactMatch());
   }


### PR DESCRIPTION
this should have always been the case but seems to not be in certain situations.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)