### PR TITLE
Update after-pattern.yaml to fix typo

### DIFF
--- a/src/main/resources/swagger/schemas/after-pattern.yaml
+++ b/src/main/resources/swagger/schemas/after-pattern.yaml
@@ -1,4 +1,4 @@
-title: Before datetime
+title: After datetime
 type: object
 properties:
   after:


### PR DESCRIPTION
Correctly document after-pattern.yaml as being after a datetime rather than before
