### PR TITLE
Allow the webhook scheduler thread pool size to be configured

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2024 Thomas Akehurst
+ * Copyright (C) 2013-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ public interface Options {
   int DEFAULT_CONTAINER_THREADS = 25;
   String DEFAULT_BIND_ADDRESS = "0.0.0.0";
   int DEFAULT_MAX_HTTP_CONNECTIONS = 1000;
+  int DEFAULT_WEBHOOK_THREADPOOL_SIZE = 10;
   boolean DEFAULT_DISABLE_CONNECTION_REUSE = true;
   Long DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES = 1000L;
 
@@ -160,4 +161,6 @@ public interface Options {
   Set<String> getSupportedProxyEncodings();
 
   boolean getDisableConnectionReuse();
+
+  int getWebhookThreadPoolSize();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2024 Thomas Akehurst
+ * Copyright (C) 2013-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,6 +150,8 @@ public class WireMockConfiguration implements Options {
   private boolean templateEscapingDisabled = true;
 
   private Set<String> supportedProxyEncodings = null;
+
+  private int webhookThreadPoolSize = DEFAULT_WEBHOOK_THREADPOOL_SIZE;
 
   private MappingsSource getMappingsSource() {
     if (mappingsSource == null) {
@@ -602,6 +604,11 @@ public class WireMockConfiguration implements Options {
     return withSupportedProxyEncodings(Set.of(supportedProxyEncodings));
   }
 
+  public WireMockConfiguration withWebhookThreadPoolSize(Integer webhookThreadPoolSize) {
+    this.webhookThreadPoolSize = webhookThreadPoolSize;
+    return this;
+  }
+
   @Override
   public int portNumber() {
     return portNumber;
@@ -900,5 +907,10 @@ public class WireMockConfiguration implements Options {
   @Override
   public Set<String> getSupportedProxyEncodings() {
     return supportedProxyEncodings;
+  }
+
+  @Override
+  public int getWebhookThreadPoolSize() {
+    return webhookThreadPoolSize;
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/Extensions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/Extensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -169,7 +169,10 @@ public class Extensions implements WireMockServices {
         ofType(WebhookTransformer.class).values().stream().collect(Collectors.toUnmodifiableList());
 
     final Webhooks webhooks =
-        new Webhooks(this, Executors.newScheduledThreadPool(10), webhookTransformers);
+        new Webhooks(
+            this,
+            Executors.newScheduledThreadPool(options.getWebhookThreadPoolSize()),
+            webhookTransformers);
     loadedExtensions.put(webhooks.getName(), webhooks);
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -309,5 +309,10 @@ public class WarConfiguration implements Options {
   @Override
   public Set<String> getSupportedProxyEncodings() {
     return null;
+  }
+
+  @Override
+  public int getWebhookThreadPoolSize() {
+    return DEFAULT_WEBHOOK_THREADPOOL_SIZE;
   }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,6 +130,7 @@ public class CommandLineOptions implements Options {
   private static final String DISABLE_CONNECTION_REUSE = "disable-connection-reuse";
   private static final String PROXY_PASS_THROUGH = "proxy-pass-through";
   private static final String SUPPORTED_PROXY_ENCODINGS = "supported-proxy-encodings";
+  private static final String WEBHOOK_THREADPOOL_SIZE = "webhook-threadpool-size";
 
   private final OptionSet optionSet;
 
@@ -397,6 +398,9 @@ public class CommandLineOptions implements Options {
         .withRequiredArg()
         .ofType(String.class)
         .withValuesSeparatedBy(",");
+    optionParser
+        .accepts(WEBHOOK_THREADPOOL_SIZE, "The size of the webhook thread pool")
+        .withRequiredArg();
 
     optionParser.accepts(VERSION, "Prints wiremock version information and exits");
 
@@ -1056,5 +1060,12 @@ public class CommandLineOptions implements Options {
     return optionSet.has(DISABLE_CONNECTION_REUSE)
         ? Boolean.parseBoolean((String) optionSet.valueOf(DISABLE_CONNECTION_REUSE))
         : DEFAULT_DISABLE_CONNECTION_REUSE;
+  }
+
+  @Override
+  public int getWebhookThreadPoolSize() {
+    return optionSet.has(WEBHOOK_THREADPOOL_SIZE)
+        ? Integer.parseInt((String) optionSet.valueOf(WEBHOOK_THREADPOOL_SIZE))
+        : DEFAULT_WEBHOOK_THREADPOOL_SIZE;
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
@@ -86,7 +86,7 @@ public class WireMockConfigurationTest {
     Options config = WireMockConfiguration.wireMockConfig().withWebhookThreadPoolSize(1000);
     assertThat(config.getWebhookThreadPoolSize(), is(1000));
   }
-  
+
   @Test
   void webhookThreadpoolSizeWhenNotSpecified() {
     Options config = WireMockConfiguration.wireMockConfig();

--- a/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.core;
 
 import static com.github.tomakehurst.wiremock.core.Options.DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES;
+import static com.github.tomakehurst.wiremock.core.Options.DEFAULT_WEBHOOK_THREADPOOL_SIZE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -78,5 +79,17 @@ public class WireMockConfigurationTest {
   void maxTemplateCacheEntriesDefaultsWhenNotSpecified() {
     Options config = WireMockConfiguration.wireMockConfig();
     assertThat(config.getMaxTemplateCacheEntries(), is(DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES));
+  }
+
+  @Test
+  void setsWebhookThreadpoolSize() {
+    Options config = WireMockConfiguration.wireMockConfig().withWebhookThreadPoolSize(1000);
+    assertThat(config.getWebhookThreadPoolSize(), is(1000));
+  }
+
+  @Test
+  void webhookThreadpoolSizeWhenNotSpecified() {
+    Options config = WireMockConfiguration.wireMockConfig();
+    assertThat(config.getWebhookThreadPoolSize(), is(DEFAULT_WEBHOOK_THREADPOOL_SIZE));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.standalone;
 import static com.github.tomakehurst.wiremock.common.BrowserProxySettings.DEFAULT_CA_KESTORE_PASSWORD;
 import static com.github.tomakehurst.wiremock.common.BrowserProxySettings.DEFAULT_CA_KEYSTORE_PATH;
 import static com.github.tomakehurst.wiremock.core.Options.DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES;
+import static com.github.tomakehurst.wiremock.core.Options.DEFAULT_WEBHOOK_THREADPOOL_SIZE;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.matchesMultiLine;
 import static java.util.Arrays.asList;
@@ -855,6 +856,20 @@ public class CommandLineOptionsTest {
   void testDisableConnectionReuseOptionPassedAsTrue() {
     CommandLineOptions options = new CommandLineOptions("--disable-connection-reuse", "true");
     assertTrue(options.getDisableConnectionReuse());
+  }
+
+  @Test
+  public void configuresWebhookThreadPoolSizeIfSpecified() {
+    CommandLineOptions options = new CommandLineOptions("--webhook-threadpool-size", "5");
+
+    assertThat(options.getWebhookThreadPoolSize(), is(5));
+  }
+
+  @Test
+  public void configuresWebhookThreadPoolSizeSetToDefaultIfNotSpecified() {
+    CommandLineOptions options = new CommandLineOptions();
+
+    assertThat(options.getWebhookThreadPoolSize(), is(DEFAULT_WEBHOOK_THREADPOOL_SIZE));
   }
 
   public static class ResponseDefinitionTransformerExt1 extends ResponseDefinitionTransformer {


### PR DESCRIPTION
Adds an option to the WireMock config, the CLI options and War config. If not specified, it defaults to 10 which was the original hardcoded value.

Not sure if there is a nice way to test that the configured value is propagated to the `Executors.newScheduledThreadPool` creation. 

Docs PR still needed

<!-- Please describe your pull request here. -->

## References

- Implements suggestion in #2998

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
