### PR TITLE
Reduce visibility of Recorder API that does not need to be public

### DIFF
--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
@@ -125,7 +125,7 @@ public class Recorder {
     return recordSpec.getOutputFormat().format(stubMappings);
   }
 
-  public List<StubMapping> serveEventsToStubMappings(
+  private List<StubMapping> serveEventsToStubMappings(
       List<ServeEvent> serveEventsResult,
       ProxiedServeEventFilters serveEventFilters,
       SnapshotStubMappingGenerator stubMappingGenerator,
@@ -139,7 +139,7 @@ public class Recorder {
     return stubMappingPostProcessor.process(stubMappings);
   }
 
-  public SnapshotStubMappingPostProcessor getStubMappingPostProcessor(RecordSpec recordSpec) {
+  private SnapshotStubMappingPostProcessor getStubMappingPostProcessor(RecordSpec recordSpec) {
     final SnapshotStubMappingTransformerRunner transformerRunner =
         new SnapshotStubMappingTransformerRunner(
             extensions.ofType(StubMappingTransformer.class).values(),

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessor.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessor.java
@@ -34,13 +34,13 @@ import java.util.Objects;
  *   <li>Extract response bodies to a separate file, if applicable.
  * </ol>
  */
-public class SnapshotStubMappingPostProcessor {
+class SnapshotStubMappingPostProcessor {
   private final boolean shouldRecordRepeatsAsScenarios;
   private final SnapshotStubMappingTransformerRunner transformerRunner;
   private final ResponseDefinitionBodyMatcher bodyExtractMatcher;
   private final SnapshotStubMappingBodyExtractor bodyExtractor;
 
-  public SnapshotStubMappingPostProcessor(
+  SnapshotStubMappingPostProcessor(
       boolean shouldRecordRepeatsAsScenarios,
       SnapshotStubMappingTransformerRunner transformerRunner,
       ResponseDefinitionBodyMatcher bodyExtractMatcher,
@@ -51,7 +51,7 @@ public class SnapshotStubMappingPostProcessor {
     this.bodyExtractor = bodyExtractor;
   }
 
-  public List<StubMapping> process(List<Pair<ServeEvent, StubMapping>> serveEventsToStubMappings) {
+  List<StubMapping> process(List<Pair<ServeEvent, StubMapping>> serveEventsToStubMappings) {
     // 1. Run any applicable StubMappingTransformers against the stub mappings.
     List<StubMapping> transformedStubMappings =
         serveEventsToStubMappings.stream().map(transformerRunner).filter(Objects::nonNull).toList();

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingTransformerRunner.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingTransformerRunner.java
@@ -30,19 +30,18 @@ import java.util.function.Function;
  * Applies all registered StubMappingTransformer extensions against a stub mapping when applicable,
  * passing them any supplied Parameters.
  */
-public class SnapshotStubMappingTransformerRunner
+class SnapshotStubMappingTransformerRunner
     implements Function<Pair<ServeEvent, StubMapping>, StubMapping> {
   private final FileSource filesRoot;
   private final Parameters parameters;
   private final Iterable<StubMappingTransformer> registeredTransformers;
   private final List<String> requestedTransformers;
 
-  public SnapshotStubMappingTransformerRunner(
-      Iterable<StubMappingTransformer> registeredTransformers) {
+  SnapshotStubMappingTransformerRunner(Iterable<StubMappingTransformer> registeredTransformers) {
     this(registeredTransformers, null, null, null);
   }
 
-  public SnapshotStubMappingTransformerRunner(
+  SnapshotStubMappingTransformerRunner(
       Iterable<StubMappingTransformer> registeredTransformers,
       List<String> requestedTransformers,
       Parameters parameters,


### PR DESCRIPTION
As far as we can see the `SnapshotStubMappingPostProcessor` and `SnapshotStubMappingTransformerRunner` do not need to be public API - they are instantiated explicitly by `Recorder` and cannot be injected anywhere.

We want to change their API, so reducing the visibility first.

Likewise, we see no benefit to `Recorder.getStubMappingPostProcessor` and `Recorder.serveEventsToStubMappings` being public, they are only called by `takeSnapshot`.

## References

https://github.com/wiremock/wiremock/pull/3039

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
