### PR TITLE
Fix OpenAPI 3.0 schemas

### DIFF
--- a/src/main/resources/swagger/schemas/equal-to-json-pattern.yaml
+++ b/src/main/resources/swagger/schemas/equal-to-json-pattern.yaml
@@ -2,9 +2,15 @@ title: JSON equals
 type: object
 properties:
   equalToJson:
-    type: string
-    example: |-
-      { "message": "hello" }
+    oneOf:
+      - type: object
+        description: The JSON object to match.
+        example:
+          message: hello
+      - type: string
+        description: A JSON-encoded JSON string to match.
+        example: |-
+          { "message": "hello" }
   ignoreExtraElements:
     type: boolean
   ignoreArrayOrder:

--- a/src/main/resources/swagger/schemas/equal-to-json-pattern.yaml
+++ b/src/main/resources/swagger/schemas/equal-to-json-pattern.yaml
@@ -3,7 +3,7 @@ type: object
 properties:
   equalToJson:
     type: string
-    example: |
+    example: |-
       { "message": "hello" }
   ignoreExtraElements:
     type: boolean

--- a/src/main/resources/swagger/schemas/equal-to-xml-pattern.yaml
+++ b/src/main/resources/swagger/schemas/equal-to-xml-pattern.yaml
@@ -3,12 +3,13 @@ type: object
 properties:
   equalToXml:
     type: string
-    example: "<amount>123</amount>"
+    example: |-
+      <amount>123</amount>
   enablePlaceholders:
     type: boolean
   placeholderOpeningDelimiterRegex:
     type: string
-    example: "["
+    example: "\\["
   placeholderClosingDelimiterRegex:
     type: string
     example: "]"

--- a/src/main/resources/swagger/schemas/logged-request.yaml
+++ b/src/main/resources/swagger/schemas/logged-request.yaml
@@ -15,19 +15,19 @@ properties:
   headers:
     description: 'Header patterns to match against in the <key>: { "<predicate>": "<value>" } form'
     type: object
-    example: |-
-      {
-        "Connection": { "equalTo": "keep-alive" },
-        "Host": { "equalTo": "localhost:56738" },
-        "User-Agent": { "equalTo": "Apache-HttpClient/4.5.1 (Java/1.7.0_51)" }
-      }
+    example:
+      Connection:
+        equalTo: keep-alive
+      Host:
+        equalTo: "localhost:56738"
+      User-Agent:
+        equalTo: "Apache-HttpClient/4.5.1 (Java/1.7.0_51)"
   cookies:
     description: 'Cookie patterns to match against in the <key>: { "<predicate>": "<value>" } form'
     type: object
-    example: |-
-      {
-        "user_id": { "equalTo": "tom1234" }
-      }
+    example:
+      user_id:
+        equalTo: tom1234
   body:
     description: Body string to match against
     type: string

--- a/src/main/resources/swagger/schemas/logged-request.yaml
+++ b/src/main/resources/swagger/schemas/logged-request.yaml
@@ -7,22 +7,27 @@ properties:
   url:
     description: The path and query to match exactly against
     type: string
-    example: "/received-request/2"
+    example: "/received-request/2?foo=bar"
   absoluteUrl:
     description: The full URL to match against
     type: string
-    example: "http://localhost:56738/received-request/2"
+    example: "http://localhost:56738/received-request/2?foo=bar"
   headers:
     description: 'Header patterns to match against in the <key>: { "<predicate>": "<value>" } form'
     type: object
-    example:
-      Connection: keep-alive
-      Host: localhost:56738
-      User-Agent: Apache-HttpClient/4.5.1 (Java/1.7.0_51)
+    example: |-
+      {
+        "Connection": { "equalTo": "keep-alive" },
+        "Host": { "equalTo": "localhost:56738" },
+        "User-Agent": { "equalTo": "Apache-HttpClient/4.5.1 (Java/1.7.0_51)" }
+      }
   cookies:
     description: 'Cookie patterns to match against in the <key>: { "<predicate>": "<value>" } form'
     type: object
-    example: {}
+    example: |-
+      {
+        "user_id": { "equalTo": "tom1234" }
+      }
   body:
     description: Body string to match against
     type: string

