### PR TITLE
Mark APIs that will stop being public in v4.x as deprecated

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
@@ -121,6 +121,7 @@ public class Recorder {
       admin.addStubMapping(stubMapping);
     }
 
+    //noinspection removal
     return recordSpec.getOutputFormat().format(stubMappings);
   }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
@@ -105,6 +105,7 @@ public class Recorder {
     return input -> input.getId().equals(id);
   }
 
+  @SuppressWarnings("removal")
   public SnapshotRecordResult takeSnapshot(List<ServeEvent> serveEvents, RecordSpec recordSpec) {
     final List<StubMapping> stubMappings =
         serveEventsToStubMappings(
@@ -121,7 +122,6 @@ public class Recorder {
       admin.addStubMapping(stubMapping);
     }
 
-    //noinspection removal
     return recordSpec.getOutputFormat().format(stubMappings);
   }
 
@@ -134,7 +134,7 @@ public class Recorder {
   public List<StubMapping> serveEventsToStubMappings(
       List<ServeEvent> serveEventsResult,
       ProxiedServeEventFilters serveEventFilters,
-      SnapshotStubMappingGenerator stubMappingGenerator,
+      @SuppressWarnings("removal") SnapshotStubMappingGenerator stubMappingGenerator,
       @SuppressWarnings("removal") SnapshotStubMappingPostProcessor stubMappingPostProcessor) {
     final List<StubMapping> stubMappings =
         serveEventsResult.stream()

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformer.java
@@ -30,10 +30,14 @@ import java.util.function.Function;
  * Creates a RequestPatternBuilder from a Request's URL, method, body (if present), and optionally
  * headers from a whitelist.
  */
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated(forRemoval = true)
 public class RequestPatternTransformer implements Function<Request, RequestPatternBuilder> {
   private final Map<String, CaptureHeadersSpec> headers;
   private final RequestBodyPatternFactory bodyPatternFactory;
 
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated(forRemoval = true)
   public RequestPatternTransformer(
       Map<String, CaptureHeadersSpec> headers, RequestBodyPatternFactory bodyPatternFactory) {
     this.headers = headers;

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
@@ -25,8 +25,12 @@ import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated(forRemoval = true)
 public class ScenarioProcessor {
 
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated(forRemoval = true)
   public void putRepeatedRequestsInScenarios(List<StubMapping> stubMappings) {
     Map<RequestPattern, List<StubMapping>> stubsGroupedByRequest =
         stubMappings.stream()

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotOutputFormatter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotOutputFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,18 +22,26 @@ import java.util.List;
 /** Wraps a list of generated StubMappings into a SnapshotRecordResult object */
 public enum SnapshotOutputFormatter {
   FULL {
+    @SuppressWarnings("removal")
     @Override
     public SnapshotRecordResult format(List<StubMapping> stubMappings) {
       return SnapshotRecordResult.full(stubMappings);
     }
   },
   IDS {
+    @SuppressWarnings("removal")
     @Override
     public SnapshotRecordResult format(List<StubMapping> stubMappings) {
       return SnapshotRecordResult.idsFromMappings(stubMappings);
     }
   };
 
+  /**
+   * @deprecated This method will become non-public in the next major version. If you rely on it,
+   *     please contact the maintainers.
+   */
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated(forRemoval = true)
   public abstract SnapshotRecordResult format(List<StubMapping> stubMappings);
 
   @JsonCreator

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractor.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractor.java
@@ -25,9 +25,13 @@ import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.store.BlobStore;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated(forRemoval = true)
 public class SnapshotStubMappingBodyExtractor {
   private final BlobStore filesBlobStore;
 
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated(forRemoval = true)
   public SnapshotStubMappingBodyExtractor(BlobStore filesBlobStore) {
     this.filesBlobStore = filesBlobStore;
   }
@@ -38,6 +42,8 @@ public class SnapshotStubMappingBodyExtractor {
    *
    * @param stubMapping Stub mapping to extract
    */
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated(forRemoval = true)
   public void extractInPlace(StubMapping stubMapping) {
     byte[] body = stubMapping.getResponse().getByteBody();
     HttpHeaders responseHeaders = stubMapping.getResponse().getHeaders();

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGenerator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,14 @@ import java.util.function.Function;
  * Transforms ServeEvents to StubMappings using RequestPatternTransformer and
  * LoggedResponseDefinitionTransformer
  */
+@SuppressWarnings({"DeprecatedIsStillUsed", "removal"})
+@Deprecated(forRemoval = true)
 public class SnapshotStubMappingGenerator implements Function<ServeEvent, StubMapping> {
   private final RequestPatternTransformer requestTransformer;
   private final LoggedResponseDefinitionTransformer responseTransformer;
 
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated(forRemoval = true)
   public SnapshotStubMappingGenerator(
       RequestPatternTransformer requestTransformer,
       LoggedResponseDefinitionTransformer responseTransformer) {
@@ -39,6 +43,8 @@ public class SnapshotStubMappingGenerator implements Function<ServeEvent, StubMa
     this.responseTransformer = responseTransformer;
   }
 
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated(forRemoval = true)
   public SnapshotStubMappingGenerator(
       Map<String, CaptureHeadersSpec> captureHeaders,
       RequestBodyPatternFactory requestBodyPatternFactory) {

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessor.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessor.java
@@ -46,19 +46,22 @@ public class SnapshotStubMappingPostProcessor {
   private final SnapshotStubMappingTransformerRunner transformerRunner;
 
   private final ResponseDefinitionBodyMatcher bodyExtractMatcher;
+
+  @SuppressWarnings("removal")
   private final SnapshotStubMappingBodyExtractor bodyExtractor;
 
   public SnapshotStubMappingPostProcessor(
       boolean shouldRecordRepeatsAsScenarios,
       @SuppressWarnings("removal") SnapshotStubMappingTransformerRunner transformerRunner,
       ResponseDefinitionBodyMatcher bodyExtractMatcher,
-      SnapshotStubMappingBodyExtractor bodyExtractor) {
+      @SuppressWarnings("removal") SnapshotStubMappingBodyExtractor bodyExtractor) {
     this.shouldRecordRepeatsAsScenarios = shouldRecordRepeatsAsScenarios;
     this.transformerRunner = transformerRunner;
     this.bodyExtractMatcher = bodyExtractMatcher;
     this.bodyExtractor = bodyExtractor;
   }
 
+  @SuppressWarnings("removal")
   public List<StubMapping> process(Collection<StubMapping> stubMappings) {
     // 1. Run any applicable StubMappingTransformers against the stub mappings.
     List<StubMapping> transformedStubMappings =
@@ -89,6 +92,7 @@ public class SnapshotStubMappingPostProcessor {
     return processedStubMappings;
   }
 
+  @SuppressWarnings("removal")
   private void extractStubMappingBodies(List<StubMapping> stubMappings) {
     if (bodyExtractMatcher == null) {
       return;

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.github.tomakehurst.wiremock.http.*;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("removal")
 public class LoggedResponseDefinitionTransformerTest {
   private LoggedResponseDefinitionTransformer aTransformer() {
     return new LoggedResponseDefinitionTransformer();

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("removal")
 public class RequestPatternTransformerTest {
   @Test
   public void applyIncludesMethodAndUrlMatchers() {

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("removal")
 public class ScenarioProcessorTest {
 
   private final ScenarioProcessor processor = new ScenarioProcessor();

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+@SuppressWarnings("removal")
 public class SnapshotStubMappingBodyExtractorTest {
   private FileSource filesSource;
   private SnapshotStubMappingBodyExtractor bodyExtractor;

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGeneratorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import java.util.concurrent.LinkedBlockingDeque;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("removal")
 public class SnapshotStubMappingGeneratorTest {
   @Test
   public void apply() {

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingPostProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("removal")
 public class SnapshotStubMappingPostProcessorTest {
 
   // NOTE: testStubMappings is not deeply immutable, as StubMappings are mutable, and to preserve

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingTransformerRunnerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingTransformerRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Thomas Akehurst
+ * Copyright (C) 2017-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.testsupport.NonGlobalStubMappingTransform
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("removal")
 public class SnapshotStubMappingTransformerRunnerTest {
   private final StubMapping stubMapping = WireMock.get("/").build();
 


### PR DESCRIPTION
## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
