### PR TITLE
When using a dynamic port always bind to loopback

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/BindAddressIssueTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/BindAddressIssueTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025-2026 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import java.net.InetAddress;
+import org.junit.jupiter.api.Test;
+
+public class BindAddressIssueTest {
+
+  @Test
+  void dynamicPortGivesYouAGenuinelyUniquePort() {
+    var wireMockBoundToLoopback =
+        new WireMockServer(
+            wireMockConfig()
+                .dynamicPort()
+                .bindAddress(InetAddress.getLoopbackAddress().getHostAddress()));
+    var wireMockBoundToDefaultBindAddress = new WireMockServer(wireMockConfig().dynamicPort());
+
+    try {
+      wireMockBoundToLoopback.stubFor(get("/whoami").willReturn(ok("wireMockBoundToLoopback")));
+      wireMockBoundToDefaultBindAddress.stubFor(
+          get("/whoami").willReturn(ok("wireMockBoundToDefaultBindAddress")));
+
+      wireMockBoundToLoopback.start();
+      wireMockBoundToDefaultBindAddress.start();
+
+      String content =
+          new WireMockTestClient(wireMockBoundToDefaultBindAddress.port()).get("/whoami").content();
+
+      assertThat(content).isEqualTo("wireMockBoundToDefaultBindAddress");
+    } finally {
+      wireMockBoundToLoopback.stop();
+      wireMockBoundToDefaultBindAddress.stop();
+    }
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,44 +15,90 @@
  */
 package com.github.tomakehurst.wiremock.core;
 
-import static com.github.tomakehurst.wiremock.core.Options.DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES;
-import static com.github.tomakehurst.wiremock.core.Options.DEFAULT_WEBHOOK_THREADPOOL_SIZE;
+import static com.github.tomakehurst.wiremock.core.Options.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.net.InetAddress;
 import org.junit.jupiter.api.Test;
 
 public class WireMockConfigurationTest {
 
+  private static final String LOOPBACK_ADDRESS = InetAddress.getLoopbackAddress().getHostAddress();
+
   @Test
   public void testProxyPassThroughSetAsFalse() {
-    WireMockConfiguration wireMockConfiguration =
-        WireMockConfiguration.wireMockConfig().proxyPassThrough(false);
-    assertFalse(wireMockConfiguration.getStores().getSettingsStore().get().getProxyPassThrough());
+    Options config = wireMockConfig().proxyPassThrough(false);
+    assertFalse(config.getStores().getSettingsStore().get().getProxyPassThrough());
   }
 
   @Test
   void setsMaxTemplateCacheEntries() {
-    Options config = WireMockConfiguration.wireMockConfig().withMaxTemplateCacheEntries(11L);
+    Options config = wireMockConfig().withMaxTemplateCacheEntries(11L);
     assertThat(config.getMaxTemplateCacheEntries(), is(11L));
   }
 
   @Test
   void maxTemplateCacheEntriesDefaultsWhenNotSpecified() {
-    Options config = WireMockConfiguration.wireMockConfig();
+    Options config = wireMockConfig();
     assertThat(config.getMaxTemplateCacheEntries(), is(DEFAULT_MAX_TEMPLATE_CACHE_ENTRIES));
   }
 
   @Test
   void setsWebhookThreadpoolSize() {
-    Options config = WireMockConfiguration.wireMockConfig().withWebhookThreadPoolSize(1000);
+    Options config = wireMockConfig().withWebhookThreadPoolSize(1000);
     assertThat(config.getWebhookThreadPoolSize(), is(1000));
   }
 
   @Test
   void webhookThreadpoolSizeWhenNotSpecified() {
-    Options config = WireMockConfiguration.wireMockConfig();
+    Options config = wireMockConfig();
     assertThat(config.getWebhookThreadPoolSize(), is(DEFAULT_WEBHOOK_THREADPOOL_SIZE));
+  }
+
+  @Test
+  void bindAddressStartsAsDefault() {
+    Options config = wireMockConfig();
+    assertThat(config.bindAddress(), is(DEFAULT_BIND_ADDRESS));
+    assertThat(DEFAULT_BIND_ADDRESS, is(not(LOOPBACK_ADDRESS)));
+  }
+
+  @Test
+  void dynamicPortSetsBindAddress() {
+    Options config = wireMockConfig().dynamicPort();
+    assertThat(config.bindAddress(), is(LOOPBACK_ADDRESS));
+  }
+
+  @Test
+  void dynamicPortDoesNotOverwriteBindAddress() {
+    Options config = wireMockConfig().bindAddress("1.2.3.4").dynamicPort();
+    assertThat(config.bindAddress(), is("1.2.3.4"));
+  }
+
+  @Test
+  void bindAddressDoesOverwriteDynamicPort() {
+    Options config = wireMockConfig().dynamicPort().bindAddress("1.2.3.4");
+    assertThat(config.bindAddress(), is("1.2.3.4"));
+  }
+
+  @Test
+  void dynamicHttpsPortSetsBindAddress() {
+    Options config = wireMockConfig().dynamicHttpsPort();
+    assertThat(config.bindAddress(), is(LOOPBACK_ADDRESS));
+  }
+
+  @Test
+  void dynamicHttpsPortDoesNotOverwriteBindAddress() {
+    Options config = wireMockConfig().bindAddress("1.2.3.4").dynamicHttpsPort();
+    assertThat(config.bindAddress(), is("1.2.3.4"));
+  }
+
+  @Test
+  void bindAddressDoesOverwriteDynamicHttpsPort() {
+    Options config = wireMockConfig().dynamicHttpsPort().bindAddress("1.2.3.4");
+    assertThat(config.bindAddress(), is("1.2.3.4"));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
@@ -101,4 +101,16 @@ public class WireMockConfigurationTest {
     Options config = wireMockConfig().dynamicHttpsPort().bindAddress("1.2.3.4");
     assertThat(config.bindAddress(), is("1.2.3.4"));
   }
+
+  @Test
+  void bindAddressCanBeSetBackToAll() {
+    Options config = wireMockConfig().dynamicHttpsPort().bindToAllAddresses();
+    assertThat(config.bindAddress(), is("0.0.0.0"));
+  }
+
+  @Test
+  void bindAddressCanBeSetToLocalhost() {
+    Options config = wireMockConfig().bindToLocalhost();
+    assertThat(config.bindAddress(), is(InetAddress.getLoopbackAddress().getHostAddress()));
+  }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -49,6 +49,7 @@ import com.github.tomakehurst.wiremock.store.DefaultStores;
 import com.github.tomakehurst.wiremock.store.Stores;
 import com.github.tomakehurst.wiremock.verification.notmatched.NotMatchedRenderer;
 import com.github.tomakehurst.wiremock.verification.notmatched.PlainTextStubNotMatchedRenderer;
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -208,6 +209,7 @@ public class WireMockConfiguration implements Options {
   }
 
   public WireMockConfiguration dynamicPort() {
+    maybeSetBindAddress();
     this.portNumber = DYNAMIC_PORT;
     return this;
   }
@@ -233,8 +235,21 @@ public class WireMockConfiguration implements Options {
   }
 
   public WireMockConfiguration dynamicHttpsPort() {
+    maybeSetBindAddress();
     this.httpsPort = DYNAMIC_PORT;
     return this;
+  }
+
+  private void maybeSetBindAddress() {
+    /*
+     * By default, a wiremock instance (including the mock host) binds to address 0.0.0.0. When binding to a random
+     * port, that port is only unique for bind address 0.0.0.0; another application may be listening on the same TCP/IP
+     * port for a more specific bind address (like localhost). If so, and you request that port as localhost, you will
+     * talk to the other application, and your test will fail.
+     */
+    if (DEFAULT_BIND_ADDRESS.equals(this.bindAddress)) {
+      this.bindAddress = InetAddress.getLoopbackAddress().getHostAddress();
+    }
   }
 
   public WireMockConfiguration containerThreads(Integer containerThreads) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -372,6 +372,14 @@ public class WireMockConfiguration implements Options {
     return this;
   }
 
+  public WireMockConfiguration bindToAllAddresses() {
+    return bindAddress(DEFAULT_BIND_ADDRESS);
+  }
+
+  public WireMockConfiguration bindToLocalhost() {
+    return bindAddress(InetAddress.getLoopbackAddress().getHostAddress());
+  }
+
   public WireMockConfiguration disableRequestJournal() {
     requestJournalDisabled = true;
     return this;


### PR DESCRIPTION
By default, a wiremock instance (including the mock host) binds to address 0.0.0.0. When binding to a random port, that port is only unique for bind address 0.0.0.0; another application may be listening on the same TCP/IP port for a more specific bind address (like localhost). If so, and you request that port as localhost, you will talk to the other application, and your test will fail.

By binding explicitly to the IP address of the loopback adapter this problem is avoided.

Assumption here is that you would always want to do this... whether this is a correct assumption...

Of course you can still explicitly set the `bindAddress` to whatever you like.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