--- a/src/main/resources/swagger/schemas/logged-request.yaml
+++ b/src/main/resources/swagger/schemas/logged-request.yaml
@@ -7,27 +7,22 @@ properties:
   url:
     description: The path and query to match exactly against
     type: string
-    example: "/received-request/2?foo=bar"
+    example: "/received-request/2"
   absoluteUrl:
     description: The full URL to match against
     type: string
-    example: "http://localhost:56738/received-request/2?foo=bar"
+    example: "http://localhost:56738/received-request/2"
   headers:
     description: 'Header patterns to match against in the <key>: { "<predicate>": "<value>" } form'
     type: object
     example:
-      Connection:
-        equalTo: keep-alive
-      Host:
-        equalTo: "localhost:56738"
-      User-Agent:
-        equalTo: "Apache-HttpClient/4.5.1 (Java/1.7.0_51)"
+      Connection: keep-alive
+      Host: localhost:56738
+      User-Agent: Apache-HttpClient/4.5.1 (Java/1.7.0_51)
   cookies:
     description: 'Cookie patterns to match against in the <key>: { "<predicate>": "<value>" } form'
     type: object
-    example:
-      user_id:
-        equalTo: tom1234
+    example: {}
   body:
     description: Body string to match against
     type: string

--- a/src/main/resources/swagger/schemas/matches-json-schema-pattern.yaml
+++ b/src/main/resources/swagger/schemas/matches-json-schema-pattern.yaml
@@ -16,10 +16,5 @@ properties:
         required:
           - expression
 
-  xPathNamespaces:
-    type: object
-    additionalProperties:
-      type: string
-
 required:
   - matchesJsonSchema

--- a/src/main/resources/swagger/schemas/matches-json-schema-pattern.yaml
+++ b/src/main/resources/swagger/schemas/matches-json-schema-pattern.yaml
@@ -3,18 +3,43 @@ type: object
 properties:
   matchesJsonSchema:
     oneOf:
-      - type: string
-        example: "//Order/Amount"
       - type: object
