### PR TITLE
import stubs in bulk where possible.

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/RecordedStubPersistenceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/RecordedStubPersistenceTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.stubbing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.recordSpec;
+import static com.github.tomakehurst.wiremock.common.Limit.UNLIMITED;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.github.tomakehurst.wiremock.common.Timing;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.extension.Extensions;
+import com.github.tomakehurst.wiremock.http.LoggedResponse;
+import com.github.tomakehurst.wiremock.http.Response;
+import com.github.tomakehurst.wiremock.recording.Recorder;
+import com.github.tomakehurst.wiremock.stubbing.StubImport.Options.DuplicatePolicy;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingDeque;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class RecordedStubPersistenceTest {
+
+  @Test
+  void importsAllRecordedStubsInASingleRequest() {
+    Admin admin = mock();
+    Recorder recorder = new Recorder(admin, Extensions.NONE, mock(), mock());
+    ArgumentCaptor<StubImport> importCaptor = ArgumentCaptor.captor();
+
+    verifyNoInteractions(admin);
+
+    List<ServeEvent> serveEvents =
+        List.of(
+            new ServeEvent(
+                null,
+                LoggedRequest.createFrom(mockRequest().method(GET).url("/")),
+                null,
+                null,
+                LoggedResponse.from(Response.response().status(200).build(), UNLIMITED),
+                false,
+                Timing.UNTIMED,
+                new LinkedBlockingDeque<>()),
+            new ServeEvent(
+                null,
+                LoggedRequest.createFrom(mockRequest().method(POST).url("/persist-me")),
+                null,
+                null,
+                LoggedResponse.from(Response.response().status(202).build(), UNLIMITED),
+                false,
+                Timing.UNTIMED,
+                new LinkedBlockingDeque<>()));
+    recorder.takeSnapshot(
+        serveEvents, recordSpec().allowNonProxied(true).makeStubsPersistent(true).build());
+
+    verify(admin, times(1)).importStubs(importCaptor.capture());
+    verifyNoMoreInteractions(admin);
+
+    StubImport stubImport = importCaptor.getValue();
+    assertFalse(stubImport.getImportOptions().getDeleteAllNotInImport());
+    assertThat(stubImport.getImportOptions().getDuplicatePolicy(), is(DuplicatePolicy.OVERWRITE));
+
+    assertThat(stubImport.getMappings().get(0).getRequest().getUrl(), is("/"));
+    assertThat(stubImport.getMappings().get(0).getResponse().getStatus(), is(200));
+    assertTrue(stubImport.getMappings().get(0).shouldBePersisted());
+
+    assertThat(stubImport.getMappings().get(1).getRequest().getUrl(), is("/persist-me"));
+    assertThat(stubImport.getMappings().get(1).getResponse().getStatus(), is(202));
+    assertTrue(stubImport.getMappings().get(1).shouldBePersisted());
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubImportPersistenceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubImportPersistenceTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.stubbing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.created;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.noContent;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.standalone.MappingsSource;
+import com.github.tomakehurst.wiremock.stubbing.StubImport.Options.DuplicatePolicy;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class StubImportPersistenceTest {
+
+  private final MappingsSource mappingsSource = mock();
+
+  @RegisterExtension
+  WireMockExtension wm =
+      WireMockExtension.newInstance()
+          .options(wireMockConfig().mappingSource(mappingsSource).dynamicPort())
+          .build();
+
+  @Test
+  void savesAllStubsTogetherWhenImportingMultipleStubs() {
+    StubMapping existingStub = get("/existing/stub").persistent(true).willReturn(ok()).build();
+    wm.addStubMapping(existingStub);
+    wm.addStubMapping(
+        put("/another/existing/stub").persistent(true).willReturn(noContent()).build());
+
+    clearInvocations(mappingsSource);
+
+    List<StubMapping> newStubs =
+        List.of(
+            get("/").persistent(true).willReturn(ok()).build(),
+            get("/do/not/persist").willReturn(ok()).persistent(false).build(),
+            post("/thing").willReturn(created()).persistent(true).build(),
+            put("/thing/4")
+                .withId(existingStub.getId())
+                .willReturn(okJson("{}"))
+                .persistent(true)
+                .build());
+    wm.importStubs(
+        new StubImport(newStubs, new StubImport.Options(DuplicatePolicy.OVERWRITE, false)));
+    verify(mappingsSource, times(1))
+        .save(List.of(newStubs.get(3), newStubs.get(2), newStubs.get(0)));
+    verifyNoMoreInteractions(mappingsSource);
+  }
+
+  @Test
+  void doesNotSaveIgnoredStubsWhenImportingMultipleStubs() {
+    StubMapping existingStub = get("/existing/stub").persistent(true).willReturn(ok()).build();
+    wm.addStubMapping(existingStub);
+    wm.addStubMapping(
+        put("/another/existing/stub").persistent(true).willReturn(noContent()).build());
+
+    clearInvocations(mappingsSource);
+
+    List<StubMapping> newStubs =
+        List.of(
+            get("/").persistent(true).willReturn(ok()).build(),
+            get("/do/not/persist").willReturn(ok()).persistent(false).build(),
+            post("/thing").willReturn(created()).persistent(true).build(),
+            put("/thing/4")
+                .withId(existingStub.getId())
+                .willReturn(okJson("{}"))
+                .persistent(true)
+                .build());
+    wm.importStubs(new StubImport(newStubs, new StubImport.Options(DuplicatePolicy.IGNORE, false)));
+    verify(mappingsSource, times(1)).save(List.of(newStubs.get(2), newStubs.get(0)));
+    verifyNoMoreInteractions(mappingsSource);
+  }
+
+  @Test
+  void setsAllStubsTogetherWhenImportingMultipleStubsAndRemovingNonImportedStubs() {
+    wm.addStubMapping(get("/existing/stub").persistent(true).willReturn(ok()).build());
+    wm.addStubMapping(
+        put("/another/existing/stub").persistent(true).willReturn(noContent()).build());
+
+    clearInvocations(mappingsSource);
+
+    List<StubMapping> newStubs =
+        List.of(
+            get("/").persistent(true).willReturn(ok()).build(),
+            get("/do/not/persist").willReturn(ok()).persistent(false).build(),
+            post("/thing").willReturn(created()).persistent(true).build(),
+            put("/thing/4").willReturn(okJson("{}")).persistent(true).build());
+    wm.importStubs(
+        new StubImport(newStubs, new StubImport.Options(DuplicatePolicy.OVERWRITE, true)));
+    verify(mappingsSource, times(1))
+        .setAll(List.of(newStubs.get(3), newStubs.get(2), newStubs.get(0)));
+    verifyNoMoreInteractions(mappingsSource);
+  }
+
+  @Test
+  void removesAllPersistedStubsWhenNoImportedStubsAreSetToPersistAndNonImportedStubsAreDeleted() {
+    wm.addStubMapping(get("/existing/stub").persistent(true).willReturn(ok()).build());
+    wm.addStubMapping(
+        put("/another/existing/stub").persistent(true).willReturn(noContent()).build());
+
+    clearInvocations(mappingsSource);
+
+    List<StubMapping> newStubs =
+        List.of(
+            get("/").persistent(false).willReturn(ok()).build(),
+            get("/do/not/persist").willReturn(ok()).persistent(false).build());
+    wm.importStubs(
+        new StubImport(newStubs, new StubImport.Options(DuplicatePolicy.OVERWRITE, true)));
+    verify(mappingsSource, times(1)).setAll(List.of());
+    verifyNoMoreInteractions(mappingsSource);
+  }
+
+  @Test
+  void savesNothingWhenNoStubsAreSetToPersist() {
+    StubMapping existingStub = get("/existing/stub").persistent(true).willReturn(ok()).build();
+    wm.importStubs(new StubImport(List.of(existingStub), StubImport.Options.DEFAULTS));
+    verify(mappingsSource, times(1)).save(List.of(existingStub));
+
+    clearInvocations(mappingsSource);
+
+    List<StubMapping> newStubs =
+        List.of(
+            get("/").persistent(false).willReturn(ok()).build(),
+            get("/do/not/persist").willReturn(ok()).persistent(false).build());
+    wm.importStubs(new StubImport(newStubs, StubImport.Options.DEFAULTS));
+    verifyNoInteractions(mappingsSource);
+  }
+}

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/core/MappingsSaver.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/core/MappingsSaver.java
@@ -27,4 +27,10 @@ public interface MappingsSaver {
   void remove(UUID stubMappingId);
 
   void removeAll();
+
+  /** Saves the provided stubs and removes all others. */
+  default void setAll(List<StubMapping> stubMappings) {
+    removeAll();
+    save(stubMappings);
+  }
 }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/ProxiedServeEventFilters.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/ProxiedServeEventFilters.java
@@ -70,7 +70,7 @@ public class ProxiedServeEventFilters implements Predicate<ServeEvent> {
 
   @Override
   public boolean test(ServeEvent serveEvent) {
-    if (!serveEvent.getResponseDefinition().isProxyResponse() && !allowNonProxied) {
+    if (!allowNonProxied && !serveEvent.getResponseDefinition().isProxyResponse()) {
       return false;
     }
 

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
@@ -27,6 +27,7 @@ import com.github.tomakehurst.wiremock.extension.StubMappingTransformer;
 import com.github.tomakehurst.wiremock.store.BlobStore;
 import com.github.tomakehurst.wiremock.store.RecorderStateStore;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import com.github.tomakehurst.wiremock.stubbing.StubImport;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import java.util.List;
 import java.util.UUID;
@@ -119,8 +120,8 @@ public class Recorder {
       if (recordSpec.shouldPersist()) {
         stubMapping.setPersistent(true);
       }
-      admin.addStubMapping(stubMapping);
     }
+    admin.importStubs(new StubImport(results.b, StubImport.Options.DEFAULTS));
 
     return recordSpec.getOutputFormat().format(results.b, results.a);
   }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/servlet/NotImplementedMappingsSaver.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/servlet/NotImplementedMappingsSaver.java
@@ -40,4 +40,9 @@ public class NotImplementedMappingsSaver implements MappingsSaver {
   public void removeAll() {
     throw new UnsupportedOperationException("Remove all mappings is not supported");
   }
+
+  @Override
+  public void setAll(List<StubMapping> stubMappings) {
+    throw new UnsupportedOperationException("Set all mappings is not supported");
+  }
 }


### PR DESCRIPTION
to allow implementations of MappingsSaver to be more efficient when persisting stubs.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
