### PR TITLE
Add the 'x-intellij-language-injection' property to schemas

### DIFF
--- a/src/main/resources/swagger/schemas/does-not-match-pattern.yaml
+++ b/src/main/resources/swagger/schemas/does-not-match-pattern.yaml
@@ -3,5 +3,6 @@ type: object
 properties:
   doesNotMatch:
     type: string
+    x-intellij-language-injection: RegExp
 required:
   - doesNotMatch

--- a/src/main/resources/swagger/schemas/equal-to-json-pattern.yaml
+++ b/src/main/resources/swagger/schemas/equal-to-json-pattern.yaml
@@ -8,6 +8,7 @@ properties:
         example:
           message: hello
       - type: string
+        x-intellij-language-injection: JSON
         description: A JSON-encoded JSON string to match.
         example: |-
           { "message": "hello" }

--- a/src/main/resources/swagger/schemas/equal-to-xml-pattern.yaml
+++ b/src/main/resources/swagger/schemas/equal-to-xml-pattern.yaml
@@ -3,6 +3,7 @@ type: object
 properties:
   equalToXml:
     type: string
+    x-intellij-language-injection: XML
     example: |-
       <amount>123</amount>
   enablePlaceholders:

--- a/src/main/resources/swagger/schemas/matches-json-path-pattern.yaml
+++ b/src/main/resources/swagger/schemas/matches-json-path-pattern.yaml
@@ -5,6 +5,7 @@ properties:
     oneOf:
       - type: string
         example: "$.name"
+        x-intellij-language-injection: JSONPath
       - type: object
         allOf:
           - properties:

--- a/src/main/resources/swagger/schemas/matches-json-schema-pattern.yaml
+++ b/src/main/resources/swagger/schemas/matches-json-schema-pattern.yaml
@@ -3,6 +3,7 @@ type: object
 properties:
   matchesJsonSchema:
     type: string
+    x-intellij-language-injection: JSON
     description: A valid JSON schema as a string
     example: |-
       {

--- a/src/main/resources/swagger/schemas/matches-pattern.yaml
+++ b/src/main/resources/swagger/schemas/matches-pattern.yaml
@@ -3,5 +3,6 @@ type: object
 properties:
   matches:
     type: string
+    x-intellij-language-injection: RegExp
 required:
   - matches

--- a/src/main/resources/swagger/schemas/matches-xpath-pattern.yaml
+++ b/src/main/resources/swagger/schemas/matches-xpath-pattern.yaml
@@ -5,6 +5,7 @@ properties:
     oneOf:
       - type: string
         example: "//Order/Amount"
+        x-intellij-language-injection: XPath
       - type: object
         allOf:
           - properties:


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The **x-intellij-language-injection** property is added to a couple of schemas. This enables automatic language injection into those properties in JetBrains IDEs.

## References

N/A

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
