### PR TITLE
Drop to the version of spotless where we didn't have any issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
   id 'idea'
   id 'eclipse'
   id 'project-report'
-  id 'com.diffplug.spotless' version '7.0.2'
+  id 'com.diffplug.spotless' version '6.25.0'
   id 'com.github.johnrengelman.shadow' version '8.1.1'
   id "org.sonarqube" version "6.0.1.5171"
   id 'jacoco'

--- a/wiremock-jetty12/build.gradle
+++ b/wiremock-jetty12/build.gradle
@@ -12,7 +12,7 @@ plugins {
   id 'java-test-fixtures'
   id 'signing'
   id 'maven-publish'
-  id 'com.diffplug.spotless' version '7.0.2'
+  id 'com.diffplug.spotless' version '6.25.0'
   id "org.sonarqube" version "6.0.1.5171"
   id 'jacoco'
   id 'idea'


### PR DESCRIPTION
When we updated to `7.x.x` we started having issues where files that hadn't been changed were reporting headers that needed updating.

This has been reported here:
https://github.com/diffplug/spotless/issues/2404

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
