### PR TITLE
Use DateTimeFormatter instead of SimpleDateFormat in RenderableDate

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDateTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Thomas Akehurst
+ * Copyright (C) 2024-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.common.Json;
+import java.time.ZoneId;
 import java.util.Date;
 import org.junit.jupiter.api.Test;
 
@@ -26,7 +27,15 @@ public class RenderableDateTest {
 
   @Test
   void writesToJsonInStringFormat() {
-    RenderableDate renderableDate = new RenderableDate(new Date(1729266504000L), null, null);
+    RenderableDate renderableDate = new RenderableDate(new Date(1729266504010L), null, null);
     assertThat(Json.write(renderableDate), is("\"2024-10-18T15:48:24Z\""));
+  }
+
+  @Test
+  void handlesCorrectlyFormatsExcessivePrecision() {
+    RenderableDate renderableDate =
+        new RenderableDate(
+            new Date(1729266504010L), "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", ZoneId.of("UTC"));
+    assertThat(Json.write(renderableDate), is("\"2024-10-18T15:48:24.010000Z\""));
   }
 }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDate.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDate.java
@@ -17,8 +17,12 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.util.ISO8601Utils;
+
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -63,11 +67,9 @@ public class RenderableDate extends Date {
   }
 
   private String formatCustom() {
-    SimpleDateFormat dateFormat = new SimpleDateFormat(format);
-    if (timezone != null) {
-      TimeZone zone = TimeZone.getTimeZone(timezone);
-      dateFormat.setTimeZone(zone);
-    }
-    return dateFormat.format(this);
+    ZonedDateTime zonedDateTime = toInstant().atZone(timezone != null ? timezone : ZoneId.systemDefault());
+
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+    return formatter.format(zonedDateTime);
   }
 }


### PR DESCRIPTION
Replaced `SimpleDateFormat` with `DateTimeFormatter` in `RenderableDate` for the sake leveraging more user-friendly formatting.

For example, if you use template like ```{{now format="yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'"}}``` to format `"2025-07-07T15:23:11.123000Z"`, this is what you get:
- `DateTimeFormatter`: ```2025-07-07T15:23:11.123000Z``` (as expected)
- `SimpleDateFormat`:  ```2025-07-07T15:23:11.000123Z``` (with milliseconds converted into microseconds)

The new test fails when run against the SimpleDateFormat-based implementation:

```
RenderableDateTest > handlesCorrectlyFormatsExcessivePrecision() FAILED
    java.lang.AssertionError: 
    Expected: is "\"2024-10-18T15:48:24.010000Z\""
        but: was "\"2024-10-18T15:48:24.000010Z\""
```

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
