### PR TITLE
Always use the system default `DocumentBuilderFactory`, `TransformerFactory` and `XPathFactory`

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/Xml.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/Xml.java
@@ -48,8 +48,8 @@ public class Xml {
 
   public static void optimizeFactoriesLoading() {
     try {
-      String transformerFactoryImpl = TransformerFactory.newInstance().getClass().getName();
-      String xPathFactoryImpl = XPathFactory.newInstance().getClass().getName();
+      String transformerFactoryImpl = TransformerFactory.newDefaultInstance().getClass().getName();
+      String xPathFactoryImpl = XPathFactory.newDefaultInstance().getClass().getName();
 
       System.setProperty(TransformerFactory.class.getName(), transformerFactoryImpl);
       System.setProperty(
@@ -97,7 +97,7 @@ public class Xml {
                   .getDeclaredConstructor()
                   .newInstance();
     } catch (Exception e) {
-      transformerFactory = TransformerFactory.newInstance();
+      transformerFactory = TransformerFactory.newDefaultInstance();
     }
     transformerFactory.setAttribute("indent-number", 2);
     transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
@@ -148,7 +148,7 @@ public class Xml {
           new BuilderPerThreadDocumentBuilderFactory(
               new SilentErrorDocumentBuilderFactory(
                   new SkipResolvingEntitiesDocumentBuilderFactory(
-                      DocumentBuilderFactory.newInstance())));
+                      DocumentBuilderFactory.newDefaultInstance())));
       dbf.setFeature("http://xml.org/sax/features/validation", false);
       dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false);
       dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);

--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/XmlNode.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/XmlNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Thomas Akehurst
+ * Copyright (C) 2020-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public abstract class XmlNode {
   protected static final ThreadLocal<XPath> XPATH_CACHE =
       ThreadLocal.withInitial(
           () -> {
-            final XPathFactory xPathfactory = XPathFactory.newInstance();
+            final XPathFactory xPathfactory = XPathFactory.newDefaultInstance();
             return xPathfactory.newXPath();
           });
 
@@ -52,7 +52,7 @@ public abstract class XmlNode {
                           .getDeclaredConstructor()
                           .newInstance();
             } catch (Exception e) {
-              transformerFactory = TransformerFactory.newInstance();
+              transformerFactory = TransformerFactory.newDefaultInstance();
             }
             transformerFactory.setAttribute("indent-number", 2);
 


### PR DESCRIPTION
Closes #2454
Related #2913

Followup to recently merged https://github.com/wiremock/wiremock/pull/2918 which solved the issue partly.

The `newInstance()` method of aforementioned classes may return a different implementation based on classes present on classpath. For example when `oracle.xml.jaxp.JXDocumentBuilderFactory` is present on the classpath, the use use of the `http://xml.org/sax/features/validation` attribute in the `Xml.java` file causes `ParserConfigurationException`.

The `newDefaultInstance()` method ensures consistency across different environment by using the same implementation irrespective to the classpath.

<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
