### PR TITLE
feat: admin API endpoints to find/remove unmatched stub mappings

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -529,6 +529,11 @@ public class WireMockServer implements Container, Stubbing, Admin {
   @Override
   public void shutdownServer() {
     shutdown();
+  }
+
+  @Override
+  public ListStubMappingsResult findUnmatchedStubs() {
+    return wireMockApp.findUnmatchedStubs();
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,8 @@ public class AdminRoutes {
 
     router.add(POST, "/mappings/save", new SaveMappingsTask());
     router.add(POST, "/mappings/reset", new ResetToDefaultMappingsTask());
+    router.add(GET, "/mappings/unmatched", new GetUnmatchedStubMappingsTask());
+    router.add(DELETE, "/mappings/unmatched", new RemoveUnmatchedStubMappingsTask());
     router.add(GET, "/mappings/{id}", new GetStubMappingTask());
     router.add(PUT, "/mappings/{id}", new EditStubMappingTask());
     router.add(POST, "/mappings/remove", new RemoveMatchingStubMappingTask());

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/GetUnmatchedStubMappingsTask.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/GetUnmatchedStubMappingsTask.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2016-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.admin.tasks;
+
+import com.github.tomakehurst.wiremock.admin.AdminTask;
+import com.github.tomakehurst.wiremock.admin.model.ListStubMappingsResult;
+import com.github.tomakehurst.wiremock.common.url.PathParams;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+
+public class GetUnmatchedStubMappingsTask implements AdminTask {
+
+  @Override
+  public ResponseDefinition execute(Admin admin, ServeEvent serveEvent, PathParams pathParams) {
+    ListStubMappingsResult result = admin.findUnmatchedStubs();
+    return ResponseDefinition.okForJson(result);
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/RemoveUnmatchedStubMappingsTask.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/RemoveUnmatchedStubMappingsTask.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.admin.tasks;
+
+import com.github.tomakehurst.wiremock.admin.AdminTask;
+import com.github.tomakehurst.wiremock.common.url.PathParams;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+
+public class RemoveUnmatchedStubMappingsTask implements AdminTask {
+
+  @Override
+  public ResponseDefinition execute(Admin admin, ServeEvent serveEvent, PathParams pathParams) {
+    admin.findUnmatchedStubs().getMappings().forEach(admin::removeStubMapping);
+    return ResponseDefinition.okEmptyJson();
+  }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -404,6 +404,13 @@ public class HttpAdminClient implements Admin {
   @Override
   public void shutdownServer() {
     postJsonAssertOkAndReturnBody(urlFor(ShutdownServerTask.class), null);
+  }
+
+  @Override
+  public ListStubMappingsResult findUnmatchedStubs() {
+    return executeRequest(
+        adminRoutes.requestSpecForTask(GetUnmatchedStubMappingsTask.class),
+        ListStubMappingsResult.class);
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,6 +105,8 @@ public interface Admin {
   Options getOptions();
 
   void shutdownServer();
+
+  ListStubMappingsResult findUnmatchedStubs();
 
   ListStubMappingsResult findAllStubsByMetadata(StringValuePattern pattern);
 

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2024 Thomas Akehurst
+ * Copyright (C) 2012-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -576,6 +576,27 @@ public class WireMockApp implements StubServer, Admin {
   @Override
   public RecordingStatusResult getRecordingStatus() {
     return new RecordingStatusResult(recorder.getStatus().name());
+  }
+
+  private Set<UUID> findMatchedStubIds() {
+    return requestJournal.getAllServeEvents().stream()
+        .filter(event -> event.getStubMapping() != null)
+        .map(event -> event.getStubMapping().getId())
+        .collect(Collectors.toSet());
+  }
+
+  @Override
+  public ListStubMappingsResult findUnmatchedStubs() {
+    // Collect IDs of stub mappings that have matched at least one request in a HashSet for O(1)
+    // lookups so this method is O(n + m), where n is the number of stubs and m is the number of
+    // requests in the journal.
+    // It'd be slightly more efficient to use IdentityHashMap, but that's error-prone.
+    Set<UUID> servedStubIds = findMatchedStubIds();
+    List<StubMapping> foundMappings =
+        stubMappings.getAll().stream()
+            .filter(stub -> !servedStubIds.contains(stub.getId()))
+            .collect(Collectors.toList());
+    return new ListStubMappingsResult(LimitAndOffsetPaginator.none(foundMappings));
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/junit/DslWrapper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/DslWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Thomas Akehurst
+ * Copyright (C) 2021-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -229,6 +229,11 @@ public class DslWrapper implements Admin, Stubbing {
   @Override
   public void shutdownServer() {
     admin.shutdownServer();
+  }
+
+  @Override
+  public ListStubMappingsResult findUnmatchedStubs() {
+    return admin.findUnmatchedStubs();
   }
 
   @Override

--- a/src/main/resources/swagger/wiremock-admin-api.json
+++ b/src/main/resources/swagger/wiremock-admin-api.json
@@ -399,6 +399,85 @@
         }
       }
     },
+    "/__admin/mappings/unmatched": {
+      "get": {
+        "operationId": "findUnmatchedStubMappings",
+        "summary": "Find unmatched stub mappings",
+        "description": "Find stub mappings that haven't matched any requests in the journal",
+        "tags": [
+          "Stub Mappings"
+        ],
+        "responses": {
+          "200": {
+            "description": "Unmatched stub mappings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/stub-mappings"
+                },
+                "example": {
+                  "meta": {
+                    "total": 2
+                  },
+                  "mappings": [
+                    {
+                      "id": "76ada7b0-49ae-4229-91c4-396a36f18e09",
+                      "uuid": "76ada7b0-49ae-4229-91c4-396a36f18e09",
+                      "request": {
+                        "method": "GET",
+                        "url": "/search?q=things",
+                        "headers": {
+                          "Accept": {
+                            "equalTo": "application/json"
+                          }
+                        }
+                      },
+                      "response": {
+                        "status": 200,
+                        "jsonBody": [
+                          "thing1",
+                          "thing2"
+                        ],
+                        "headers": {
+                          "Content-Type": "application/json"
+                        }
+                      }
+                    },
+                    {
+                      "request": {
+                        "method": "POST",
+                        "urlPath": "/some/things",
+                        "bodyPatterns": [
+                          {
+                            "equalToXml": "<stuff />"
+                          }
+                        ]
+                      },
+                      "response": {
+                        "status": 201
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "removeUnmatchedStubMappings",
+        "summary": "Remove unmatched stub mappings",
+        "description": "Remove stub mappings that haven't matched any requests in the journal",
+        "tags": [
+          "Stub Mappings"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/__admin/requests": {
       "get": {
         "operationId": "getAllRequestsInJournal",
@@ -1832,7 +1911,7 @@
         ]
       },
       "after-pattern": {
-        "title": "Before datetime",
+        "title": "After datetime",
         "type": "object",
         "properties": {
           "after": {
@@ -1949,7 +2028,11 @@
           },
           "namespaceAwareness": {
             "type": "string",
-            "enum": ["LEGACY", "STRICT", "NONE"]
+            "enum": [
+              "LEGACY",
+              "STRICT",
+              "NONE"
+            ]
           }
         },
         "required": [
@@ -2233,6 +2316,9 @@
               "type": "object",
               "properties": {
                 "name": {
+                  "type": "string"
+                },
+                "fileName": {
                   "type": "string"
                 },
                 "matchingType": {

--- a/src/main/resources/swagger/wiremock-admin-api.yaml
+++ b/src/main/resources/swagger/wiremock-admin-api.yaml
@@ -211,6 +211,32 @@ paths:
         '200':
           description: 'The stub mappings were successfully removed'
 
+  /__admin/mappings/unmatched:
+    get:
+      operationId: findUnmatchedStubMappings
+      summary: Find unmatched stub mappings
+      description: Find stub mappings that haven't matched any requests in the journal
+      tags:
+        - Stub Mappings
+      responses:
+        '200':
+          description: Unmatched stub mappings
+          content:
+            application/json:
+              schema:
+                $ref: 'schemas/stub-mappings.yaml'
+              example:
+                $ref: 'examples/stub-mappings.yaml'
+    delete:
+      operationId: removeUnmatchedStubMappings
+      summary: Remove unmatched stub mappings
+      description: Remove stub mappings that haven't matched any requests in the journal
+      tags:
+        - Stub Mappings
+      responses:
+        '200':
+          description: OK
+
   /__admin/requests:
     get:
       operationId: getAllRequestsInJournal


### PR DESCRIPTION
This integrates the functionality of https://github.com/MasonM/wiremock-unused-stubs-extension into WireMock proper, as requested in https://github.com/wiremock/wiremock/issues/615#issuecomment-2724287164.

Specifically, it adds two endpoints:
* `GET /__admin/mappings/unmatched` - Retrieve stub mappings that haven't matched any requests in the journal.
* `DELETE /__admin/mappings/unmatched` - Remove all such stub mappings.
  Note that the extension supports an additional `?remove_files=1` query parameter that I didn't include here because it introduces some additional complications (https://github.com/MasonM/wiremock-unused-stubs-extension/blob/424dfad1a21e25d588ac9230a46be820a579d7cf/src/main/java/com/github/masonm/wiremock/UnusedStubsAdminExtension.java#L71). I added that feature because it was requested in https://github.com/MasonM/wiremock-unused-stubs-extension/issues/1, but I haven't personally used it much, so I'm not sure if it's worth porting.

<!-- Please describe your pull request here. -->

## References

-  Fixes https://github.com/wiremock/wiremock/issues/615
- https://github.com/MasonM/wiremock-unused-stubs-extension/issues/1
<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
