### PR TITLE
fix: use thread local document builder.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/Xml.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/Xml.java
@@ -43,21 +43,21 @@ public class Xml {
 
   public static final DocumentBuilderFactory DEFAULT_DOCUMENT_BUILDER_FACTORY =
       new DelegateDocumentBuilderFactory(newDocumentBuilderFactory()) {
-        private final DocumentBuilder documentBuilder;
+        // DocumentBuilder is NOT thread safe.
+        private final ThreadLocal<DocumentBuilder> documentBuilder =
+            ThreadLocal.withInitial(this::build);
 
-        {
-          DocumentBuilder db;
+        private DocumentBuilder build() {
           try {
-            db = delegate.newDocumentBuilder();
+            return delegate.newDocumentBuilder();
           } catch (ParserConfigurationException e) {
-            db = throwUnchecked(e, DocumentBuilder.class);
+            return throwUnchecked(e, DocumentBuilder.class);
           }
-          documentBuilder = db;
         }
 
         @Override
         public DocumentBuilder newDocumentBuilder() {
-          return documentBuilder;
+          return documentBuilder.get();
         }
       };
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/xml/XmlTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/xml/XmlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Thomas Akehurst
+ * Copyright (C) 2020-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@ package com.github.tomakehurst.wiremock.common.xml;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.equalsMultiLine;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
@@ -130,5 +132,23 @@ public class XmlTest {
     ListOrSingle<XmlNode> xmlNodes = xmlDocument.findNodes("/things/fluff/inner[@id=\"123\"]");
 
     assertThat(xmlNodes.toString(), is("<fl:inner fl:code=\"D1\" id=\"123\">Innards</fl:inner>"));
+  }
+
+  @Test
+  void canReadConcurrently() {
+    String xml =
+        "<?xml version=\"1.0\"?>\n"
+            + "<things xmlns:s=\"https://stuff.biz\" id=\"1\">\n"
+            + "    <stuff id=\"1\"/>\n"
+            + "    <fl:fluff xmlns:fl=\"https://fluff.abc\" id=\"2\">\n"
+            + "        <fl:inner id=\"123\" fl:code=\"D1\">Innards</fl:inner>\n"
+            + "        <fl:inner>More Innards</fl:inner>\n"
+            + "    </fl:fluff>\n"
+            + "</things>";
+    int iterations = 10000;
+    IntStream.range(0, iterations)
+        .parallel()
+        .mapToObj(i -> Xml.read(xml))
+        .forEach(document -> assertThat(document, notNullValue()));
   }
 }


### PR DESCRIPTION
DocumentBuilders are not thread safe.

This was a bug I introduced in [this commit](https://github.com/wiremock/wiremock/commit/f91326573547a90fd143252d77961eaa0345dbb1)

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
