### PR TITLE
Add `getRawBody()` to `Request`

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapper.java
@@ -221,6 +221,11 @@ public class RequestWrapper implements Request {
   }
 
   @Override
+  public byte[] getRawBody() {
+    return delegate.getRawBody();
+  }
+
+  @Override
   public String getBodyAsString() {
     if (bodyTransformer != null) {
       return bodyTransformer.transform(new Body(delegate.getBodyAsString())).asString();

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
@@ -163,6 +163,11 @@ public class ImmutableRequest implements Request {
   }
 
   @Override
+  public byte[] getRawBody() {
+    return body;
+  }
+
+  @Override
   public String getBodyAsString() {
     return Strings.stringFromBytes(body);
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -83,7 +83,21 @@ public interface Request {
 
   Map<String, Cookie> getCookies();
 
+  /**
+   * Returns the body of the request.
+   * <p>
+   * It will transparently decode the body if it is encoded with gzip.
+   * @return the body of the request
+   */
   byte[] getBody();
+
+  /**
+   * Returns the raw body of the request.
+   * <p>
+   * It will not decode the body if it is encoded with gzip.
+   * @return the raw body of the request
+   */
+  byte[] getRawBody();
 
   String getBodyAsString();
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/RequestIdDecorator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/RequestIdDecorator.java
@@ -135,6 +135,11 @@ public class RequestIdDecorator implements Request {
   }
 
   @Override
+  public byte[] getRawBody() {
+    return request.getRawBody();
+  }
+
+  @Override
   public String getBodyAsString() {
     return request.getBodyAsString();
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/RequestPathParamsDecorator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/RequestPathParamsDecorator.java
@@ -140,6 +140,11 @@ public class RequestPathParamsDecorator implements Request {
   }
 
   @Override
+  public byte[] getRawBody() {
+    return request.getRawBody();
+  }
+
+  @Override
   public String getBodyAsString() {
     return request.getBodyAsString();
   }

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -52,6 +52,7 @@ public class LoggedRequest implements Request {
   private final Map<String, QueryParameter> queryParams;
   private final Map<String, FormParameter> formParameters;
   private final byte[] body;
+  private byte[] rawBody;
   private final boolean isBrowserProxyRequest;
   private final Date loggedDate;
   private final Collection<Part> multiparts;
@@ -76,6 +77,7 @@ public class LoggedRequest implements Request {
         request.isBrowserProxyRequest(),
         new Date(),
         request.getBody(),
+        request.getRawBody(),
         request.getParts(),
         request.getProtocol(),
         request.formParameters());
@@ -110,6 +112,7 @@ public class LoggedRequest implements Request {
         isBrowserProxyRequest,
         loggedDate,
         decodeBase64(bodyAsBase64),
+        decodeBase64(bodyAsBase64),
         multiparts,
         protocol,
         new HashMap<>());
@@ -130,6 +133,7 @@ public class LoggedRequest implements Request {
       boolean isBrowserProxyRequest,
       Date loggedDate,
       byte[] body,
+      byte[] rawBody,
       Collection<Part> multiparts,
       String protocol,
       Map<String, FormParameter> formParameters) {
@@ -137,7 +141,8 @@ public class LoggedRequest implements Request {
     this.url = url;
 
     this.absoluteUrl = absoluteUrl;
-    if (absoluteUrl == null) {
+      this.rawBody = rawBody;
+      if (absoluteUrl == null) {
       this.scheme = scheme;
       this.host = host;
       this.port = port != null ? port : -1;
@@ -256,6 +261,11 @@ public class LoggedRequest implements Request {
   @Override
   public byte[] getBody() {
     return body;
+  }
+
+  @Override
+  public byte[] getRawBody() {
+    return rawBody;
   }
 
   @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/diff/EmptyToStringRequestWrapper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/diff/EmptyToStringRequestWrapper.java
@@ -120,6 +120,11 @@ public class EmptyToStringRequestWrapper implements Request {
   }
 
   @Override
+  public byte[] getRawBody() {
+    return target.getRawBody();
+  }
+
+  @Override
   public String getBodyAsString() {
     return target.getBodyAsString();
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/GzipAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/GzipAcceptanceTest.java
@@ -22,13 +22,16 @@ import static com.github.tomakehurst.wiremock.common.Strings.randomAlphabetic;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import com.github.tomakehurst.wiremock.common.Gzip;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import org.apache.hc.client5.http.entity.GzipCompressingEntity;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
@@ -38,6 +41,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 public class GzipAcceptanceTest {
 
@@ -91,6 +97,12 @@ public class GzipAcceptanceTest {
       WireMockResponse response = testClient.post("/gzip-request", compressedBody);
 
       assertThat(response.content(), is("response body"));
+
+      List<LoggedRequest> loggedRequests = wireMockServer.findAll(postRequestedFor(anyUrl()));
+      assertThat(loggedRequests, hasSize(1));
+      assertThat(loggedRequests.get(0).getBodyAsString(), is("request body"));
+      assertThat(loggedRequests.get(0).getBody(), is("request body".getBytes(StandardCharsets.UTF_8)));
+      assertThat(loggedRequests.get(0).getRawBody(), is(Gzip.gzip("request body")));
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
@@ -253,6 +253,11 @@ public class MockRequest implements Request {
   }
 
   @Override
+  public byte[] getRawBody() {
+    return body;
+  }
+
+  @Override
   public String getBodyAsString() {
     return body != null ? new String(body) : null;
   }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- fixes #547 

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
