### PR TITLE
fix: handle null key in RequestPartTemplateModel for RFC 2387 compliance

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Thomas Akehurst
+ * Copyright (C) 2021-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,6 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Maps;
-
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -185,12 +184,15 @@ public class TemplateEngine {
         int partIndex = 0;
         for (Request.Part part : request.getParts()) {
           String key = part.getName() != null ? part.getName() : "part-" + partIndex++;
-          result.put(key, new RequestPartTemplateModel(
+          result.put(
               key,
-              part.getHeaders().all().stream()
-                  .collect(Collectors.toMap(
-                      HttpHeader::key, header -> ListOrSingle.of(header.values()))),
-              part.getBody()));
+              new RequestPartTemplateModel(
+                  key,
+                  part.getHeaders().all().stream()
+                      .collect(
+                          Collectors.toMap(
+                              HttpHeader::key, header -> ListOrSingle.of(header.values()))),
+                  part.getBody()));
         }
 
         return result;
@@ -205,7 +207,8 @@ public class TemplateEngine {
                             part.getHeaders().all().stream()
                                 .collect(
                                     Collectors.toMap(
-                                        HttpHeader::key, header -> ListOrSingle.of(header.values()))),
+                                        HttpHeader::key,
+                                        header -> ListOrSingle.of(header.values()))),
                             part.getBody())));
       }
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartTemplatingAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Thomas Akehurst
+ * Copyright (C) 2024-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,12 +187,13 @@ public class MultipartTemplatingAcceptanceTest {
   void acceptsAMultipartRelatedRFC2387Request() throws Exception {
     final String boundary = "boundary_example";
 
-    final String expectBody = "{\n" +
-        "  \"error\": {\n" +
-        "    \"code\": 404,\n" +
-        "    \"message\": \"parent not found.\"\n" +
-        "  }\n" +
-        "}";
+    final String expectBody =
+        "{\n"
+            + "  \"error\": {\n"
+            + "    \"code\": 404,\n"
+            + "    \"message\": \"parent not found.\"\n"
+            + "  }\n"
+            + "}";
 
     wm.stubFor(
         post(urlPathMatching("/templated"))
@@ -200,29 +201,35 @@ public class MultipartTemplatingAcceptanceTest {
             .withHeader("Authorization", matching("^Bearer [a-zA-Z0-9_\\-.]+$"))
             .withHeader("Content-Type", equalTo("multipart/related; boundary=" + boundary))
             .withHeader("Content-Length", equalTo("255"))
-            .willReturn(aResponse()
-                .withStatus(404)
-                .withHeader("Content-Type", "application/json; charset=UTF-8")
-                .withBody(expectBody)));
+            .willReturn(
+                aResponse()
+                    .withStatus(404)
+                    .withHeader("Content-Type", "application/json; charset=UTF-8")
+                    .withBody(expectBody)));
 
     String rfc2387Body =
-        "--" + boundary + "\r\n" +
-            "Content-Type: application/json; charset=UTF-8\r\n\r\n" +
-            "{\"parents\": [\"parents_example\"], \"name\": \"test_upload.txt\"}\r\n" +
-            "--" + boundary + "\r\n" +
-            "Content-Transfer-Encoding: base64\r\n\r\n" +
-            "VGhpcyBpcyBhbiBleGFtcGxlIGJpbmFyeSBkYXRhLg==\r\n" +
-            "--" + boundary + "--\r\n";
+        "--"
+            + boundary
+            + "\r\n"
+            + "Content-Type: application/json; charset=UTF-8\r\n\r\n"
+            + "{\"parents\": [\"parents_example\"], \"name\": \"test_upload.txt\"}\r\n"
+            + "--"
+            + boundary
+            + "\r\n"
+            + "Content-Transfer-Encoding: base64\r\n\r\n"
+            + "VGhpcyBpcyBhbiBleGFtcGxlIGJpbmFyeSBkYXRhLg==\r\n"
+            + "--"
+            + boundary
+            + "--\r\n";
 
-    HttpEntity entity = new StringEntity(
-        rfc2387Body,
-        ContentType.create("multipart/related", "UTF-8")
-    );
+    HttpEntity entity =
+        new StringEntity(rfc2387Body, ContentType.create("multipart/related", "UTF-8"));
 
-    TestHttpHeader[] headers = new TestHttpHeader[]{
-        new TestHttpHeader("Authorization", "Bearer token"),
-        new TestHttpHeader("Content-Type", "multipart/related; boundary=" + boundary)
-    };
+    TestHttpHeader[] headers =
+        new TestHttpHeader[] {
+          new TestHttpHeader("Authorization", "Bearer token"),
+          new TestHttpHeader("Content-Type", "multipart/related; boundary=" + boundary)
+        };
 
     WireMockResponse response = client.post("/templated?uploadType=multipart", entity, headers);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartTemplatingAcceptanceTest.java
@@ -21,10 +21,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.testsupport.TestHttpHeader;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -178,5 +181,52 @@ public class MultipartTemplatingAcceptanceTest {
             "multipart:true\n"
                 + "[name='file', headers={content-disposition=form-data; name=\"file\"; filename=\"abcd.bin\", content-type=application/octet-stream}, body=ABCD]\n"
                 + "[name='text', headers={content-disposition=form-data; name=\"text\", content-type=text/plain; charset=UTF-8}, body=hello]\n"));
+  }
+
+  @Test
+  void acceptsAMultipartRelatedRFC2387Request() throws Exception {
+    final String boundary = "boundary_example";
+
+    final String expectBody = "{\n" +
+        "  \"error\": {\n" +
+        "    \"code\": 404,\n" +
+        "    \"message\": \"parent not found.\"\n" +
+        "  }\n" +
+        "}";
+
+    wm.stubFor(
+        post(urlPathMatching("/templated"))
+            .withQueryParam("uploadType", equalTo("multipart"))
+            .withHeader("Authorization", matching("^Bearer [a-zA-Z0-9_\\-.]+$"))
+            .withHeader("Content-Type", equalTo("multipart/related; boundary=" + boundary))
+            .withHeader("Content-Length", equalTo("255"))
+            .willReturn(aResponse()
+                .withStatus(404)
+                .withHeader("Content-Type", "application/json; charset=UTF-8")
+                .withBody(expectBody)));
+
+    String rfc2387Body =
+        "--" + boundary + "\r\n" +
+            "Content-Type: application/json; charset=UTF-8\r\n\r\n" +
+            "{\"parents\": [\"parents_example\"], \"name\": \"test_upload.txt\"}\r\n" +
+            "--" + boundary + "\r\n" +
+            "Content-Transfer-Encoding: base64\r\n\r\n" +
+            "VGhpcyBpcyBhbiBleGFtcGxlIGJpbmFyeSBkYXRhLg==\r\n" +
+            "--" + boundary + "--\r\n";
+
+    HttpEntity entity = new StringEntity(
+        rfc2387Body,
+        ContentType.create("multipart/related", "UTF-8")
+    );
+
+    TestHttpHeader[] headers = new TestHttpHeader[]{
+        new TestHttpHeader("Authorization", "Bearer token"),
+        new TestHttpHeader("Content-Type", "multipart/related; boundary=" + boundary)
+    };
+
+    WireMockResponse response = client.post("/templated?uploadType=multipart", entity, headers);
+
+    assertThat(response.content(), is(expectBody));
+    assertThat(response.statusCode(), is(404));
   }
 }


### PR DESCRIPTION
According to RFC 2387, request part name is an optional parameter for multipart/related content. When global templating is enabled, null part names cause duplicate key issues in the template model map. This change ensures proper handling of null keys in RequestPartTemplateModel to prevent errors when processing multipart/related requests without part names.

<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
