### PR TITLE
feat: record query param matchers.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MultipleMatchMultiValuePattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MultipleMatchMultiValuePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.matching;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.tomakehurst.wiremock.http.MultiValue;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public abstract class MultipleMatchMultiValuePattern extends MultiValuePattern {
@@ -62,5 +63,18 @@ public abstract class MultipleMatchMultiValuePattern extends MultiValuePattern {
   @JsonIgnore
   public String getOperator() {
     return "";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MultipleMatchMultiValuePattern that = (MultipleMatchMultiValuePattern) o;
+    return Objects.equals(getValues(), that.getValues());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getValues());
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.github.tomakehurst.wiremock.recording;
+
+import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 
 import com.github.tomakehurst.wiremock.common.Urls;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
@@ -60,7 +62,11 @@ public class ScenarioProcessor {
         "scenario-"
             + scenarioIndex
             + "-"
-            + Urls.urlToPathParts(URI.create(firstScenario.getRequest().getUrl()));
+            + Urls.urlToPathParts(
+                URI.create(
+                    getFirstNonNull(
+                        firstScenario.getRequest().getUrl(),
+                        firstScenario.getRequest().getUrlPath())));
 
     int count = 1;
     for (StubMapping stub : stubMappings) {

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractor.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.github.tomakehurst.wiremock.recording;
+
+import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.common.*;
@@ -41,7 +43,8 @@ public class SnapshotStubMappingBodyExtractor {
     HttpHeaders responseHeaders = stubMapping.getResponse().getHeaders();
     String extension =
         ContentTypes.determineFileExtension(
-            stubMapping.getRequest().getUrl(),
+            getFirstNonNull(
+                stubMapping.getRequest().getUrl(), stubMapping.getRequest().getUrlPath()),
             responseHeaders != null
                 ? responseHeaders.getContentTypeHeader()
                 : ContentTypeHeader.absent(),

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MultiValuePatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MultiValuePatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -179,5 +180,52 @@ public class MultiValuePatternTest {
     String actual = Json.write(MultiValuePattern.absent());
     JSONAssert.assertEquals(
         "{                   \n" + "  \"absent\": true   \n" + "}", actual, true);
+  }
+
+  @Test
+  public void equalsChecksSingleValuePattern() {
+    MultiValuePattern a = new SingleMatchMultiValuePattern(equalTo("something"));
+    MultiValuePattern b = new SingleMatchMultiValuePattern(equalTo("something else"));
+    MultiValuePattern c = new SingleMatchMultiValuePattern(equalTo("something"));
+    MultiValuePattern d = new ExactMatchMultiValuePattern(List.of(equalTo("something")));
+    assertNotEquals(a, b);
+    assertEquals(a, c);
+    assertNotEquals(a, d);
+  }
+
+  @Test
+  public void equalsChecksExactMatchPattern() {
+    MultiValuePattern a =
+        new ExactMatchMultiValuePattern(List.of(equalTo("something"), equalTo("another thing")));
+    MultiValuePattern b = new ExactMatchMultiValuePattern(List.of(equalTo("something")));
+    MultiValuePattern c =
+        new ExactMatchMultiValuePattern(List.of(equalTo("something"), equalTo("another thing")));
+    MultiValuePattern d =
+        new ExactMatchMultiValuePattern(
+            List.of(equalTo("something"), equalTo("a different thing")));
+    MultiValuePattern e =
+        new IncludesMatchMultiValuePattern(List.of(equalTo("something"), equalTo("another thing")));
+    assertNotEquals(a, b);
+    assertEquals(a, c);
+    assertNotEquals(a, d);
+    assertNotEquals(a, e);
+  }
+
+  @Test
+  public void equalsChecksIncludesMatchPattern() {
+    MultiValuePattern a =
+        new IncludesMatchMultiValuePattern(List.of(equalTo("something"), equalTo("another thing")));
+    MultiValuePattern b = new IncludesMatchMultiValuePattern(List.of(equalTo("something")));
+    MultiValuePattern c =
+        new IncludesMatchMultiValuePattern(List.of(equalTo("something"), equalTo("another thing")));
+    MultiValuePattern d =
+        new IncludesMatchMultiValuePattern(
+            List.of(equalTo("something"), equalTo("a different thing")));
+    MultiValuePattern e =
+        new ExactMatchMultiValuePattern(List.of(equalTo("something"), equalTo("another thing")));
+    assertNotEquals(a, b);
+    assertEquals(a, c);
+    assertNotEquals(a, d);
+    assertNotEquals(a, e);
   }
 }


### PR DESCRIPTION
previously, query parameters of recorded requests were part of the url pattern. creating separate query parameter matchers adds more flexibility to the stub mapping.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
