### PR TITLE
Use camel-case format for the fileName property in the request-pattern schema

### DIFF
--- a/src/main/resources/swagger/schemas/request-pattern.yaml
+++ b/src/main/resources/swagger/schemas/request-pattern.yaml
@@ -107,7 +107,7 @@ properties:
       properties:
         name:
           type: string
-        filename:
+        fileName:
           type: string
         matchingType:
           type: string


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

#2888 introduced the fileName property in `MultipartValuePattern` and along with it in the `request-pattern.yaml` schema.
In the former, it was deserialized as `fileName` while in the latter it was defined as `filename`. Now both use `fileName`.

## References

- #2888

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
