### PR TITLE
Fix global timeout CLI option

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -160,7 +160,7 @@ public class CommandLineOptions implements Options {
         .withRequiredArg();
     optionParser.accepts(BIND_ADDRESS, "The IP to listen connections").withRequiredArg();
     optionParser.accepts(CONTAINER_THREADS, "The number of container threads").withRequiredArg();
-    optionParser.accepts(TIMEOUT, "The default global timeout.");
+    optionParser.accepts(TIMEOUT, "The default global timeout in milliseconds.").withRequiredArg();
     optionParser.accepts(
         DISABLE_OPTIMIZE_XML_FACTORIES_LOADING,
         "Whether to disable optimize XML factories loading or not.");
@@ -916,7 +916,7 @@ public class CommandLineOptions implements Options {
 
   @Override
   public long timeout() {
-    return optionSet.has(TIMEOUT)
+    return optionSet.hasArgument(TIMEOUT)
         ? Long.parseLong((String) optionSet.valueOf(TIMEOUT))
         : DEFAULT_TIMEOUT;
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -329,6 +329,18 @@ public class CommandLineOptionsTest {
   }
 
   @Test
+  public void returnsCorrectlyParsedGlobalTimeout() {
+    CommandLineOptions options = new CommandLineOptions("--timeout", "45000");
+    assertThat(options.timeout(), is(45_000L));
+  }
+
+  @Test
+  public void returnsDefaultGlobalTimeout() {
+    CommandLineOptions options = new CommandLineOptions();
+    assertThat(options.timeout(), is(300_000L));
+  }
+
+  @Test
   public void returnsCorrectlyParsedJettyAcceptorThreads() {
     CommandLineOptions options = new CommandLineOptions("--jetty-acceptor-threads", "400");
     assertThat(


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- Fixes #3129

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
