### PR TITLE
Allow the WireMockExtension to not reset in beforeEach

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit5/WireMockExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Thomas Akehurst
+ * Copyright (C) 2021-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ public class WireMockExtension extends DslWrapper
 
   private final boolean configureStaticDsl;
   private final boolean failOnUnmatchedRequests;
+  private final boolean resetOnEachTest;
 
   private final boolean isDeclarative;
 
@@ -54,6 +55,7 @@ public class WireMockExtension extends DslWrapper
     configureStaticDsl = true;
     failOnUnmatchedRequests = false;
     isDeclarative = true;
+    resetOnEachTest = true;
   }
 
   /**
@@ -71,6 +73,7 @@ public class WireMockExtension extends DslWrapper
     this.failOnUnmatchedRequests = builder.failOnUnmatchedRequests;
     this.proxyMode = builder.proxyMode;
     this.isDeclarative = false;
+    this.resetOnEachTest = builder.resetOnEachTest;
   }
 
   private WireMockExtension(
@@ -83,6 +86,21 @@ public class WireMockExtension extends DslWrapper
     this.failOnUnmatchedRequests = failOnUnmatchedRequests;
     this.proxyMode = proxyMode;
     this.isDeclarative = false;
+    this.resetOnEachTest = true;
+  }
+
+  private WireMockExtension(
+      Options options,
+      boolean configureStaticDsl,
+      boolean failOnUnmatchedRequests,
+      boolean proxyMode,
+      boolean resetOnEachTest) {
+    this.options = options;
+    this.configureStaticDsl = configureStaticDsl;
+    this.failOnUnmatchedRequests = failOnUnmatchedRequests;
+    this.proxyMode = proxyMode;
+    this.isDeclarative = false;
+    this.resetOnEachTest = resetOnEachTest;
   }
 
   /**
@@ -291,7 +309,9 @@ public class WireMockExtension extends DslWrapper
       isNonStatic = true;
       startServerIfRequired(context);
     } else {
-      resetToDefaultMappings();
+      if (resetOnEachTest) {
+        resetToDefaultMappings();
+      }
     }
 
     setAdditionalOptions(context);
@@ -352,6 +372,7 @@ public class WireMockExtension extends DslWrapper
     private Options options = WireMockConfiguration.wireMockConfig().dynamicPort();
     private boolean configureStaticDsl = false;
     private boolean failOnUnmatchedRequests = false;
+    private boolean resetOnEachTest = true;
     private boolean proxyMode = false;
 
     public Builder options(Options options) {
@@ -374,6 +395,11 @@ public class WireMockExtension extends DslWrapper
       return this;
     }
 
+    public Builder resetOnEachTest(boolean resetOnEachTest) {
+      this.resetOnEachTest = resetOnEachTest;
+      return this;
+    }
+
     public WireMockExtension build() {
       if (proxyMode
           && !options.browserProxySettings().enabled()
@@ -381,7 +407,8 @@ public class WireMockExtension extends DslWrapper
         ((WireMockConfiguration) options).enableBrowserProxying(true);
       }
 
-      return new WireMockExtension(options, configureStaticDsl, failOnUnmatchedRequests, proxyMode);
+      return new WireMockExtension(
+          options, configureStaticDsl, failOnUnmatchedRequests, proxyMode, resetOnEachTest);
     }
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionResetOnEachTestTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit5/JUnitJupiterExtensionResetOnEachTestTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2021-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.junit5;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import java.util.Optional;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.Mockito;
+
+public class JUnitJupiterExtensionResetOnEachTestTest {
+
+  CloseableHttpClient client;
+  ExtensionContext extensionContext;
+
+  @BeforeEach
+  void init() {
+    client = HttpClientFactory.createClient();
+
+    extensionContext = Mockito.mock(ExtensionContext.class);
+    when(extensionContext.getElement()).thenReturn(Optional.empty());
+  }
+
+  @Test
+  void default_behavior_is_to_reset_stubs_in_before_each() throws Exception {
+    WireMockExtension extension = WireMockExtension.newInstance().build();
+
+    extension.beforeEach(extensionContext);
+    assertThat(extension.getStubMappings(), hasSize(0));
+
+    extension.stubFor(get("/one").willReturn(ok()));
+    assertThat(extension.getStubMappings(), hasSize(1));
+
+    extension.beforeEach(extensionContext);
+    assertThat(extension.getStubMappings(), hasSize(0));
+
+    extension.stubFor(get("/two").willReturn(ok()));
+    assertThat(extension.getStubMappings(), hasSize(1));
+
+    extension.beforeEach(extensionContext);
+    assertThat(extension.getStubMappings(), hasSize(0));
+  }
+
+  @Test
+  void default_behavior_is_to_reset_requests_in_before_each() throws Exception {
+    WireMockExtension extension = WireMockExtension.newInstance().build();
+
+    extension.beforeEach(extensionContext);
+    assertThat(extension.getAllServeEvents(), hasSize(0));
+
+    extension.stubFor(get("/one").willReturn(ok()));
+    try (CloseableHttpResponse response = client.execute(new HttpGet(extension.url("/one")))) {
+      assertThat(response.getCode(), is(200));
+    }
+    assertThat(extension.getAllServeEvents(), hasSize(1));
+
+    extension.beforeEach(extensionContext);
+    assertThat(extension.getAllServeEvents(), hasSize(0));
+
+    extension.stubFor(get("/two").willReturn(ok()));
+    try (CloseableHttpResponse response = client.execute(new HttpGet(extension.url("/two")))) {
+      assertThat(response.getCode(), is(200));
+    }
+    assertThat(extension.getAllServeEvents(), hasSize(1));
+
+    extension.beforeEach(extensionContext);
+    assertThat(extension.getAllServeEvents(), hasSize(0));
+  }
+
+  @Test
+  void can_configure_to_not_reset_stubs_in_before_each() throws Exception {
+    WireMockExtension extension = WireMockExtension.newInstance().resetOnEachTest(false).build();
+
+    extension.beforeEach(extensionContext);
+    assertThat(extension.getStubMappings(), hasSize(0));
+
+    extension.stubFor(get("/one").willReturn(ok()));
+    assertThat(extension.getStubMappings(), hasSize(1));
+
+    extension.beforeEach(extensionContext);
+    assertThat(extension.getStubMappings(), hasSize(1));
+
+    extension.stubFor(get("/two").willReturn(ok()));
+    assertThat(extension.getStubMappings(), hasSize(2));
+
+    extension.beforeEach(extensionContext);
+    assertThat(extension.getStubMappings(), hasSize(2));
+  }
+
+  @Test
+  void can_configure_to_not_reset_requests_in_before_each() throws Exception {
+    WireMockExtension extension = WireMockExtension.newInstance().resetOnEachTest(false).build();
+
+    extension.beforeEach(extensionContext);
+    assertThat(extension.getAllServeEvents(), hasSize(0));
+
+    extension.stubFor(get("/one").willReturn(ok()));
+    try (CloseableHttpResponse response = client.execute(new HttpGet(extension.url("/one")))) {
+      assertThat(response.getCode(), is(200));
+    }
+    assertThat(extension.getAllServeEvents(), hasSize(1));
+
+    extension.beforeEach(extensionContext);
+    assertThat(extension.getAllServeEvents(), hasSize(1));
+
+    extension.stubFor(get("/two").willReturn(ok()));
+    try (CloseableHttpResponse response = client.execute(new HttpGet(extension.url("/two")))) {
+      assertThat(response.getCode(), is(200));
+    }
+    assertThat(extension.getAllServeEvents(), hasSize(2));
+
+    extension.beforeEach(extensionContext);
+    assertThat(extension.getAllServeEvents(), hasSize(2));
+  }
+}


### PR DESCRIPTION
By default the JUnit `WireMockExtension` resets stubs and requests in the `beforeEach` method.  This is not always desirable (as per issue #2895).  This PR keeps the default behaviour with regards to reseting but adds a new method to allow the behaviour to be turned off

Docs PR still needs to be done

<!-- Please describe your pull request here. -->

## References

- #2895

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