-        allOf:
-          - properties:
-              expression:
-                type: string
-                example: "//Order/Amount"
-          - $ref: "content-pattern.yaml"
+        description: A valid JSON schema object
+        example: |-
+          {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+            "name": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
+      - type: string
+        description: A valid string containing a JSON-encoded JSON schema
+        example: |-
+          {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+            "name": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
 
-        required:
-          - expression
+  schemaVersion:
+    type: string
+    description: The JSON schema version to interpret the schema against
+    example: "V202012"
 
 required:
   - matchesJsonSchema

--- a/src/main/resources/swagger/schemas/matches-json-schema-pattern.yaml
+++ b/src/main/resources/swagger/schemas/matches-json-schema-pattern.yaml
@@ -2,40 +2,27 @@ title: JSON Schema match
 type: object
 properties:
   matchesJsonSchema:
-    oneOf:
-      - type: object
-        description: A valid JSON schema object
-        example:
-          type: object
-          required:
-            - name
-          properties:
-            name:
-              type: string
-            tag:
-              type: string
-
-      - type: string
-        description: A valid string containing a JSON-encoded JSON schema
-        example: |-
-          {
-            "type": "object",
-            "required": [
-              "name"
-            ],
-            "properties": {
-            "name": {
-              "type": "string"
-            },
-            "tag": {
-              "type": "string"
-            }
-          }
+    type: object
+    description: A valid JSON schema object
+    example:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
 
   schemaVersion:
-    type: string
     description: The JSON schema version to interpret the schema against
     example: "V202012"
+    enum:
+      - V4
+      - V6
+      - V7
+      - V201909
+      - V202012
 
 required:
   - matchesJsonSchema

--- a/src/main/resources/swagger/schemas/matches-json-schema-pattern.yaml
+++ b/src/main/resources/swagger/schemas/matches-json-schema-pattern.yaml
@@ -5,20 +5,16 @@ properties:
     oneOf:
       - type: object
         description: A valid JSON schema object
-        example: |-
-          {
-            "type": "object",
-            "required": [
-              "name"
-            ],
-            "properties": {
-            "name": {
-              "type": "string"
-            },
-            "tag": {
-              "type": "string"
-            }
-          }
+        example:
+          type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+            tag:
+              type: string
+
       - type: string
         description: A valid string containing a JSON-encoded JSON schema
         example: |-

--- a/src/main/resources/swagger/schemas/not-pattern.yaml
+++ b/src/main/resources/swagger/schemas/not-pattern.yaml
@@ -1,4 +1,4 @@
-title: NOT modifier
+title: Logical NOT modifier
 type: object
 properties:
   not:

--- a/src/main/resources/swagger/schemas/request-pattern.yaml
+++ b/src/main/resources/swagger/schemas/request-pattern.yaml
@@ -1,5 +1,5 @@
 type: object
-example: |
+example: |-
   {
     "urlPath" : "/charges",
     "method" : "POST",
@@ -42,7 +42,7 @@ properties:
 
   pathParameters:
     type: object
-    description: |
+    description: |-
       Path parameter patterns to match against in the <key>: { "<predicate>": "<value>" } form. Can only
       be used when the urlPathPattern URL match type is in use and all keys must be present as variables
       in the path template.
@@ -78,6 +78,7 @@ properties:
     required:
       - username
       - password
+
   cookies:
     type: object
     description: 'Cookie patterns to match against in the <key>: { "<predicate>": "<value>" } form'
@@ -85,7 +86,7 @@ properties:
       $ref: "content-pattern.yaml"
   bodyPatterns:
     type: array
-    description: 'Request body patterns to match against in the <key>: { "<predicate>": "<value>" } form'
+    description: 'Request body patterns to match against in the { "<predicate>": "<value>" } form'
     items:
       $ref: "content-pattern.yaml"
 
@@ -124,6 +125,6 @@ properties:
 
         bodyPatterns:
           type: array
-          description: 'Body patterns to match against in the <key>: { "<predicate>": "<value>" } form'
+          description: 'Body patterns to match against in the { "<predicate>": "<value>" } form'
           items:
             $ref: "content-pattern.yaml"

--- a/src/main/resources/swagger/schemas/request-pattern.yaml
+++ b/src/main/resources/swagger/schemas/request-pattern.yaml
@@ -8,6 +8,7 @@ example: |-
         "equalTo" : "application/json"
       }
     }
+  }
 properties:
   scheme:
     type: string

--- a/src/main/resources/swagger/wiremock-admin-api.yaml
+++ b/src/main/resources/swagger/wiremock-admin-api.yaml
@@ -334,8 +334,6 @@ paths:
             application/json:
               example:
                 $ref: "examples/requests.yaml"
-                    
-                    
 
   /__admin/requests/remove-by-metadata:
     post:
@@ -548,7 +546,7 @@ paths:
                   type: string
                 example: ["file1.json", "file2.json", "file3.txt"]
           description: All scenarios
-          
+
   /__admin/files/{fileId}:
     parameters:
       - description: The name of the file
@@ -576,7 +574,7 @@ paths:
       requestBody:
         content:
           application/octet-stream:
-            schema: 
+            schema:
               type: string
               format: byte
       responses:
@@ -635,7 +633,6 @@ paths:
       responses:
         '200':
           description: Server will be shut down
-          
 
   /__admin/version:
     get:
@@ -647,7 +644,7 @@ paths:
       responses:
         '200':
           description: Successfully returned the version of the WireMock server
-          content: 
+          content:
             application/json:
               schema:
                 type: object


### PR DESCRIPTION
Spotted a few more issues with the OpenAPI docs over the weekend, so have put a PR together to try and address them in bulk. Hope it is all okay.

- Fix `equal-to-json` to document that using a raw object is also valid, and add example.
- Rewrite schema for `matches-json-schema` as it was just copied from the `matches-xpath` schema.
- Removed undocumented `xPathNamespaces` attributes from `matches-json-schema`.
- Update description of `not` to match `or` and `and`.
- Fix example in `request-pattern` that was not valid JSON.
- Fix headers example in `logged-request`.
- Correctly trim whitespace out of `equal-to-pattern` example.
- Remove spurious whitespace from admin API descriptors.
- Convert raw JSON examples to raw YAML objects to make the example format clear in any generated Swagger/OA3 HTML pages.