### PR TITLE
Xml perf improvements

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/BuilderPerThreadDocumentBuilderFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/BuilderPerThreadDocumentBuilderFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.common.xml;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.uncheck;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+class BuilderPerThreadDocumentBuilderFactory extends DelegateDocumentBuilderFactory {
+
+  // DocumentBuilder is NOT thread safe.
+  private final ThreadLocal<DocumentBuilder> documentBuilderThreadLocal;
+
+  BuilderPerThreadDocumentBuilderFactory(DocumentBuilderFactory delegate) {
+    super(delegate);
+    this.documentBuilderThreadLocal =
+        ThreadLocal.withInitial(() -> uncheck(delegate::newDocumentBuilder, null));
+  }
+
+  @Override
+  public DocumentBuilder newDocumentBuilder() {
+    return documentBuilderThreadLocal.get();
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/DelegateDocumentBuilderFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/DelegateDocumentBuilderFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.common.xml;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+abstract class DelegateDocumentBuilderFactory extends DocumentBuilderFactory {
+  protected final DocumentBuilderFactory delegate;
+
+  DelegateDocumentBuilderFactory(DocumentBuilderFactory delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void setAttribute(String name, Object value) throws IllegalArgumentException {
+    delegate.setAttribute(name, value);
+  }
+
+  @Override
+  public Object getAttribute(String name) throws IllegalArgumentException {
+    return delegate.getAttribute(name);
+  }
+
+  @Override
+  public void setFeature(String name, boolean value) throws ParserConfigurationException {
+    delegate.setFeature(name, value);
+  }
+
+  @Override
+  public boolean getFeature(String name) throws ParserConfigurationException {
+    return delegate.getFeature(name);
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/SilentErrorDocumentBuilderFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/SilentErrorDocumentBuilderFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.common.xml;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+
+import com.github.tomakehurst.wiremock.common.SilentErrorHandler;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+class SilentErrorDocumentBuilderFactory extends DelegateDocumentBuilderFactory {
+
+  SilentErrorDocumentBuilderFactory(DocumentBuilderFactory delegate) {
+    super(delegate);
+  }
+
+  @Override
+  public DocumentBuilder newDocumentBuilder() {
+    try {
+      DocumentBuilder documentBuilder = delegate.newDocumentBuilder();
+      documentBuilder.setErrorHandler(new SilentErrorHandler());
+      return documentBuilder;
+    } catch (ParserConfigurationException e) {
+      return throwUnchecked(e, DocumentBuilder.class);
+    }
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/SkipResolvingEntitiesDocumentBuilderFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/SkipResolvingEntitiesDocumentBuilderFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.common.xml;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+
+import java.io.StringReader;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+
+class SkipResolvingEntitiesDocumentBuilderFactory extends DelegateDocumentBuilderFactory {
+
+  SkipResolvingEntitiesDocumentBuilderFactory(DocumentBuilderFactory delegate) {
+    super(delegate);
+  }
+
+  @Override
+  public DocumentBuilder newDocumentBuilder() {
+    try {
+      DocumentBuilder documentBuilder = delegate.newDocumentBuilder();
+      documentBuilder.setEntityResolver(new ResolveToEmptyString());
+      return documentBuilder;
+    } catch (ParserConfigurationException e) {
+      return throwUnchecked(e, DocumentBuilder.class);
+    }
+  }
+
+  private static class ResolveToEmptyString implements EntityResolver {
+    @Override
+    public InputSource resolveEntity(String publicId, String systemId) {
+      return new InputSource(new StringReader(""));
+    }
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/Xml.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/Xml.java
@@ -40,7 +40,7 @@ import org.xml.sax.SAXException;
 public class Xml {
 
   public static final DocumentBuilderFactory DEFAULT_DOCUMENT_BUILDER_FACTORY =
-      new BuilderPerThreadDocumentBuilderFactory(newDocumentBuilderFactory());
+      newDocumentBuilderFactory();
 
   private Xml() {
     // Hide constructor
@@ -145,9 +145,10 @@ public class Xml {
   public static DocumentBuilderFactory newDocumentBuilderFactory() {
     try {
       DocumentBuilderFactory dbf =
-          new SilentErrorDocumentBuilderFactory(
-              new SkipResolvingEntitiesDocumentBuilderFactory(
-                  DocumentBuilderFactory.newInstance()));
+          new BuilderPerThreadDocumentBuilderFactory(
+              new SilentErrorDocumentBuilderFactory(
+                  new SkipResolvingEntitiesDocumentBuilderFactory(
+                      DocumentBuilderFactory.newInstance())));
       dbf.setFeature("http://xml.org/sax/features/validation", false);
       dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false);
       dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
@@ -161,5 +162,4 @@ public class Xml {
       return throwUnchecked(e, DocumentBuilderFactory.class);
     }
   }
-
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/Xml.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/Xml.java
@@ -20,7 +20,6 @@ import static javax.xml.transform.OutputKeys.INDENT;
 import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
 
 import com.github.tomakehurst.wiremock.common.Errors;
-import com.github.tomakehurst.wiremock.common.SilentErrorHandler;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -35,31 +34,13 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPathFactory;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.w3c.dom.Document;
-import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 public class Xml {
 
   public static final DocumentBuilderFactory DEFAULT_DOCUMENT_BUILDER_FACTORY =
-      new DelegateDocumentBuilderFactory(newDocumentBuilderFactory()) {
-        // DocumentBuilder is NOT thread safe.
-        private final ThreadLocal<DocumentBuilder> documentBuilder =
-            ThreadLocal.withInitial(this::build);
-
-        private DocumentBuilder build() {
-          try {
-            return delegate.newDocumentBuilder();
-          } catch (ParserConfigurationException e) {
-            return throwUnchecked(e, DocumentBuilder.class);
-          }
-        }
-
-        @Override
-        public DocumentBuilder newDocumentBuilder() {
-          return documentBuilder.get();
-        }
-      };
+      new BuilderPerThreadDocumentBuilderFactory(newDocumentBuilderFactory());
 
   private Xml() {
     // Hide constructor
@@ -181,75 +162,4 @@ public class Xml {
     }
   }
 
-  private static class SkipResolvingEntitiesDocumentBuilderFactory
-      extends DelegateDocumentBuilderFactory {
-
-    public SkipResolvingEntitiesDocumentBuilderFactory(DocumentBuilderFactory delegate) {
-      super(delegate);
-    }
-
-    @Override
-    public DocumentBuilder newDocumentBuilder() {
-      try {
-        DocumentBuilder documentBuilder = delegate.newDocumentBuilder();
-        documentBuilder.setEntityResolver(new ResolveToEmptyString());
-        return documentBuilder;
-      } catch (ParserConfigurationException e) {
-        return throwUnchecked(e, DocumentBuilder.class);
-      }
-    }
-
-    private static class ResolveToEmptyString implements EntityResolver {
-      @Override
-      public InputSource resolveEntity(String publicId, String systemId) {
-        return new InputSource(new StringReader(""));
-      }
-    }
-  }
-
-  private static class SilentErrorDocumentBuilderFactory extends DelegateDocumentBuilderFactory {
-
-    public SilentErrorDocumentBuilderFactory(DocumentBuilderFactory delegate) {
-      super(delegate);
-    }
-
-    @Override
-    public DocumentBuilder newDocumentBuilder() {
-      try {
-        DocumentBuilder documentBuilder = delegate.newDocumentBuilder();
-        documentBuilder.setErrorHandler(new SilentErrorHandler());
-        return documentBuilder;
-      } catch (ParserConfigurationException e) {
-        return throwUnchecked(e, DocumentBuilder.class);
-      }
-    }
-  }
-
-  private abstract static class DelegateDocumentBuilderFactory extends DocumentBuilderFactory {
-    protected final DocumentBuilderFactory delegate;
-
-    public DelegateDocumentBuilderFactory(DocumentBuilderFactory delegate) {
-      this.delegate = delegate;
-    }
-
-    @Override
-    public void setAttribute(String name, Object value) throws IllegalArgumentException {
-      delegate.setAttribute(name, value);
-    }
-
-    @Override
-    public Object getAttribute(String name) throws IllegalArgumentException {
-      return delegate.getAttribute(name);
-    }
-
-    @Override
-    public void setFeature(String name, boolean value) throws ParserConfigurationException {
-      delegate.setFeature(name, value);
-    }
-
-    @Override
-    public boolean getFeature(String name) throws ParserConfigurationException {
-      return delegate.getFeature(name);
-    }
-  }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
@@ -89,7 +89,7 @@ public class EqualToXmlPattern extends StringValuePattern {
       @JsonProperty("namespaceAwareness") NamespaceAwareness namespaceAwareness) {
 
     super(expectedValue);
-    documentBuilderFactory = newDocumentBuilderFactory(namespaceAwareness);
+    documentBuilderFactory = getDocumentBuilderFactory(namespaceAwareness);
     // Throw an exception if we can't parse the document
     expectedXmlDoc = Xml.read(expectedValue, documentBuilderFactory);
     this.enablePlaceholders = enablePlaceholders;
@@ -252,14 +252,23 @@ public class EqualToXmlPattern extends StringValuePattern {
     };
   }
 
-  private static DocumentBuilderFactory newDocumentBuilderFactory(
+  private static final DocumentBuilderFactory namespaceAware = newDocumentBuilderFactory(true);
+  private static final DocumentBuilderFactory namespaceUnaware = newDocumentBuilderFactory(false);
+
+  private static DocumentBuilderFactory getDocumentBuilderFactory(
       NamespaceAwareness namespaceAwareness) {
+    if (namespaceAwareness == null || namespaceAwareness == NamespaceAwareness.STRICT) {
+      return namespaceAware;
+    } else {
+      return namespaceUnaware;
+    }
+  }
+
+  private static DocumentBuilderFactory newDocumentBuilderFactory(boolean namespaceAware) {
     DocumentBuilderFactory factory = Xml.newDocumentBuilderFactory();
     try {
       factory.setFeature("http://apache.org/xml/features/include-comments", false);
-      factory.setFeature(
-          "http://xml.org/sax/features/namespaces",
-          namespaceAwareness == null || namespaceAwareness == NamespaceAwareness.STRICT);
+      factory.setFeature("http://xml.org/sax/features/namespaces", namespaceAware);
     } catch (ParserConfigurationException e) {
       throwUnchecked(e);
     }


### PR DESCRIPTION
Caches DocumentBuilderFactories, allowing caching DocumentBuilders, for EqualToXmlPattern.

## References

fix: use thread local document builder. #2977
Fix XML bad performances on matching XPath #1096

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
