### PR TITLE
Disable problematic protocol update for httpclient 5.4

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
@@ -81,6 +81,7 @@ public class HttpClientFactory {
             .setDefaultRequestConfig(
                 RequestConfig.custom()
                     .setResponseTimeout(Timeout.ofMilliseconds(timeoutMilliseconds))
+                    .setProtocolUpgradeEnabled(false)
                     .build());
 
     if (disableConnectionReuse) {


### PR DESCRIPTION
https://github.com/wiremock/wiremock/issues/2948

With the update to apache httpclient 5.4 a new feature creeps into the codebase.
It adds TLS Upgrade (https://datatracker.ietf.org/doc/html/rfc2817#section-3.1) headers as a default.

This in turn breaks all communication via envoy (eg. k8s/istio)

    https://github.com/envoyproxy/envoy/issues/36305
    https://issues.apache.org/jira/browse/HTTPCLIENT-2344

This fix sets the "protocolUpgradeEnabled" flag for the httpclient to false (default is true).

## References

https://github.com/wiremock/wiremock/issues/2948

## Submitter checklist

- [-] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [?] Test coverage that demonstrates that the change works as expected
- [-] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
