### PR TITLE
fix: WireMock can have non-path-based BlobStore

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/store/NonPathBasedBlobStoreTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/store/NonPathBasedBlobStoreTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.store;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.InputStreamSource;
+import com.github.tomakehurst.wiremock.common.StreamSources;
+import com.github.tomakehurst.wiremock.store.files.BlobStoreFileSource;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class NonPathBasedBlobStoreTest {
+
+  @Test
+  void canUseANonPathBasedBlobStoreTest() {
+    WireMockServer wireMockServer =
+        new WireMockServer(
+            wireMockConfig().fileSource(new BlobStoreFileSource(new NonPathBasedBlobStore())));
+    try {
+      wireMockServer.start();
+    } finally {
+      wireMockServer.stop();
+    }
+  }
+
+  static class NonPathBasedBlobStore implements BlobStore {
+    @Override
+    public Optional<InputStream> getStream(String key) {
+      return Optional.empty();
+    }
+
+    @Override
+    public InputStreamSource getStreamSource(String key) {
+      return StreamSources.empty();
+    }
+
+    @Override
+    public Stream<String> getAllKeys() {
+      return Stream.empty();
+    }
+
+    @Override
+    public Optional<byte[]> get(String key) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void put(String key, byte[] content) {}
+
+    @Override
+    public void remove(String key) {}
+
+    @Override
+    public void clear() {}
+  }
+}

--- a/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty12/Jetty12HttpServer.java
+++ b/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty12/Jetty12HttpServer.java
@@ -16,7 +16,6 @@
 package com.github.tomakehurst.wiremock.jetty12;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
-import static com.github.tomakehurst.wiremock.common.ResourceUtil.getResource;
 import static com.github.tomakehurst.wiremock.core.WireMockApp.ADMIN_CONTEXT_ROOT;
 import static com.github.tomakehurst.wiremock.jetty11.Jetty11Utils.createHttpConfig;
 import static com.github.tomakehurst.wiremock.jetty11.SslContexts.buildManInTheMiddleSslContextFactory;
@@ -261,8 +260,7 @@ public class Jetty12HttpServer extends JettyHttpServer {
 
     adminContext.setInitParameter("org.eclipse.jetty.servlet.Default.maxCacheSize", "0");
 
-    Resource assetsResource =
-        ResourceFactory.of(adminContext).newClassLoaderResource("assets");
+    Resource assetsResource = ResourceFactory.of(adminContext).newClassLoaderResource("assets");
     if (Resources.isReadable(assetsResource)) {
       adminContext.setBaseResource(assetsResource);
     }
@@ -310,10 +308,13 @@ public class Jetty12HttpServer extends JettyHttpServer {
     ServletContextHandler mockServiceContext = new ServletContextHandler();
     mockServiceContext.setServer(jettyServer);
     mockServiceContext.setContextPath("/");
-    Resource fileSourceResource =
-        ResourceFactory.of(mockServiceContext).newResource(fileSource.getPath());
-    if (Resources.isReadable(fileSourceResource)) {
-      mockServiceContext.setBaseResource(fileSourceResource);
+    String fileSourcePath = fileSource.getPath();
+    if (!fileSourcePath.isEmpty()) {
+      Resource fileSourceResource =
+          ResourceFactory.of(mockServiceContext).newResource(fileSourcePath);
+      if (Resources.isReadable(fileSourceResource)) {
+        mockServiceContext.setBaseResource(fileSourceResource);
+      }
     }
 
     decorateMockServiceContextBeforeConfig(mockServiceContext);


### PR DESCRIPTION
`BlobStoreFileSource.getPath()` returns an empty string if its `BlobStore` is not an instance of `PathBased`. Jetty 12 does not allow an empty string as the argument to `ResourceFactory.newResource`, preventing startup, so skip creating one in these circumstances.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
