### PR TITLE
remove stubs in bulk where possible.

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,8 +62,10 @@ public class AcceptanceTestBase {
     setupServer(wireMockConfig().withRootDirectory(filePath("empty")));
   }
 
-  public static void setupServerWithTempFileRoot() {
-    setupServer(wireMockConfig().withRootDirectory(setupTempFileRoot().getAbsolutePath()));
+  public static File setupServerWithTempFileRoot() {
+    File tempFileRoot = setupTempFileRoot();
+    setupServer(wireMockConfig().withRootDirectory(tempFileRoot.getAbsolutePath()));
+    return tempFileRoot;
   }
 
   public static File setupTempFileRoot() {

--- a/src/test/java/com/github/tomakehurst/wiremock/RemoveStubMappingsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RemoveStubMappingsAcceptanceTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2016-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.listAllStubMappings;
+import static com.github.tomakehurst.wiremock.client.WireMock.removeStubs;
+import static com.github.tomakehurst.wiremock.client.WireMock.saveAllMappings;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.tomakehurst.wiremock.core.WireMockApp;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RemoveStubMappingsAcceptanceTest extends AcceptanceTestBase {
+
+  File rootDir;
+
+  @BeforeEach
+  @Override
+  public void init() throws InterruptedException {
+    rootDir = setupServerWithTempFileRoot();
+  }
+
+  @AfterEach
+  void cleanup() {
+    serverShutdown();
+  }
+
+  @Test
+  void removeStubsThatExistUsingUUID() {
+    StubMapping stub1 =
+        stubFor(
+            get(urlEqualTo("/stub-1")).withName("stub 1").willReturn(aResponse().withStatus(200)));
+    StubMapping stub2 =
+        stubFor(
+            get(urlEqualTo("/stub-2")).withName("stub 2").willReturn(aResponse().withStatus(201)));
+    StubMapping stub3 =
+        stubFor(
+            get(urlEqualTo("/stub-3")).withName("stub 3").willReturn(aResponse().withStatus(202)));
+
+    saveAllMappings();
+
+    assertThat(testClient.get("/stub-1").statusCode(), is(200));
+    assertThat(testClient.get("/stub-2").statusCode(), is(201));
+    assertThat(testClient.get("/stub-3").statusCode(), is(202));
+    assertEquals(1, matchingStubCount("/stub-1"));
+    assertEquals(1, matchingStubCount("/stub-2"));
+    assertEquals(1, matchingStubCount("/stub-3"));
+    File mappingsDir = rootDir.toPath().resolve(WireMockApp.MAPPINGS_ROOT).toFile();
+    assertThat(
+        Arrays.stream(Objects.requireNonNull(mappingsDir.listFiles())).toList(),
+        containsInAnyOrder(
+            new File(mappingsDir, "stub-1-" + stub1.getId() + ".json"),
+            new File(mappingsDir, "stub-2-" + stub2.getId() + ".json"),
+            new File(mappingsDir, "stub-3-" + stub3.getId() + ".json")));
+
+    removeStubs(
+        List.of(
+            get("/whatever").withId(stub1.getId()).build(),
+            get("/whatever").withId(stub3.getId()).build()));
+
+    assertThat(testClient.get("/stub-1").statusCode(), is(404));
+    assertThat(testClient.get("/stub-2").statusCode(), is(201));
+    assertThat(testClient.get("/stub-3").statusCode(), is(404));
+    assertEquals(0, matchingStubCount("/stub-1"));
+    assertEquals(1, matchingStubCount("/stub-2"));
+    assertEquals(0, matchingStubCount("/stub-3"));
+    assertThat(
+        Arrays.stream(Objects.requireNonNull(mappingsDir.listFiles())).toList(),
+        containsInAnyOrder(new File(mappingsDir, "stub-2-" + stub2.getId() + ".json")));
+  }
+
+  @Test
+  void removeStubsThatExistUsingRequestMatch() {
+    StubMapping stub1 =
+        stubFor(
+            get(urlEqualTo("/stub-1")).withName("stub 1").willReturn(aResponse().withStatus(200)));
+    StubMapping stub2 =
+        stubFor(
+            get(urlEqualTo("/stub-2")).withName("stub 2").willReturn(aResponse().withStatus(201)));
+    StubMapping stub3 =
+        stubFor(
+            get(urlEqualTo("/stub-3")).withName("stub 3").willReturn(aResponse().withStatus(202)));
+
+    saveAllMappings();
+
+    assertThat(testClient.get("/stub-1").statusCode(), is(200));
+    assertThat(testClient.get("/stub-2").statusCode(), is(201));
+    assertThat(testClient.get("/stub-3").statusCode(), is(202));
+    assertEquals(1, matchingStubCount("/stub-1"));
+    assertEquals(1, matchingStubCount("/stub-2"));
+    assertEquals(1, matchingStubCount("/stub-3"));
+    File mappingsDir = rootDir.toPath().resolve(WireMockApp.MAPPINGS_ROOT).toFile();
+    assertThat(
+        Arrays.stream(Objects.requireNonNull(mappingsDir.listFiles())).toList(),
+        containsInAnyOrder(
+            new File(mappingsDir, "stub-1-" + stub1.getId() + ".json"),
+            new File(mappingsDir, "stub-2-" + stub2.getId() + ".json"),
+            new File(mappingsDir, "stub-3-" + stub3.getId() + ".json")));
+
+    removeStubs(
+        List.of(
+            get(urlEqualTo("/stub-1")).withId(UUID.randomUUID()).build(),
+            get(urlEqualTo("/stub-3")).withId(UUID.randomUUID()).build()));
+
+    assertThat(testClient.get("/stub-1").statusCode(), is(404));
+    assertThat(testClient.get("/stub-2").statusCode(), is(201));
+    assertThat(testClient.get("/stub-3").statusCode(), is(404));
+    assertEquals(0, matchingStubCount("/stub-1"));
+    assertEquals(1, matchingStubCount("/stub-2"));
+    assertEquals(0, matchingStubCount("/stub-3"));
+    assertThat(
+        Arrays.stream(Objects.requireNonNull(mappingsDir.listFiles())).toList(),
+        containsInAnyOrder(new File(mappingsDir, "stub-2-" + stub2.getId() + ".json")));
+  }
+
+  @Test
+  void removesNothingWhenNoneOfTheStubsExist() {
+    StubMapping stub1 =
+        stubFor(
+            get(urlEqualTo("/stub-1")).withName("stub 1").willReturn(aResponse().withStatus(200)));
+    StubMapping stub2 =
+        stubFor(
+            get(urlEqualTo("/stub-2")).withName("stub 2").willReturn(aResponse().withStatus(201)));
+
+    saveAllMappings();
+
+    assertThat(testClient.get("/stub-1").statusCode(), is(200));
+    assertThat(testClient.get("/stub-2").statusCode(), is(201));
+    assertEquals(1, matchingStubCount("/stub-1"));
+    assertEquals(1, matchingStubCount("/stub-2"));
+    File mappingsDir = rootDir.toPath().resolve(WireMockApp.MAPPINGS_ROOT).toFile();
+    assertThat(
+        Arrays.stream(Objects.requireNonNull(mappingsDir.listFiles())).toList(),
+        containsInAnyOrder(
+            new File(mappingsDir, "stub-1-" + stub1.getId() + ".json"),
+            new File(mappingsDir, "stub-2-" + stub2.getId() + ".json")));
+
+    removeStubs(
+        List.of(
+            get(urlEqualTo("/whatever")).withId(UUID.randomUUID()).build(),
+            get(urlEqualTo("/whatever")).withId(UUID.randomUUID()).build()));
+
+    assertThat(testClient.get("/stub-1").statusCode(), is(200));
+    assertThat(testClient.get("/stub-2").statusCode(), is(201));
+    assertEquals(1, matchingStubCount("/stub-1"));
+    assertEquals(1, matchingStubCount("/stub-2"));
+    assertThat(
+        Arrays.stream(Objects.requireNonNull(mappingsDir.listFiles())).toList(),
+        containsInAnyOrder(
+            new File(mappingsDir, "stub-1-" + stub1.getId() + ".json"),
+            new File(mappingsDir, "stub-2-" + stub2.getId() + ".json")));
+  }
+
+  @Test
+  void removesOnlyTheStubsThatExist() {
+    StubMapping stub1 =
+        stubFor(
+            get(urlEqualTo("/stub-1")).withName("stub 1").willReturn(aResponse().withStatus(200)));
+    StubMapping stub2 =
+        stubFor(
+            get(urlEqualTo("/stub-2")).withName("stub 2").willReturn(aResponse().withStatus(201)));
+    StubMapping stub3 =
+        stubFor(
+            get(urlEqualTo("/stub-3")).withName("stub 3").willReturn(aResponse().withStatus(202)));
+
+    saveAllMappings();
+
+    assertThat(testClient.get("/stub-1").statusCode(), is(200));
+    assertThat(testClient.get("/stub-2").statusCode(), is(201));
+    assertThat(testClient.get("/stub-3").statusCode(), is(202));
+    assertEquals(1, matchingStubCount("/stub-1"));
+    assertEquals(1, matchingStubCount("/stub-2"));
+    assertEquals(1, matchingStubCount("/stub-3"));
+    File mappingsDir = rootDir.toPath().resolve(WireMockApp.MAPPINGS_ROOT).toFile();
+    assertThat(
+        Arrays.stream(Objects.requireNonNull(mappingsDir.listFiles())).toList(),
+        containsInAnyOrder(
+            new File(mappingsDir, "stub-1-" + stub1.getId() + ".json"),
+            new File(mappingsDir, "stub-2-" + stub2.getId() + ".json"),
+            new File(mappingsDir, "stub-3-" + stub3.getId() + ".json")));
+
+    removeStubs(
+        List.of(
+            get(urlEqualTo("/whatever")).withId(UUID.randomUUID()).build(),
+            get(urlEqualTo("/whatever")).withId(stub3.getId()).build()));
+
+    assertThat(testClient.get("/stub-1").statusCode(), is(200));
+    assertThat(testClient.get("/stub-2").statusCode(), is(201));
+    assertThat(testClient.get("/stub-3").statusCode(), is(404));
+    assertEquals(1, matchingStubCount("/stub-1"));
+    assertEquals(1, matchingStubCount("/stub-2"));
+    assertEquals(0, matchingStubCount("/stub-3"));
+    assertThat(
+        Arrays.stream(Objects.requireNonNull(mappingsDir.listFiles())).toList(),
+        containsInAnyOrder(
+            new File(mappingsDir, "stub-1-" + stub1.getId() + ".json"),
+            new File(mappingsDir, "stub-2-" + stub2.getId() + ".json")));
+  }
+
+  private synchronized long matchingStubCount(String url) {
+    return listAllStubMappings().getMappings().stream()
+        .filter(stub -> stub.getRequest().getUrl().equals(url))
+        .count();
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/tasks/RemoveMatchingStubMappingTaskTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/tasks/RemoveMatchingStubMappingTaskTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2013-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.admin.tasks;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.created;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.github.tomakehurst.wiremock.admin.AdminTask;
+import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.common.url.PathParams;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class RemoveMatchingStubMappingTaskTest {
+
+  private final Admin mockAdmin = Mockito.mock(Admin.class);
+
+  private final AdminTask task = new RemoveMatchingStubMappingTask();
+
+  @Test
+  void removesMultipleMappingsInASingleRequest() {
+    List<StubMapping> stubMappings =
+        List.of(get("/").willReturn(ok()).build(), post("/create").willReturn(created()).build());
+
+    task.execute(
+        mockAdmin,
+        ServeEvent.of(mockRequest().body(Json.write(Map.of("mappings", stubMappings)))),
+        PathParams.empty());
+
+    verify(mockAdmin).removeStubMappings(stubMappings);
+    verifyNoMoreInteractions(mockAdmin);
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/tasks/RemoveUnmatchedStubMappingsTaskTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/tasks/RemoveUnmatchedStubMappingsTaskTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2013-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.admin.tasks;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.created;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.github.tomakehurst.wiremock.admin.AdminTask;
+import com.github.tomakehurst.wiremock.admin.model.ListStubMappingsResult;
+import com.github.tomakehurst.wiremock.admin.model.PaginatedResult;
+import com.github.tomakehurst.wiremock.common.url.PathParams;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class RemoveUnmatchedStubMappingsTaskTest {
+
+  private final Admin mockAdmin = Mockito.mock(Admin.class);
+
+  private final AdminTask task = new RemoveUnmatchedStubMappingsTask();
+
+  @Test
+  void removesMappingsInASingleRequest() {
+    List<StubMapping> stubMappings =
+        List.of(get("/").willReturn(ok()).build(), post("/create").willReturn(created()).build());
+    when(mockAdmin.findUnmatchedStubs())
+        .thenReturn(
+            new ListStubMappingsResult(
+                stubMappings, new PaginatedResult.Meta(stubMappings.size())));
+
+    task.execute(mockAdmin, ServeEvent.of(mockRequest()), PathParams.empty());
+
+    verify(mockAdmin).findUnmatchedStubs();
+    verify(mockAdmin).removeStubMappings(stubMappings);
+    verifyNoMoreInteractions(mockAdmin);
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/RemoveStubMappingsByMetadataPersistenceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/RemoveStubMappingsByMetadataPersistenceTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.stubbing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.standalone.MappingsSource;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+
+class RemoveStubMappingsByMetadataPersistenceTest {
+
+  private final MappingsSource mappingsSource = mock();
+
+  @RegisterExtension
+  WireMockExtension wm =
+      WireMockExtension.newInstance()
+          .options(wireMockConfig().mappingSource(mappingsSource).dynamicPort())
+          .build();
+
+  @Test
+  void deletesAllStubsTogetherWhenRemovingMultipleStubs() {
+    ArgumentCaptor<List<UUID>> removedCaptor = ArgumentCaptor.captor();
+
+    StubMapping stub1 =
+        get("/stub-1")
+            .withName("stub 1")
+            .willReturn(aResponse().withStatus(200))
+            .withMetadata(Map.of("key1", "value1"))
+            .persistent(true)
+            .build();
+    StubMapping stub2 =
+        get("/stub-2")
+            .withName("stub 2")
+            .willReturn(aResponse().withStatus(201))
+            .withMetadata(Map.of("key1", "value1"))
+            .persistent(false)
+            .build();
+    StubMapping stub3 =
+        get("/stub-3")
+            .withName("stub 3")
+            .willReturn(aResponse().withStatus(202))
+            .withMetadata(Map.of("key2", "value2"))
+            .persistent(true)
+            .build();
+    StubMapping stub4 =
+        get("/stub-4")
+            .withName("stub 4")
+            .willReturn(aResponse().withStatus(202))
+            .withMetadata(Map.of("key1", "value1"))
+            .persistent(true)
+            .build();
+
+    wm.addStubMapping(stub1);
+    wm.addStubMapping(stub2);
+    wm.addStubMapping(stub3);
+    wm.addStubMapping(stub4);
+
+    clearInvocations(mappingsSource);
+
+    wm.removeStubMappingsByMetadata(equalToJson("{ \"key1\": \"value1\" }"));
+    verify(mappingsSource, times(1)).remove(removedCaptor.capture());
+    verifyNoMoreInteractions(mappingsSource);
+
+    List<UUID> removedStubIds = removedCaptor.getValue();
+    assertThat(removedStubIds, containsInAnyOrder(stub1.getId(), stub4.getId()));
+  }
+
+  @Test
+  void deletesNothingWhenNoRemovedStubsAreSetToPersist() {
+    StubMapping stub1 =
+        get("/stub-1")
+            .withName("stub 1")
+            .willReturn(aResponse().withStatus(200))
+            .persistent(true)
+            .withMetadata(Map.of("key1", "value1"))
+            .build();
+    StubMapping stub2 =
+        get("/stub-2")
+            .withName("stub 2")
+            .willReturn(aResponse().withStatus(201))
+            .withMetadata(Map.of("key2", "value2"))
+            .persistent(false)
+            .build();
+    StubMapping stub3 =
+        get("/stub-3")
+            .withName("stub 3")
+            .willReturn(aResponse().withStatus(202))
+            .withMetadata(Map.of("key2", "value2"))
+            .persistent(false)
+            .build();
+    StubMapping stub4 =
+        get("/stub-4")
+            .withName("stub 4")
+            .willReturn(aResponse().withStatus(202))
+            .withMetadata(Map.of("key2", "value2"))
+            .persistent(false)
+            .build();
+    wm.importStubs(
+        new StubImport(List.of(stub1, stub2, stub3, stub4), StubImport.Options.DEFAULTS));
+    assertThat(
+        wm.listAllStubMappings().getMappings(), containsInAnyOrder(stub1, stub2, stub3, stub4));
+    clearInvocations(mappingsSource);
+
+    wm.removeStubMappingsByMetadata(equalToJson("{ \"key1\": \"value1\" }"));
+
+    assertThat(wm.listAllStubMappings().getMappings(), containsInAnyOrder(stub2, stub3, stub4));
+    verify(mappingsSource, times(1)).remove(List.of(stub1.getId()));
+
+    clearInvocations(mappingsSource);
+
+    wm.removeStubMappingsByMetadata(equalToJson("{ \"key2\": \"value2\" }"));
+
+    assertThat(wm.listAllStubMappings().getMappings(), empty());
+    verifyNoInteractions(mappingsSource);
+  }
+
+  @Test
+  void deletesNothingWhenNoStubsAreRemoved() {
+    wm.addStubMapping(
+        get("/existing/stub")
+            .persistent(true)
+            .withMetadata(Map.of("key1", "value1"))
+            .willReturn(ok())
+            .build());
+
+    clearInvocations(mappingsSource);
+
+    wm.removeStubMappingsByMetadata(equalToJson("{ \"key2\": \"value2\" }"));
+    verifyNoInteractions(mappingsSource);
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/RemoveStubMappingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/RemoveStubMappingsTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.stubbing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.extension.StubLifecycleListener;
+import com.github.tomakehurst.wiremock.standalone.MappingsSource;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class RemoveStubMappingsTest {
+
+  @Test
+  void removingNonExistentStubsByIdDoesNotTriggerStubListeners() {
+    StubLifecycleListener listener = mock(StubLifecycleListener.class);
+    WireMockServer wireMockServer =
+        new WireMockServer(wireMockConfig().extensions(listener).dynamicPort());
+    try {
+      wireMockServer.start();
+
+      StubMapping existingStub1 = get("/").build();
+      wireMockServer.addStubMapping(existingStub1);
+      StubMapping existingStub2 = post("/create").build();
+      wireMockServer.addStubMapping(existingStub2);
+      wireMockServer.addStubMapping(put("/modify").build());
+
+      clearInvocations(listener);
+
+      wireMockServer.removeStubMappings(
+          List.of(
+              get("/whatever").withId(existingStub1.getId()).build(),
+              get("/whatever").withId(existingStub2.getId()).build()));
+
+      verify(listener).beforeStubRemoved(existingStub1);
+      verify(listener).beforeStubRemoved(existingStub2);
+      verify(listener).afterStubRemoved(existingStub1);
+      verify(listener).afterStubRemoved(existingStub2);
+      verifyNoMoreInteractions(listener);
+      clearInvocations(listener);
+
+      wireMockServer.removeStubMappings(
+          List.of(get("/whatever").build(), get("/whatever").build()));
+
+      verifyNoInteractions(listener);
+
+    } finally {
+      wireMockServer.stop();
+    }
+  }
+
+  @Test
+  void removingNonExistentStubByRequestMatchDoesNotTriggerStubListeners() {
+    StubLifecycleListener listener = mock(StubLifecycleListener.class);
+    WireMockServer wireMockServer =
+        new WireMockServer(wireMockConfig().extensions(listener).dynamicPort());
+    try {
+      wireMockServer.start();
+
+      StubMapping existingStub1 = get("/").build();
+      wireMockServer.addStubMapping(existingStub1);
+      StubMapping existingStub2 = post("/create").build();
+      wireMockServer.addStubMapping(existingStub2);
+      wireMockServer.addStubMapping(put("/modify").build());
+
+      clearInvocations(listener);
+
+      wireMockServer.removeStubMappings(List.of(get("/").build(), post("/create").build()));
+
+      verify(listener).beforeStubRemoved(existingStub1);
+      verify(listener).afterStubRemoved(existingStub1);
+      verify(listener).beforeStubRemoved(existingStub2);
+      verify(listener).afterStubRemoved(existingStub2);
+      verifyNoMoreInteractions(listener);
+      clearInvocations(listener);
+
+      wireMockServer.removeStubMappings(
+          List.of(get("/whatever").build(), put("/whatever").build()));
+
+      verifyNoInteractions(listener);
+
+    } finally {
+      wireMockServer.stop();
+    }
+  }
+
+  @Test
+  void removingNonExistentStubByIdDoesNotCallMappingSaver() {
+    MappingsSource mappingsSource = mock();
+    WireMockServer wireMockServer =
+        new WireMockServer(wireMockConfig().mappingSource(mappingsSource).dynamicPort());
+    try {
+      wireMockServer.start();
+
+      StubMapping existingStub1 = get("/").persistent(true).build();
+      wireMockServer.addStubMapping(existingStub1);
+      StubMapping existingStub2 = post("/create").persistent(true).build();
+      wireMockServer.addStubMapping(existingStub2);
+      wireMockServer.addStubMapping(put("/modify").persistent(true).build());
+
+      clearInvocations(mappingsSource);
+
+      wireMockServer.removeStubMappings(
+          List.of(
+              get("/whatever").withId(existingStub1.getId()).build(),
+              get("/whatever").withId(existingStub2.getId()).build()));
+
+      verify(mappingsSource).remove(List.of(existingStub1.getId(), existingStub2.getId()));
+      verifyNoMoreInteractions(mappingsSource);
+      clearInvocations(mappingsSource);
+
+      wireMockServer.removeStubMappings(
+          List.of(get("/whatever").build(), get("/whatever").build()));
+
+      verifyNoInteractions(mappingsSource);
+
+    } finally {
+      wireMockServer.stop();
+    }
+  }
+
+  @Test
+  void removingNonExistentStubByRequestMatchDoesNotCallMappingSaver() {
+    MappingsSource mappingsSource = mock();
+    WireMockServer wireMockServer =
+        new WireMockServer(wireMockConfig().mappingSource(mappingsSource).dynamicPort());
+    try {
+      wireMockServer.start();
+
+      StubMapping existingStub1 = get("/").persistent(true).build();
+      wireMockServer.addStubMapping(existingStub1);
+      StubMapping existingStub2 = post("/create").persistent(true).build();
+      wireMockServer.addStubMapping(existingStub2);
+      wireMockServer.addStubMapping(put("/modify").persistent(true).build());
+
+      clearInvocations(mappingsSource);
+
+      wireMockServer.removeStubMappings(List.of(get("/").build(), post("/create").build()));
+
+      verify(mappingsSource).remove(List.of(existingStub1.getId(), existingStub2.getId()));
+      verifyNoMoreInteractions(mappingsSource);
+      clearInvocations(mappingsSource);
+
+      wireMockServer.removeStubMappings(
+          List.of(get("/whatever").build(), put("/whatever").build()));
+
+      verifyNoInteractions(mappingsSource);
+
+    } finally {
+      wireMockServer.stop();
+    }
+  }
+
+  @Test
+  void stubsAreNotDeletedIfListenersPreventRemoval() {
+    MappingsSource mappingsSource = mock();
+    StubLifecycleListener listener = mock(StubLifecycleListener.class);
+    List<UUID> disallowedStubIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    doThrow(new RuntimeException("stop that"))
+        .when(listener)
+        .beforeStubRemoved(argThat(stub -> disallowedStubIds.contains(stub.getId())));
+    WireMockServer wireMockServer =
+        new WireMockServer(
+            wireMockConfig().mappingSource(mappingsSource).extensions(listener).dynamicPort());
+    try {
+      wireMockServer.start();
+
+      UUID allowedStubId1 = UUID.randomUUID();
+      wireMockServer.addStubMapping(get("/").withId(allowedStubId1).persistent(true).build());
+      wireMockServer.addStubMapping(
+          post("/create").withId(disallowedStubIds.get(0)).persistent(true).build());
+      wireMockServer.addStubMapping(
+          put("/modify").withId(disallowedStubIds.get(1)).persistent(true).build());
+      UUID allowedStubId2 = UUID.randomUUID();
+      wireMockServer.addStubMapping(
+          delete("/remove").withId(allowedStubId2).persistent(true).build());
+
+      clearInvocations(mappingsSource);
+
+      wireMockServer.removeStub(allowedStubId1);
+
+      verify(mappingsSource).remove(allowedStubId1);
+      verifyNoMoreInteractions(mappingsSource);
+      clearInvocations(mappingsSource);
+
+      try {
+        wireMockServer.removeStubMappings(
+            List.of(
+                get("/whatever").withId(disallowedStubIds.get(0)).build(),
+                get("/whatever").withId(allowedStubId2).build(),
+                get("/whatever").withId(disallowedStubIds.get(1)).build()));
+      } catch (RuntimeException e) {
+        assertThat(e.getMessage(), is("stop that"));
+      }
+
+      verifyNoInteractions(mappingsSource);
+
+    } finally {
+      wireMockServer.stop();
+    }
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/RemoveStubsPersistenceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/RemoveStubsPersistenceTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.stubbing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.standalone.MappingsSource;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class RemoveStubsPersistenceTest {
+
+  private final MappingsSource mappingsSource = mock();
+
+  @RegisterExtension
+  WireMockExtension wm =
+      WireMockExtension.newInstance()
+          .options(wireMockConfig().mappingSource(mappingsSource).dynamicPort())
+          .build();
+
+  @Test
+  void deletesAllStubsTogetherWhenRemovingMultipleStubs() {
+    StubMapping stub1 =
+        get("/stub-1")
+            .withName("stub 1")
+            .willReturn(aResponse().withStatus(200))
+            .persistent(true)
+            .build();
+    StubMapping stub2 =
+        get("/stub-2")
+            .withName("stub 2")
+            .willReturn(aResponse().withStatus(201))
+            .persistent(false)
+            .build();
+    StubMapping stub3 =
+        get("/stub-3")
+            .withName("stub 3")
+            .willReturn(aResponse().withStatus(202))
+            .persistent(true)
+            .build();
+    StubMapping stub4 =
+        get("/stub-4")
+            .withName("stub 4")
+            .willReturn(aResponse().withStatus(202))
+            .persistent(true)
+            .build();
+
+    wm.addStubMapping(stub1);
+    wm.addStubMapping(stub2);
+    wm.addStubMapping(stub3);
+    wm.addStubMapping(stub4);
+
+    clearInvocations(mappingsSource);
+
+    List<StubMapping> stubsToRemove =
+        List.of(
+            get("/whatever").withId(stub1.getId()).build(),
+            get("/stub-4").withId(UUID.randomUUID()).build(),
+            get("/whatever").withId(stub2.getId()).build());
+    wm.removeStubMappings(stubsToRemove);
+    verify(mappingsSource, times(1)).remove(List.of(stub1.getId(), stub4.getId()));
+    verifyNoMoreInteractions(mappingsSource);
+  }
+
+  @Test
+  void deletesNothingWhenNoRemovedStubsAreSetToPersist() {
+    StubMapping stub1 =
+        get("/stub-1")
+            .withName("stub 1")
+            .willReturn(aResponse().withStatus(200))
+            .persistent(true)
+            .build();
+    StubMapping stub2 =
+        get("/stub-2")
+            .withName("stub 2")
+            .willReturn(aResponse().withStatus(201))
+            .persistent(false)
+            .build();
+    StubMapping stub3 =
+        get("/stub-3")
+            .withName("stub 3")
+            .willReturn(aResponse().withStatus(202))
+            .persistent(false)
+            .build();
+    StubMapping stub4 =
+        get("/stub-4")
+            .withName("stub 4")
+            .willReturn(aResponse().withStatus(202))
+            .persistent(false)
+            .build();
+    wm.importStubs(
+        new StubImport(List.of(stub1, stub2, stub3, stub4), StubImport.Options.DEFAULTS));
+    assertThat(
+        wm.listAllStubMappings().getMappings(), containsInAnyOrder(stub1, stub2, stub3, stub4));
+    clearInvocations(mappingsSource);
+
+    wm.removeStubMappings(List.of(stub1));
+
+    assertThat(wm.listAllStubMappings().getMappings(), containsInAnyOrder(stub2, stub3, stub4));
+    verify(mappingsSource, times(1)).remove(List.of(stub1.getId()));
+
+    clearInvocations(mappingsSource);
+
+    wm.removeStubMappings(List.of(stub2, stub3, stub4));
+
+    assertThat(wm.listAllStubMappings().getMappings(), empty());
+    verifyNoInteractions(mappingsSource);
+  }
+
+  @Test
+  void deletesNothingWhenNoStubsAreRemoved() {
+    wm.addStubMapping(get("/existing/stub").persistent(true).willReturn(ok()).build());
+
+    clearInvocations(mappingsSource);
+
+    wm.removeStubMappings(List.of(get("/whatever").build()));
+    verifyNoInteractions(mappingsSource);
+  }
+
+  @Test
+  void deletesNothingWhenNoStubsAreProvided() {
+    wm.addStubMapping(get("/existing/stub").persistent(true).willReturn(ok()).build());
+
+    clearInvocations(mappingsSource);
+
+    wm.removeStubMappings(List.of());
+    verifyNoInteractions(mappingsSource);
+  }
+}

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -549,6 +549,11 @@ public class WireMockServer implements Container, Stubbing, Admin {
   }
 
   @Override
+  public void removeStubMappings(List<StubMapping> stubMappings) {
+    wireMockApp.removeStubMappings(stubMappings);
+  }
+
+  @Override
   public GetGlobalSettingsResult getGlobalSettings() {
     return wireMockApp.getGlobalSettings();
   }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/RemoveMatchingStubMappingTask.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/RemoveMatchingStubMappingTask.java
@@ -16,18 +16,20 @@
 package com.github.tomakehurst.wiremock.admin.tasks;
 
 import com.github.tomakehurst.wiremock.admin.AdminTask;
+import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.url.PathParams;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import com.github.tomakehurst.wiremock.stubbing.StubMappingCollection;
 
 public class RemoveMatchingStubMappingTask implements AdminTask {
 
   @Override
   public ResponseDefinition execute(Admin admin, ServeEvent serveEvent, PathParams pathParams) {
-    StubMapping removeMapping = StubMapping.buildFrom(serveEvent.getRequest().getBodyAsString());
-    admin.removeStubMapping(removeMapping);
+    StubMappingCollection removeMappings =
+        Json.read(serveEvent.getRequest().getBodyAsString(), StubMappingCollection.class);
+    admin.removeStubMappings(removeMappings.getMappingOrMappings());
     return ResponseDefinition.ok();
   }
 }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/RemoveUnmatchedStubMappingsTask.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/RemoveUnmatchedStubMappingsTask.java
@@ -25,7 +25,7 @@ public class RemoveUnmatchedStubMappingsTask implements AdminTask {
 
   @Override
   public ResponseDefinition execute(Admin admin, ServeEvent serveEvent, PathParams pathParams) {
-    admin.findUnmatchedStubs().getMappings().forEach(admin::removeStubMapping);
+    admin.removeStubMappings(admin.findUnmatchedStubs().getMappings());
     return ResponseDefinition.okEmptyJson();
   }
 }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -49,6 +49,7 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.verification.*;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -455,6 +456,14 @@ public class HttpAdminClient implements Admin {
   public void importStubs(StubImport stubImport) {
     executeRequest(
         adminRoutes.requestSpecForTask(ImportStubMappingsTask.class), stubImport, Void.class);
+  }
+
+  @Override
+  public void removeStubMappings(List<StubMapping> stubMappings) {
+    executeRequest(
+        adminRoutes.requestSpecForTask(RemoveMatchingStubMappingTask.class),
+        Map.of("mappings", stubMappings),
+        Void.class);
   }
 
   @Override

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -1105,6 +1105,14 @@ public class WireMock {
     defaultInstance.get().importStubMappings(stubImport);
   }
 
+  public void removeStubMappings(List<StubMapping> stubs) {
+    admin.removeStubMappings(stubs);
+  }
+
+  public static void removeStubs(List<StubMapping> stubs) {
+    defaultInstance.get().removeStubMappings(stubs);
+  }
+
   public GlobalSettings getGlobalSettings() {
     return admin.getGlobalSettings().getSettings();
   }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
@@ -26,6 +26,7 @@ import com.github.tomakehurst.wiremock.recording.SnapshotRecordResult;
 import com.github.tomakehurst.wiremock.stubbing.StubImport;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.verification.*;
+import java.util.List;
 import java.util.UUID;
 
 public interface Admin {
@@ -113,6 +114,8 @@ public interface Admin {
   void removeStubsByMetadata(StringValuePattern pattern);
 
   void importStubs(StubImport stubImport);
+
+  void removeStubMappings(List<StubMapping> stubMappings);
 
   GetGlobalSettingsResult getGlobalSettings();
 }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/core/MappingsSaver.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/core/MappingsSaver.java
@@ -26,6 +26,10 @@ public interface MappingsSaver {
 
   void remove(UUID stubMappingId);
 
+  default void remove(List<UUID> stubMappingIds) {
+    stubMappingIds.forEach(this::remove);
+  }
+
   void removeAll();
 
   /** Saves the provided stubs and removes all others. */

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/junit/DslWrapper.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/junit/DslWrapper.java
@@ -252,6 +252,11 @@ public class DslWrapper implements Admin, Stubbing {
   }
 
   @Override
+  public void removeStubMappings(List<StubMapping> stubMappings) {
+    admin.removeStubMappings(stubMappings);
+  }
+
+  @Override
   public GetGlobalSettingsResult getGlobalSettings() {
     return admin.getGlobalSettings();
   }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingCollection.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingCollection.java
@@ -31,7 +31,7 @@ public class StubMappingCollection extends StubMapping {
   }
 
   @JsonIgnore
-  public List<? extends StubMapping> getMappingOrMappings() {
+  public List<StubMapping> getMappingOrMappings() {
     return isMulti() ? getMappings() : Collections.singletonList(this);
   }
 


### PR DESCRIPTION
to allow implementations of MappingsSaver to be more efficient when persisting stubs.

this change necessitated adding the ability to delete stubs in bulk via the admin api, so RemoveMatchingStubMappingTask was updated to accept multiple stubs as well as a single stub mapping.

## References

https://github.com/wiremock/wiremock/pull/3075

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
