### PR TITLE
fix: matched stub name header value encoding.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import com.github.tomakehurst.wiremock.store.SettingsStore;
 import com.github.tomakehurst.wiremock.store.files.BlobStoreFileSource;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class StubResponseRenderer implements ResponseRenderer {
@@ -134,7 +135,11 @@ public class StubResponseRenderer implements ResponseRenderer {
               .plus(new HttpHeader("Matched-Stub-Id", stubMapping.getId().toString()));
 
       if (stubMapping.getName() != null) {
-        headers = headers.plus(new HttpHeader("Matched-Stub-Name", stubMapping.getName()));
+        // ensure stub name is compliant with http spec header values
+        // https://www.rfc-editor.org/rfc/rfc9110.html#name-field-values.
+        String sanitisedStubName =
+            new String(stubMapping.getName().getBytes(StandardCharsets.US_ASCII));
+        headers = headers.plus(new HttpHeader("Matched-Stub-Name", sanitisedStubName));
       }
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/DebugHeadersAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/DebugHeadersAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Thomas Akehurst
+ * Copyright (C) 2018-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package com.github.tomakehurst.wiremock;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -57,5 +59,13 @@ public class DebugHeadersAcceptanceTest extends AcceptanceTestBase {
 
     assertThat(response.firstHeader("Matched-Stub-Id"), nullValue());
     assertThat(response.firstHeader("Matched-Stub-Name"), nullValue());
+  }
+
+  @Test
+  public void nonAsciiCharactersAreReplacedByQuestionMarksInStubNameHeader() {
+    wireMockServer.stubFor(any(anyUrl()).withName("start Запрос ?? åéã end").willReturn(ok()));
+
+    WireMockResponse response = testClient.get("/the-match");
+    assertThat(response.firstHeader("Matched-Stub-Name"), is("start ?????? ?? ??? end"));
   }
 }


### PR DESCRIPTION
non-iso_8859_1 characters fail to be hpack encoded by jetty's http2 implementation, and iso_8859_1 characters that are not ascii characters are not handled well by most clients because they assume utf-8 encoding.

https://www.rfc-editor.org/rfc/rfc9110.html#name-field-values

fixes https://github.com/wiremock/wiremock/issues/2872

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
