### PR TITLE
Extend LogNormal to add an optional maxValue

### DIFF
--- a/src/main/resources/swagger/schemas/equal-to-json-pattern.yaml
+++ b/src/main/resources/swagger/schemas/equal-to-json-pattern.yaml
@@ -2,9 +2,15 @@ title: JSON equals
 type: object
 properties:
   equalToJson:
-    type: string
-    example: |
-      { "message": "hello" }
+    oneOf:
+      - type: object
+        description: The JSON object to match.
+        example:
+          message: hello
+      - type: string
+        description: A JSON-encoded JSON string to match.
+        example: |-
+          { "message": "hello" }
   ignoreExtraElements:
     type: boolean
   ignoreArrayOrder:

--- a/src/main/resources/swagger/schemas/equal-to-xml-pattern.yaml
+++ b/src/main/resources/swagger/schemas/equal-to-xml-pattern.yaml
@@ -3,12 +3,13 @@ type: object
 properties:
   equalToXml:
     type: string
-    example: "<amount>123</amount>"
+    example: |-
+      <amount>123</amount>
   enablePlaceholders:
     type: boolean
   placeholderOpeningDelimiterRegex:
     type: string
-    example: "["
+    example: "\\["
   placeholderClosingDelimiterRegex:
     type: string
     example: "]"

--- a/src/main/resources/swagger/schemas/matches-json-schema-pattern.yaml
+++ b/src/main/resources/swagger/schemas/matches-json-schema-pattern.yaml
@@ -2,24 +2,27 @@ title: JSON Schema match
 type: object
 properties:
   matchesJsonSchema:
-    oneOf:
-      - type: string
-        example: "//Order/Amount"
-      - type: object
-        allOf:
-          - properties:
-              expression:
-                type: string
-                example: "//Order/Amount"
-          - $ref: "content-pattern.yaml"
-
-        required:
-          - expression
-
-  xPathNamespaces:
     type: object
-    additionalProperties:
-      type: string
+    description: A valid JSON schema object
+    example:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+  schemaVersion:
+    description: The JSON schema version to interpret the schema against
+    example: "V202012"
+    enum:
+      - V4
+      - V6
+      - V7
+      - V201909
+      - V202012
 
 required:
   - matchesJsonSchema

--- a/src/main/resources/swagger/schemas/not-pattern.yaml
+++ b/src/main/resources/swagger/schemas/not-pattern.yaml
@@ -1,4 +1,4 @@
-title: NOT modifier
+title: Logical NOT modifier
 type: object
 properties:
   not:

--- a/src/main/resources/swagger/schemas/request-pattern.yaml
+++ b/src/main/resources/swagger/schemas/request-pattern.yaml
@@ -1,5 +1,5 @@
 type: object
-example: |
+example: |-
   {
     "urlPath" : "/charges",
     "method" : "POST",
@@ -8,6 +8,7 @@ example: |
         "equalTo" : "application/json"
       }
     }
+  }
 properties:
   scheme:
     type: string
@@ -42,7 +43,7 @@ properties:
 
   pathParameters:
     type: object
-    description: |
+    description: |-
       Path parameter patterns to match against in the <key>: { "<predicate>": "<value>" } form. Can only
       be used when the urlPathPattern URL match type is in use and all keys must be present as variables
       in the path template.
@@ -78,6 +79,7 @@ properties:
     required:
       - username
       - password
+
   cookies:
     type: object
     description: 'Cookie patterns to match against in the <key>: { "<predicate>": "<value>" } form'
@@ -85,7 +87,7 @@ properties:
       $ref: "content-pattern.yaml"
   bodyPatterns:
     type: array
-    description: 'Request body patterns to match against in the <key>: { "<predicate>": "<value>" } form'
+    description: 'Request body patterns to match against in the { "<predicate>": "<value>" } form'
     items:
       $ref: "content-pattern.yaml"
 
@@ -124,6 +126,6 @@ properties:
 
         bodyPatterns:
           type: array
-          description: 'Body patterns to match against in the <key>: { "<predicate>": "<value>" } form'
+          description: 'Body patterns to match against in the { "<predicate>": "<value>" } form'
           items:
             $ref: "content-pattern.yaml"

--- a/src/main/resources/swagger/wiremock-admin-api.yaml
+++ b/src/main/resources/swagger/wiremock-admin-api.yaml
@@ -334,8 +334,6 @@ paths:
             application/json:
               example:
                 $ref: "examples/requests.yaml"
-                    
-                    
 
   /__admin/requests/remove-by-metadata:
     post:
@@ -548,7 +546,7 @@ paths:
                   type: string
                 example: ["file1.json", "file2.json", "file3.txt"]
           description: All scenarios
-          
+
   /__admin/files/{fileId}:
     parameters:
       - description: The name of the file
@@ -576,7 +574,7 @@ paths:
       requestBody:
         content:
           application/octet-stream:
-            schema: 
+            schema:
               type: string
               format: byte
       responses:
@@ -635,7 +633,6 @@ paths:
       responses:
         '200':
           description: Server will be shut down
-          
 
   /__admin/version:
     get:
@@ -647,7 +644,7 @@ paths:
       responses:
         '200':
           description: Successfully returned the version of the WireMock server
-          content: 
+          content:
             application/json:
               schema:
                 type: object


### PR DESCRIPTION
Extend LogNormal to add an optional maxValue to force long tails to be truncated and the value resampled if greater than the max. The reason this might be necessary is that with some log normal configurations, a curve with quite a long tail can be experienced that can cause unexpected or unwanted timeouts in upstream systems. Setting a maximum delay value can prevent this from happening. If the value generated is greater than the max, then it is resampled a number of times (10) and then finally, the max of the two values is taken (to prevent resampling indefinitely)

Documentation changes will be raised in a subsequent PR but look as follows:

![image](https://github.com/user-attachments/assets/5dd417d0-56ca-43d1-8c84-c3df27c42c5e)


## References

- This changes replaces [this original PR](https://github.com/wiremock/wiremock/pull/1694) which had `CappedLogNormal` as a new subclass of `LogNormal` 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
