### PR TITLE
deprecate stub removal methods.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/MappingsSaver.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/MappingsSaver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Thomas Akehurst
+ * Copyright (C) 2013-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,24 @@
  */
 package com.github.tomakehurst.wiremock.core;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import java.util.List;
+import java.util.UUID;
 
 public interface MappingsSaver {
   void save(List<StubMapping> stubMappings);
 
   void save(StubMapping stubMapping);
 
+  @Deprecated(forRemoval = true)
   void remove(StubMapping stubMapping);
+
+  default void remove(UUID stubMappingId) {
+    remove(any(anyUrl()).withId(stubMappingId).build());
+  }
 
   void removeAll();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/store/StubMappingStore.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/store/StubMappingStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Thomas Akehurst
+ * Copyright (C) 2022-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 package com.github.tomakehurst.wiremock.store;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 
 import com.github.tomakehurst.wiremock.common.Pair;
 import com.github.tomakehurst.wiremock.http.Request;
@@ -49,7 +52,12 @@ public interface StubMappingStore {
 
   void replace(StubMapping existing, StubMapping updated);
 
+  @Deprecated(forRemoval = true)
   void remove(StubMapping stubMapping);
+
+  default void remove(UUID stubMappingId) {
+    remove(any(anyUrl()).withId(stubMappingId).build());
+  }
 
   void clear();
 }


### PR DESCRIPTION
moving into v4.x, the method to remove a stub by id should be used instead.

## References

https://github.com/wiremock/wiremock/pull/3087

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

