### PR TITLE
Mark Recording API that does not need to be public deprecated

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,20 +124,33 @@ public class Recorder {
     return recordSpec.getOutputFormat().format(stubMappings);
   }
 
+  /**
+   * @deprecated This method will become non-public in the next major version. If you rely on it,
+   *     please contact the maintainers.
+   */
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated(forRemoval = true)
   public List<StubMapping> serveEventsToStubMappings(
       List<ServeEvent> serveEventsResult,
       ProxiedServeEventFilters serveEventFilters,
       SnapshotStubMappingGenerator stubMappingGenerator,
-      SnapshotStubMappingPostProcessor stubMappingPostProcessor) {
+      @SuppressWarnings("removal") SnapshotStubMappingPostProcessor stubMappingPostProcessor) {
     final List<StubMapping> stubMappings =
         serveEventsResult.stream()
             .filter(serveEventFilters)
             .map(stubMappingGenerator)
             .collect(Collectors.toList());
 
+    //noinspection removal
     return stubMappingPostProcessor.process(stubMappings);
   }
 
+  /**
+   * @deprecated This method will become non-public in the next major version. If you rely on it,
+   *     please contact the maintainers.
+   */
+  @SuppressWarnings({"DeprecatedIsStillUsed", "removal"})
+  @Deprecated(forRemoval = true)
   public SnapshotStubMappingPostProcessor getStubMappingPostProcessor(RecordSpec recordSpec) {
     final SnapshotStubMappingTransformerRunner transformerRunner =
         new SnapshotStubMappingTransformerRunner(

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessor.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,16 +33,24 @@ import java.util.List;
  *   <li>Detect duplicate requests and either discard them or turn them into scenarios.
  *   <li>Extract response bodies to a separate file, if applicable.
  * </ol>
+ *
+ * @deprecated This class will become non-public in the next major version. If you rely on it,
+ *     please contact the maintainers.
  */
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated(forRemoval = true)
 public class SnapshotStubMappingPostProcessor {
   private final boolean shouldRecordRepeatsAsScenarios;
+
+  @SuppressWarnings("removal")
   private final SnapshotStubMappingTransformerRunner transformerRunner;
+
   private final ResponseDefinitionBodyMatcher bodyExtractMatcher;
   private final SnapshotStubMappingBodyExtractor bodyExtractor;
 
   public SnapshotStubMappingPostProcessor(
       boolean shouldRecordRepeatsAsScenarios,
-      SnapshotStubMappingTransformerRunner transformerRunner,
+      @SuppressWarnings("removal") SnapshotStubMappingTransformerRunner transformerRunner,
       ResponseDefinitionBodyMatcher bodyExtractMatcher,
       SnapshotStubMappingBodyExtractor bodyExtractor) {
     this.shouldRecordRepeatsAsScenarios = shouldRecordRepeatsAsScenarios;

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingTransformerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingTransformerRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,12 @@ import java.util.function.Function;
 /**
  * Applies all registered StubMappingTransformer extensions against a stub mapping when applicable,
  * passing them any supplied Parameters.
+ *
+ * @deprecated This class will become non-public in the next major version. If you rely on it,
+ *     please contact the maintainers.
  */
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated(forRemoval = true)
 public class SnapshotStubMappingTransformerRunner implements Function<StubMapping, StubMapping> {
   private final FileSource filesRoot;
   private final Parameters parameters;


### PR DESCRIPTION
As far as we can see the `SnapshotStubMappingPostProcessor` and `SnapshotStubMappingTransformerRunner` do not need to be public API - they are instantiated explicitly by `Recorder` and cannot be injected anywhere.

We want to change their API in v4, so reducing the visibility first.

Likewise, we see no benefit to `Recorder.getStubMappingPostProcessor` and `Recorder.serveEventsToStubMappings` being public, they are only called by `takeSnapshot`.

<!-- Please describe your pull request here. -->

## References

https://github.com/wiremock/wiremock/pull/3038

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
