### PR TITLE
Reduce visibility of API that does not need to be public

### DIFF
--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformer.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformer.java
@@ -30,8 +30,7 @@ import java.util.stream.Collectors;
  * Transforms a LoggedResponse into a ResponseDefinition, which will be used to construct a
  * StubMapping
  */
-public class LoggedResponseDefinitionTransformer
-    implements Function<LoggedResponse, ResponseDefinition> {
+class LoggedResponseDefinitionTransformer implements Function<LoggedResponse, ResponseDefinition> {
 
   private static final List<CaseInsensitiveKey> EXCLUDED_HEADERS =
       List.of(

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpecBuilder.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpecBuilder.java
@@ -30,7 +30,7 @@ public class RecordSpecBuilder {
   private String targetBaseUrl;
   private RequestPatternBuilder filterRequestPatternBuilder;
   private List<UUID> filterIds;
-  private Map<String, CaptureHeadersSpec> headers = new LinkedHashMap<>();
+  private final Map<String, CaptureHeadersSpec> headers = new LinkedHashMap<>();
   private RequestBodyPatternFactory requestBodyPatternFactory;
   private long maxTextBodySize = ResponseDefinitionBodyMatcher.DEFAULT_MAX_TEXT_SIZE;
   private long maxBinaryBodySize = ResponseDefinitionBodyMatcher.DEFAULT_MAX_BINARY_SIZE;
@@ -110,6 +110,7 @@ public class RecordSpecBuilder {
     return this;
   }
 
+  @SuppressWarnings("unused")
   public RecordSpecBuilder matchRequestBodyWithEqualToJson() {
     return matchRequestBodyWithEqualToJson(null, null);
   }
@@ -126,6 +127,7 @@ public class RecordSpecBuilder {
     return this;
   }
 
+  @SuppressWarnings("unused")
   public RecordSpecBuilder matchRequestBodyWithEqualTo() {
     return matchRequestBodyWithEqualTo(null);
   }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformer.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformer.java
@@ -30,11 +30,11 @@ import java.util.function.Function;
  * Creates a RequestPatternBuilder from a Request's URL, method, body (if present), and optionally
  * headers from a whitelist.
  */
-public class RequestPatternTransformer implements Function<Request, RequestPatternBuilder> {
+class RequestPatternTransformer implements Function<Request, RequestPatternBuilder> {
   private final Map<String, CaptureHeadersSpec> headers;
   private final RequestBodyPatternFactory bodyPatternFactory;
 
-  public RequestPatternTransformer(
+  RequestPatternTransformer(
       Map<String, CaptureHeadersSpec> headers, RequestBodyPatternFactory bodyPatternFactory) {
     this.headers = headers;
     this.bodyPatternFactory = bodyPatternFactory;

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
@@ -25,9 +25,9 @@ import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class ScenarioProcessor {
+class ScenarioProcessor {
 
-  public void putRepeatedRequestsInScenarios(List<StubMapping> stubMappings) {
+  void putRepeatedRequestsInScenarios(List<StubMapping> stubMappings) {
     Map<RequestPattern, List<StubMapping>> stubsGroupedByRequest =
         stubMappings.stream()
             .collect(

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotOutputFormatter.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotOutputFormatter.java
@@ -20,7 +20,7 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import java.util.List;
 
 /** Wraps a list of generated StubMappings into a SnapshotRecordResult object */
-enum SnapshotOutputFormatter {
+public enum SnapshotOutputFormatter {
   FULL {
     @Override
     SnapshotRecordResult format(

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractor.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractor.java
@@ -25,10 +25,10 @@ import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.store.BlobStore;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
-public class SnapshotStubMappingBodyExtractor {
+class SnapshotStubMappingBodyExtractor {
   private final BlobStore filesBlobStore;
 
-  public SnapshotStubMappingBodyExtractor(BlobStore filesBlobStore) {
+  SnapshotStubMappingBodyExtractor(BlobStore filesBlobStore) {
     this.filesBlobStore = filesBlobStore;
   }
 
@@ -38,7 +38,7 @@ public class SnapshotStubMappingBodyExtractor {
    *
    * @param stubMapping Stub mapping to extract
    */
-  public void extractInPlace(StubMapping stubMapping) {
+  void extractInPlace(StubMapping stubMapping) {
     byte[] body = stubMapping.getResponse().getByteBody();
     HttpHeaders responseHeaders = stubMapping.getResponse().getHeaders();
     String extension =

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGenerator.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGenerator.java
@@ -28,18 +28,18 @@ import java.util.function.Function;
  * Transforms ServeEvents to StubMappings using RequestPatternTransformer and
  * LoggedResponseDefinitionTransformer
  */
-public class SnapshotStubMappingGenerator implements Function<ServeEvent, StubMapping> {
+class SnapshotStubMappingGenerator implements Function<ServeEvent, StubMapping> {
   private final RequestPatternTransformer requestTransformer;
   private final LoggedResponseDefinitionTransformer responseTransformer;
 
-  public SnapshotStubMappingGenerator(
+  SnapshotStubMappingGenerator(
       RequestPatternTransformer requestTransformer,
       LoggedResponseDefinitionTransformer responseTransformer) {
     this.requestTransformer = requestTransformer;
     this.responseTransformer = responseTransformer;
   }
 
-  public SnapshotStubMappingGenerator(
+  SnapshotStubMappingGenerator(
       Map<String, CaptureHeadersSpec> captureHeaders,
       RequestBodyPatternFactory requestBodyPatternFactory) {
     this(

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingTransformerRunner.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingTransformerRunner.java
@@ -59,7 +59,7 @@ class SnapshotStubMappingTransformerRunner
       if (transformer.applyGlobally()
           || (requestedTransformers != null
               && requestedTransformers.contains(transformer.getName()))) {
-          StubGenerationResult result =
+        StubGenerationResult result =
             transformer.transform(stubMapping, filesRoot, parameters, serveEventToStubMapping.a);
         if (result instanceof StubGenerationResult.Success success) {
           stubMapping = success.stubMapping();


### PR DESCRIPTION
Allows us to change it in future without worrying about breaking people.

## References

N/A

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
