### PR TITLE
Expose native matcher for client ip address

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,6 +90,12 @@ class BasicMappingBuilder implements ScenarioMappingBuilder {
   @Override
   public MappingBuilder withPort(int port) {
     requestPatternBuilder.withPort(port);
+    return this;
+  }
+
+  @Override
+  public MappingBuilder withClientIp(StringValuePattern clientIpPattern) {
+    requestPatternBuilder.withClientIp(clientIpPattern);
     return this;
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,8 @@ public interface MappingBuilder {
   MappingBuilder withHost(StringValuePattern hostPattern);
 
   MappingBuilder withPort(int port);
+
+  MappingBuilder withClientIp(StringValuePattern hostPattern);
 
   MappingBuilder atPriority(Integer priority);
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ public class RequestPatternBuilder {
   private String scheme;
   private StringValuePattern hostPattern;
   private Integer port;
+  private StringValuePattern clientIpPattern;
   private UrlPattern url = UrlPattern.ANY;
   private RequestMethod method = RequestMethod.ANY;
   private Map<String, MultiValuePattern> headers = new LinkedHashMap<>();
@@ -97,6 +98,7 @@ public class RequestPatternBuilder {
     builder.scheme = requestPattern.getScheme();
     builder.hostPattern = requestPattern.getHost();
     builder.port = requestPattern.getPort();
+    builder.clientIpPattern = requestPattern.getClientIp();
     builder.url = requestPattern.getUrlMatcher();
     builder.method = requestPattern.getMethod();
     if (requestPattern.getHeaders() != null) {
@@ -144,6 +146,11 @@ public class RequestPatternBuilder {
 
   public RequestPatternBuilder withPort(int port) {
     this.port = port;
+    return this;
+  }
+
+  public RequestPatternBuilder withClientIp(StringValuePattern clientIpPattern) {
+    this.clientIpPattern = clientIpPattern;
     return this;
   }
 
@@ -270,6 +277,7 @@ public class RequestPatternBuilder {
         scheme,
         hostPattern,
         port,
+        clientIpPattern,
         url,
         method,
         headers.isEmpty() ? null : headers,

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,6 +106,7 @@ public class Diff {
 
     addHostSectionIfPresent(diffLineList);
     addPortSectionIfPresent(diffLineList);
+    addClientIpSectionIfPresent(diffLineList);
     addSchemeSectionIfPresent(diffLineList);
     addMethodSection(diffLineList);
     UrlPattern urlPattern = getFirstNonNull(requestPattern.getUrlMatcher(), anyUrl());
@@ -348,6 +349,17 @@ public class Diff {
       DiffLine<String> portSection =
           new DiffLine<>("Port", expectedPort, actualPort, expectedPort.getExpected());
       diffLineList.addAll(toDiffDescriptionLines(portSection));
+    }
+  }
+
+  private void addClientIpSectionIfPresent(List<DiffLine<?>> diffLineList) {
+    if (requestPattern.getClientIp() != null) {
+      StringValuePattern expectedClientIp = equalTo(String.valueOf(requestPattern.getClientIp()));
+      String actualClientIp = request.getClientIp();
+      DiffLine<String> clientIpSection =
+          new DiffLine<>(
+              "ClientIp", expectedClientIp, actualClientIp, expectedClientIp.getExpected());
+      diffLineList.addAll(toDiffDescriptionLines(clientIpSection));
     }
   }
 

--- a/src/main/resources/swagger/wiremock-admin-api.json
+++ b/src/main/resources/swagger/wiremock-admin-api.json
@@ -2134,6 +2134,10 @@
             "maximum": 65535,
             "description": "The HTTP port number of the request URL"
           },
+          "clientIp": {
+            "type": "string",
+            "description": "The IP of the client making the request"
+          },
           "method": {
             "type": "string",
             "pattern": "^[A-Z]+$",

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingWithBrowserProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingWithBrowserProxyAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Thomas Akehurst
+ * Copyright (C) 2020-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,45 @@ public class StubbingWithBrowserProxyAcceptanceTest {
     stubFor(get(urlPathEqualTo("/mypath")).withPort(1234).willReturn(ok(EXPECTED_RESPONSE_BODY)));
 
     ClassicHttpRequest request = ClassicRequestBuilder.get("http://localhost:4321/mypath").build();
+    makeRequestAndAssertNotOk(request);
+  }
+
+  @Test
+  public void matchesClientIp() throws Exception {
+    stubFor(
+        get(urlPathEqualTo("/mypath"))
+            .withClientIp(equalTo("192.168.1.1"))
+            .willReturn(ok(EXPECTED_RESPONSE_BODY)));
+
+    ClassicHttpRequest request =
+        ClassicRequestBuilder.get("http://localhost:1234/mypath")
+            .addHeader("X-Forwarded-For", "192.168.1.1")
+            .build();
+    makeRequestAndAssertOk(request);
+  }
+
+  @Test
+  public void doesNotMatchClientIpWhenItIsIncorrect() throws Exception {
+    stubFor(
+        get(urlPathEqualTo("/mypath"))
+            .withClientIp(equalTo("192.168.1.1"))
+            .willReturn(ok(EXPECTED_RESPONSE_BODY)));
+
+    ClassicHttpRequest request =
+        ClassicRequestBuilder.get("http://localhost:1234/mypath")
+            .addHeader("X-Forwarded-For", "192.168.100.1")
+            .build();
+    makeRequestAndAssertNotOk(request);
+  }
+
+  @Test
+  public void doesNotMatchClientIpWhenHeaderIsNotPresent() throws Exception {
+    stubFor(
+        get(urlPathEqualTo("/mypath"))
+            .withClientIp(equalTo("5.5.5.5"))
+            .willReturn(ok(EXPECTED_RESPONSE_BODY)));
+
+    ClassicHttpRequest request = ClassicRequestBuilder.get("http://localhost:1234/mypath").build();
     makeRequestAndAssertNotOk(request);
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ class RequestPatternBuilderTest {
             "https",
             WireMock.equalTo("my.wiremock.org"),
             1234,
+            WireMock.equalTo("192.168.2.2"),
             WireMock.urlEqualTo("/foo"),
             RequestMethod.POST,
             Map.of("X-Header", MultiValuePattern.of(WireMock.equalTo("bar"))),
@@ -127,6 +128,7 @@ class RequestPatternBuilderTest {
             "https",
             WireMock.equalTo("my.wiremock.org"),
             1234,
+            WireMock.equalTo("192.168.1.1"),
             WireMock.urlEqualTo("/foo"),
             RequestMethod.POST,
             Map.of("X-Header", MultiValuePattern.of(WireMock.equalTo("bar"))),

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/diff/DiffTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/diff/DiffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -495,6 +495,21 @@ class DiffTest {
             junitStyleDiffMessage(
                 "[contains] my.host\n" + "ANY\n" + "/thing\n",
                 "wrong.host\n" + "ANY\n" + "/thing\n")));
+  }
+
+  @Test
+  void includeClientIpIfSpecified() {
+    Diff diff =
+        new Diff(
+            newRequestPattern(ANY, anyUrl()).withClientIp(equalTo("192.168.1.1")).build(),
+            mockRequest().clientIp("192.168.2.2").url("/thing"));
+
+    assertThat(
+        diff.toString(),
+        is(
+            junitStyleDiffMessage(
+                "equalTo 192.168.1.1\n" + "ANY\n" + "/thing\n",
+                "192.168.2.2\n" + "ANY\n" + "/thing\n")));
   }
 
   @Test


### PR DESCRIPTION
This PR adds a new native matcher for client IP address that is available in wiremock's request ([see here](https://github.com/wiremock/wiremock/blob/7257dd665facf7329a656d14987ccfecff33606d/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java#L121) for reference where the actual value is loaded from). This improvement came up during a slack discussion available below. 

Usage looks like this:

```
wm.stubFor(get(anyUrl()).withClientIp(equalTo("127.0.0.1")));
```

As a native matcher, it benefits from a improved diff output in case of errors:

![image](https://github.com/user-attachments/assets/5c54268e-03b9-4196-a923-f4391f2bca44)



This new matcher is basically syntactic sugar for:

```
wm.stubFor(get(anyUrl()).andMatching(r -> equalTo("127.0.0.1").match(r.getClientIp())));
```

And the diff output without the native matcher would look like below (no extra info in case of failure):

![image](https://github.com/user-attachments/assets/0b4797bd-5818-4de8-a970-54a9a292ac4b)


## References

Slack conversation: https://wiremock-community.slack.com/archives/C04HHJ7F20G/p1741182115686839
<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)