### PR TITLE
allow admin calls when standalone instance is behind haproxy/loadbala…

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -125,13 +125,14 @@ public class HttpAdminClient implements Admin {
       String proxyHost,
       int proxyPort,
       ClientAuthenticator authenticator) {
-    this(scheme,
-            host,
-            port,
-            urlPathPrefix,
-            hostHeader,
-            authenticator,
-            HttpClientFactory.createClient(createProxySettings(proxyHost, proxyPort)));
+    this(
+        scheme,
+        host,
+        port,
+        urlPathPrefix,
+        hostHeader,
+        authenticator,
+        HttpClientFactory.createClient(createProxySettings(proxyHost, proxyPort)));
   }
 
   public HttpAdminClient(

--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,8 @@ import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 
 public class HttpAdminClient implements Admin {
 
-  private static final String ADMIN_URL_PREFIX = "%s://%s:%d%s/__admin";
+  private static final String ADMIN_URL_PREFIX = "%s://%s%s%s/__admin";
+  private static final int NO_PORT_DEFINED = -1;
 
   private final String scheme;
   private final String host;
@@ -77,6 +78,10 @@ public class HttpAdminClient implements Admin {
 
   public HttpAdminClient(String scheme, String host, int port) {
     this(scheme, host, port, "");
+  }
+
+  public HttpAdminClient(String scheme, String host) {
+    this(scheme, host, NO_PORT_DEFINED, "");
   }
 
   public HttpAdminClient(String host, int port, String urlPathPrefix) {
@@ -130,6 +135,25 @@ public class HttpAdminClient implements Admin {
     adminRoutes = AdminRoutes.forClient();
 
     httpClient = HttpClientFactory.createClient(createProxySettings(proxyHost, proxyPort));
+  }
+
+  public HttpAdminClient(
+      String scheme,
+      String host,
+      int port,
+      String urlPathPrefix,
+      String hostHeader,
+      ClientAuthenticator authenticator,
+      CloseableHttpClient httpClient) {
+    this.scheme = scheme;
+    this.host = host;
+    this.port = port;
+    this.urlPathPrefix = urlPathPrefix;
+    this.hostHeader = hostHeader;
+    this.authenticator = authenticator;
+    this.httpClient = httpClient;
+
+    adminRoutes = AdminRoutes.forClient();
   }
 
   public HttpAdminClient(String host, int port) {
@@ -492,13 +516,7 @@ public class HttpAdminClient implements Admin {
       QueryParams queryParams,
       B requestBody,
       Class<R> responseType) {
-    String url =
-        String.format(
-            ADMIN_URL_PREFIX + requestSpec.path(pathParams) + queryParams,
-            scheme,
-            host,
-            port,
-            urlPathPrefix);
+    String url = getAdminUrl(requestSpec.path(pathParams) + queryParams);
     ClassicRequestBuilder requestBuilder =
         ClassicRequestBuilder.create(requestSpec.method().getName()).setUri(url);
 
@@ -595,7 +613,11 @@ public class HttpAdminClient implements Admin {
   private String urlFor(Class<? extends AdminTask> taskClass, PathParams pathParams) {
     RequestSpec requestSpec = adminRoutes.requestSpecForTask(taskClass);
     requireNonNull(requestSpec, "No admin task URL is registered for " + taskClass.getSimpleName());
-    return String.format(
-        ADMIN_URL_PREFIX + requestSpec.path(pathParams), scheme, host, port, urlPathPrefix);
+    return getAdminUrl(requestSpec.path(pathParams));
+  }
+
+  private String getAdminUrl(String pathSuffix) {
+    String portPart = port == NO_PORT_DEFINED ? "" : ":" + port;
+    return String.format(ADMIN_URL_PREFIX + pathSuffix, scheme, host, portPart, urlPathPrefix);
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -125,16 +125,13 @@ public class HttpAdminClient implements Admin {
       String proxyHost,
       int proxyPort,
       ClientAuthenticator authenticator) {
-    this.scheme = scheme;
-    this.host = host;
-    this.port = port;
-    this.urlPathPrefix = urlPathPrefix;
-    this.hostHeader = hostHeader;
-    this.authenticator = authenticator;
-
-    adminRoutes = AdminRoutes.forClient();
-
-    httpClient = HttpClientFactory.createClient(createProxySettings(proxyHost, proxyPort));
+    this(scheme,
+            host,
+            port,
+            urlPathPrefix,
+            hostHeader,
+            authenticator,
+            HttpClientFactory.createClient(createProxySettings(proxyHost, proxyPort)));
   }
 
   public HttpAdminClient(
@@ -462,7 +459,7 @@ public class HttpAdminClient implements Admin {
     return port;
   }
 
-  private ProxySettings createProxySettings(String proxyHost, int proxyPort) {
+  private static ProxySettings createProxySettings(String proxyHost, int proxyPort) {
     if (isNotBlank(proxyHost)) {
       return new ProxySettings(proxyHost, proxyPort);
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -104,6 +104,10 @@ public class WireMock {
     admin = new HttpAdminClient(scheme, host, port);
   }
 
+  public WireMock(String scheme, String host) {
+    admin = new HttpAdminClient(scheme, host);
+  }
+
   public WireMock(String scheme, String host, int port, String urlPathPrefix) {
     admin = new HttpAdminClient(scheme, host, port, urlPathPrefix);
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2024 Thomas Akehurst
+ * Copyright (C) 2012-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,18 +19,27 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.admin.model.GetScenariosResult;
 import com.github.tomakehurst.wiremock.common.InvalidInputException;
+import com.github.tomakehurst.wiremock.security.ClientAuthenticator;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.List;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 class HttpAdminClientTest {
   private static final String ADMIN_TEST_PREFIX = "/admin-test";
@@ -66,6 +75,29 @@ class HttpAdminClientTest {
     var client = new HttpAdminClient("localhost", server.port(), ADMIN_TEST_PREFIX);
 
     client.resetAll();
+  }
+
+  @Test
+  void shouldBeAbleToContactWiremockIfPortIsNotSpecified() throws IOException, URISyntaxException {
+
+    CloseableHttpClient closeableHttpClient = mock(CloseableHttpClient.class);
+    ClientAuthenticator authenticator = mock(ClientAuthenticator.class);
+    when(authenticator.generateAuthHeaders()).thenReturn(Collections.emptyList());
+    ArgumentCaptor<ClassicHttpRequest> httpRequestSentCaptor =
+        ArgumentCaptor.forClass(ClassicHttpRequest.class);
+    var scheme = "https";
+    var domain = "my.domain.name";
+    var client =
+        new HttpAdminClient(scheme, domain, -1, "", "", authenticator, closeableHttpClient);
+
+    try {
+      client.getAllScenarios();
+    } catch (Exception e) {
+      // ignore
+    }
+    Mockito.verify(closeableHttpClient).execute(httpRequestSentCaptor.capture());
+    ClassicHttpRequest value = httpRequestSentCaptor.getValue();
+    assertThat(value.getUri().toString()).isEqualTo(scheme + "://" + domain + "/__admin/scenarios");
   }
 
   @Test


### PR DESCRIPTION
…ncer/service mesh

Existing Wiremock implementation does not allow to do admin calls if standalone instance is behind a load balancer/haproxy/service mesh etc. This is because it forces you to specify port (although in this case it is implied to be 443 if scheme is https for example) and the resulting url is https://domain:port/suffix. It is very often the case the routing in above loadbalancers, relies on the host header which would include the :port part, and therefore it does not work. With this change, we allow users to create a Wiremock instance without specifying the port, letting http protocol take care of that.

## References

- TODO

I did not create an issue but I had the following chat in the slack channel:
https://wiremock-community.slack.com/archives/C03N1E6HFPY/p1741623042096729

## Submitter checklist

- [x ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

