### PR TITLE
feat: Add static loadMappingsFrom() in WireMock.java

### DIFF
--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -1005,6 +1005,10 @@ public class WireMock {
     new RemoteMappingsLoader(mappingsSource, this).load();
   }
 
+  public static void loadMappings(String rootDir) {
+    defaultInstance.get().loadMappingsFrom(rootDir);
+  }
+
   public static List<StubMapping> snapshotRecord() {
     return defaultInstance.get().takeSnapshotRecording();
   }


### PR DESCRIPTION
Add static loadMappingsFrom(...) methods in WireMock.java for default instance usage

## References

- #3102 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
