### PR TITLE
More sensible default proxy user-agent and ability to override

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/NetworkTrafficListenerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/NetworkTrafficListenerAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,7 @@ public class NetworkTrafficListenerAcceptanceTest extends AcceptanceTestBase {
     assertThat(
         networkTrafficListener.getAllRequests(),
         containsString("GET /a/non-registered/resource HTTP/1.1\r\n"));
-    assertThat(
-        networkTrafficListener.getAllRequests(), containsString("User-Agent: Apache-HttpClient/"));
+    assertThat(networkTrafficListener.getAllRequests(), containsString("User-Agent: WireMock"));
     assertThat(
         networkTrafficListener.getAllResponses(), containsString("HTTP/1.1 404 Not Found\r\n"));
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,12 +50,10 @@ import org.apache.hc.client5.http.classic.methods.HttpHead;
 import org.apache.hc.client5.http.entity.GzipCompressingEntity;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.apache.hc.core5.util.VersionInfo;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -377,7 +375,7 @@ public class ProxyAcceptanceTest {
   }
 
   @Test
-  public void usesHttpClientUserAgentProxyHeaderWhenPreserveUserAgentProxyHeaderNotSpecified() {
+  public void usesWireMockUserAgentProxyHeaderWhenPreserveUserAgentProxyHeaderNotSpecified() {
     init(wireMockConfig());
 
     target.register(
@@ -391,12 +389,9 @@ public class ProxyAcceptanceTest {
     proxy.verifyThat(
         getRequestedFor(urlEqualTo("/preserve-user-agent-header"))
             .withHeader("User-Agent", equalTo("my-user-agent")));
-    String softwareInfo =
-        VersionInfo.getSoftwareInfo(
-            "Apache-HttpClient", "org.apache.hc.client5", HttpClientBuilder.class);
     target.verifyThat(
         getRequestedFor(urlEqualTo("/preserve-user-agent-header"))
-            .withHeader("User-Agent", equalTo(softwareInfo)));
+            .withHeader("User-Agent", matching("WireMock .*")));
   }
 
   @Test
@@ -466,9 +461,7 @@ public class ProxyAcceptanceTest {
     testClient.get("/duplicate/connection-header");
     LoggedRequest lastRequest =
         getLast(target.find(getRequestedFor(urlEqualTo("/duplicate/connection-header"))));
-    assertThat(
-        lastRequest.getHeaders().getHeader("Connection").values(),
-        hasItem("keep-alive"));
+    assertThat(lastRequest.getHeaders().getHeader("Connection").values(), hasItem("keep-alive"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpClientFactoryCertificateVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Thomas Akehurst
+ * Copyright (C) 2020-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,8 @@ public abstract class HttpClientFactoryCertificateVerificationTest {
             trustedHosts,
             false,
             NetworkAddressRules.ALLOW_ALL,
-            true);
+            true,
+            null);
   }
 
   @AfterEach

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Thomas Akehurst
+ * Copyright (C) 2020-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -541,7 +541,8 @@ public class ProxyResponseRendererTest {
                 Collections.emptyList(),
                 true,
                 NetworkAddressRules.ALLOW_ALL,
-                true));
+                true,
+                null));
     HttpClient reverseProxyClient = new ApacheBackedHttpClient(reverseProxyApacheClient, false);
 
     forwardProxyApacheClient =
@@ -555,7 +556,8 @@ public class ProxyResponseRendererTest {
                 Collections.emptyList(),
                 false,
                 NetworkAddressRules.ALLOW_ALL,
-                true));
+                true,
+                null));
     HttpClient forwardProxyClient = new ApacheBackedHttpClient(forwardProxyApacheClient, false);
 
     return new ProxyResponseRenderer(

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
@@ -26,6 +26,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.github.tomakehurst.wiremock.common.NetworkAddressRules;
 import com.github.tomakehurst.wiremock.common.ProxySettings;
 import com.github.tomakehurst.wiremock.common.ssl.KeyStoreSettings;
+import com.github.tomakehurst.wiremock.core.Version;
 import com.github.tomakehurst.wiremock.http.ssl.*;
 import java.net.URI;
 import java.security.*;
@@ -66,7 +67,8 @@ public class HttpClientFactory {
       final List<String> trustedHosts,
       boolean useSystemProperties,
       NetworkAddressRules networkAddressRules,
-      boolean disableConnectionReuse) {
+      boolean disableConnectionReuse,
+      String userAgent) {
 
     NetworkAddressRulesAdheringDnsResolver dnsResolver =
         new NetworkAddressRulesAdheringDnsResolver(networkAddressRules);
@@ -83,6 +85,10 @@ public class HttpClientFactory {
                     .setResponseTimeout(Timeout.ofMilliseconds(timeoutMilliseconds))
                     .setProtocolUpgradeEnabled(false)
                     .build());
+
+    String effectiveUserAgent =
+        userAgent != null ? userAgent : "WireMock " + Version.getCurrentVersion();
+    builder.setUserAgent(effectiveUserAgent);
 
     if (disableConnectionReuse) {
       builder
@@ -182,7 +188,30 @@ public class HttpClientFactory {
         Collections.emptyList(),
         useSystemProperties,
         networkAddressRules,
-        disableConnectionReuse);
+        disableConnectionReuse,
+        null);
+  }
+
+  public static CloseableHttpClient createClient(
+      int maxConnections,
+      int timeoutMilliseconds,
+      ProxySettings proxySettings,
+      KeyStoreSettings trustStoreSettings,
+      boolean useSystemProperties,
+      NetworkAddressRules networkAddressRules,
+      boolean disableConnectionReuse,
+      String userAgent) {
+    return createClient(
+        maxConnections,
+        timeoutMilliseconds,
+        proxySettings,
+        trustStoreSettings,
+        true,
+        Collections.emptyList(),
+        useSystemProperties,
+        networkAddressRules,
+        disableConnectionReuse,
+        userAgent);
   }
 
   private static SSLContext buildSSLContextWithTrustStore(

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/http/client/ApacheHttpClientFactory.java
@@ -37,7 +37,8 @@ public class ApacheHttpClientFactory implements HttpClientFactory {
             trustedHosts,
             useSystemProperties,
             options.getProxyTargetRules(),
-            options.getDisableConnectionReuse());
+            options.getDisableConnectionReuse(),
+            null);
 
     return new ApacheBackedHttpClient(apacheClient, options.shouldPreserveUserAgentProxyHeader());
   }


### PR DESCRIPTION
Set the default user-agent header sent by the proxy HTTP client to 'WireMock <version>' and added the ability to override it in the factory method.
