### PR TITLE
chore: remove json-smart dependency constraint.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,12 +129,6 @@ dependencies {
 
   testImplementation 'org.openjdk.jmh:jmh-core:1.37'
   testImplementation 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
-
-  constraints {
-    implementation "net.minidev:json-smart:2.5.2", {
-      because 'Pinning this above the transitive version from json-path to get CVE fix'
-    }
-  }
 }
 
 allprojects {


### PR DESCRIPTION
json-path is no longer lagging behind on its dependency version.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
