### PR TITLE
Include millis in the default date format

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1096,7 +1096,7 @@ public class ResponseTemplateTransformerTest {
   public void dateTruncation() {
     assertThat(
         transform("{{date (truncateDate (parseDate '2021-06-29T11:22:33Z') 'first hour of day')}}"),
-        is("2021-06-29T00:00:00Z"));
+        is("2021-06-29T00:00:00.000Z"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Thomas Akehurst
+ * Copyright (C) 2018-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,10 @@ public class HandlebarsCurrentDateHelperTest {
     Object output = render(optionsHash);
 
     assertThat(output, instanceOf(RenderableDate.class));
-    assertThat(output.toString(), WireMatchers.matches("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:]+Z$"));
+    assertThat(
+        output.toString(),
+        WireMatchers.matches(
+            "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.\\d{1,9})?Z$"));
   }
 
   @Test
@@ -117,7 +120,7 @@ public class HandlebarsCurrentDateHelperTest {
         new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'").parse("2023-10-07T00:00:00.00Z");
     Object output = render(inputDate, optionsHash);
 
-    assertThat(output.toString(), is("2023-10-10T00:00:00+11:00"));
+    assertThat(output.toString(), is("2023-10-10T00:00:00.000+11:00"));
   }
 
   @Test
@@ -142,7 +145,10 @@ public class HandlebarsCurrentDateHelperTest {
             aResponse().withBody("{{now offset='6 days'}}"));
 
     String body = responseDefinition.getBody().trim();
-    assertThat(body, WireMatchers.matches("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:]+Z$"));
+    assertThat(
+        body,
+        WireMatchers.matches(
+            "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.\\d{1,9})?Z$"));
   }
 
   @Test
@@ -154,7 +160,10 @@ public class HandlebarsCurrentDateHelperTest {
             aResponse().withBody("{{date offset='6 days'}}"));
 
     String body = responseDefinition.getBody().trim();
-    assertThat(body, WireMatchers.matches("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:]+Z$"));
+    assertThat(
+        body,
+        WireMatchers.matches(
+            "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.\\d{1,9})?Z$"));
   }
 
   @Test
@@ -166,7 +175,7 @@ public class HandlebarsCurrentDateHelperTest {
             aResponse().withBody("{{date (parseDate '2018-05-05T10:11:12Z') offset='-1 days'}}"));
 
     String body = responseDefinition.getBody().trim();
-    assertThat(body, is("2018-05-04T10:11:12Z"));
+    assertThat(body, is("2018-05-04T10:11:12.000Z"));
   }
 
   private Object render(Map<String, Object> optionsHash) throws IOException {

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDateTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Thomas Akehurst
+ * Copyright (C) 2024-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,6 @@ public class RenderableDateTest {
   @Test
   void writesToJsonInStringFormat() {
     RenderableDate renderableDate = new RenderableDate(new Date(1729266504000L), null, null);
-    assertThat(Json.write(renderableDate), is("\"2024-10-18T15:48:24Z\""));
+    assertThat(Json.write(renderableDate), is("\"2024-10-18T15:48:24.000Z\""));
   }
 }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDate.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDate.java
@@ -58,8 +58,8 @@ public class RenderableDate extends Date {
     }
 
     return timezone != null
-        ? ISO8601Utils.format(this, false, TimeZone.getTimeZone(timezone))
-        : ISO8601Utils.format(this, false);
+        ? ISO8601Utils.format(this, true, TimeZone.getTimeZone(timezone))
+        : ISO8601Utils.format(this, true);
   }
 
   private String formatCustom() {


### PR DESCRIPTION
The default ISO8601 formatter doesn't include milliseconds, and those usually in tests. That would allow users not worry about crafting their own ISO8601-compatible custom formatters like: `{{now format="yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"}}`, which is prone to bugs like the one mentioned here: https://github.com/wiremock/wiremock/pull/3100

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
