### PR TITLE
use single matcher for query params when only one.

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/RecordingDslAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecordingDslAcceptanceTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern;
 import com.github.tomakehurst.wiremock.matching.MultiValuePattern;
+import com.github.tomakehurst.wiremock.matching.SingleMatchMultiValuePattern;
 import com.github.tomakehurst.wiremock.recording.NotRecordingException;
 import com.github.tomakehurst.wiremock.recording.RecordingStatus;
 import com.github.tomakehurst.wiremock.recording.RecordingStatusResult;
@@ -437,7 +438,9 @@ public class RecordingDslAcceptanceTest extends AcceptanceTestBase {
         returnedMappings.get(0).getRequest().getQueryParameters();
     assertThat(queryParameters.size(), is(2));
     assertThat(queryParameters.get("q1"), is(havingExactly("my-value", "my-other-value")));
-    assertThat(queryParameters.get("second-q"), is(havingExactly("another-value")));
+    assertThat(
+        queryParameters.get("second-q"),
+        is(new SingleMatchMultiValuePattern(equalTo("another-value"))));
 
     assertThat(
         client

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformer.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformer.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.recording;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.havingExactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
@@ -57,7 +58,10 @@ class RequestPatternTransformer implements Function<Request, RequestPatternBuild
     queryParameters.forEach(
         (name, parameters) ->
             builder.withQueryParam(
-                name, havingExactly(parameters.values().toArray(new String[0]))));
+                name,
+                parameters.isSingleValued()
+                    ? MultiValuePattern.of(equalTo(parameters.firstValue()))
+                    : havingExactly(parameters.values().toArray(new String[0]))));
 
     if (headers != null && !headers.isEmpty()) {
       for (Map.Entry<String, CaptureHeadersSpec> header : headers.entrySet()) {


### PR DESCRIPTION
keeps the stub json clean.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
