### PR TITLE
fix: Stop using version of json-smart with a CVE

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ json-unit = { module = "net.javacrumbs.json-unit:json-unit", version.ref = "json
 
 # JSON Path
 json-path = { module = "com.jayway.jsonpath:json-path", version = "2.9.0" }
+json-smart = { module = "net.minidev:json-smart", version = "2.5.2" }
 
 # SLF4J
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }

--- a/wiremock-common/build.gradle.kts
+++ b/wiremock-common/build.gradle.kts
@@ -64,6 +64,10 @@ dependencies {
             replacedBy("org.hamcrest:hamcrest")
         }
     }
+
+    constraints {
+        implementation(libs.json.smart)
+    }
 }
 
 tasks.jar {


### PR DESCRIPTION
Denial of Service (DoS)
Affecting net.minidev:json-smart package, versions [2.5.0,2.5.2)

https://security.snyk.io/vuln/SNYK-JAVA-NETMINIDEV-8689573
