### PR TITLE
fix: publishing branch snapshots to github.

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -26,7 +26,7 @@ jobs:
           validate-wrappers: true
 
       - name: Set snapshot version
-        run: ./gradlew set-snapshot-version --stacktrace ${{ github.event_name == 'workflow_dispatch' && format('-PsnapshotVersion={0}', github.ref_name) || '' }}
+        run: ./gradlew set-snapshot-version --stacktrace ${{ github.event_name == 'workflow_dispatch' && format('-PsnapshotVersion={0}-SNAPSHOT', github.ref_name) || '' }}
 
       - name: Publish core package
         id: publish_package
@@ -55,7 +55,7 @@ jobs:
           validate-wrappers: true
 
       - name: Set snapshot version
-        run: ./gradlew set-snapshot-version --stacktrace ${{ github.event_name == 'workflow_dispatch' && format('-PsnapshotVersion={0}', github.ref_name) || '' }}
+        run: ./gradlew set-snapshot-version --stacktrace ${{ github.event_name == 'workflow_dispatch' && format('-PsnapshotVersion={0}-SNAPSHOT', github.ref_name) || '' }}
 
       - name: Publish Jetty 12 package
         id: publish_package


### PR DESCRIPTION
add -SNAPSHOT to the end of the version. hopefully this will allow duplicate packages under the same version.