### PR TITLE
fix: handle unbound ns prefixes when printing xml.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
@@ -126,7 +126,13 @@ public class EqualToXmlPattern extends StringValuePattern {
 
   @Override
   public String getExpected() {
-    return Xml.prettyPrint(getValue());
+    try {
+      // as of writing, Xml.prettyPrint will throw an exception if the provided XML has unbound
+      // namespace prefixes.
+      return Xml.prettyPrint(getValue());
+    } catch (Exception e) {
+      return getValue();
+    }
   }
 
   public Boolean isEnablePlaceholders() {

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -1032,4 +1032,11 @@ public class EqualToXmlPatternTest {
     assertFalse(patternWithExclusion.match(actual).isExactMatch());
     assertThat(patternWithExclusion.match(actual).getDistance(), not(is(0.0)));
   }
+
+  @Test
+  void getExpectedHandlesUndeclaredNamespacePrefixes() {
+    String expected = "<abc asdas:atdf=\"asdas\">123</abc>";
+    EqualToXmlPattern pattern = equalToXml(expected, EqualToXmlPattern.NamespaceAwareness.NONE);
+    assertThat(pattern.getExpected(), is(expected));
+  }
 }


### PR DESCRIPTION
Currently, if the expected XML of an EqualToXmlPattern contains unbounded namespace prefixes, calling `getExpected()` on the pattern will throw an exception. This PR fixes that.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

