### PR TITLE
Bump jetty 12 version to `12.0.16`

### DIFF
--- a/wiremock-jetty12/build.gradle
+++ b/wiremock-jetty12/build.gradle
@@ -29,7 +29,7 @@ java {
 
 project.ext {
   versions = [
-    jetty        : '12.0.14',
+    jetty        : '12.0.16',
     junitJupiter : '5.10.2'
   ]
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Bump the version of jetty 12 in the jetty 12 release of WireMock to version `12.0.16`

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
