### PR TITLE
fix: Preserve insertion order when creating maps

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/MultipartTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultipartTemplatingAcceptanceTest.java
@@ -53,9 +53,10 @@ public class MultipartTemplatingAcceptanceTest {
         post("/templated")
             .willReturn(
                 ok(
-                    "multipart:{{request.multipart}}\n"
-                        + "text:binary={{request.parts.text.binary}}:{{request.parts.text.headers.content-type}}:{{request.parts.text.body}}\n"
-                        + "file:binary={{request.parts.file.binary}}:{{request.parts.file.headers.content-type}}:{{request.parts.file.bodyAsBase64}}")));
+                    """
+                                multipart:{{request.multipart}}
+                                text:binary={{request.parts.text.binary}}:{{request.parts.text.headers.content-type}}:{{request.parts.text.body}}
+                                file:binary={{request.parts.file.binary}}:{{request.parts.file.headers.content-type}}:{{request.parts.file.bodyAsBase64}}""")));
 
     WireMockResponse response =
         client.post(
@@ -69,9 +70,10 @@ public class MultipartTemplatingAcceptanceTest {
     assertThat(
         response.content(),
         is(
-            "multipart:true\n"
-                + "text:binary=false:text/plain; charset=UTF-8:hello\n"
-                + "file:binary=true:application/octet-stream:QUJDRA=="));
+            """
+                        multipart:true
+                        text:binary=false:text/plain; charset=UTF-8:hello
+                        file:binary=true:application/octet-stream:QUJDRA=="""));
   }
 
   @Test
@@ -80,9 +82,10 @@ public class MultipartTemplatingAcceptanceTest {
         post("/templated")
             .willReturn(
                 ok(
-                    "multipart:{{request.multipart}}\n"
-                        + "text:content-type={{request.parts.text.headers.CoNtEnT-TyPe}}\n"
-                        + "file:content-type={{request.parts.file.headers.cOnTeNt-tYpE}}")));
+                    """
+                                multipart:{{request.multipart}}
+                                text:content-type={{request.parts.text.headers.CoNtEnT-TyPe}}
+                                file:content-type={{request.parts.file.headers.cOnTeNt-tYpE}}""")));
 
     WireMockResponse response =
         client.post(
@@ -96,9 +99,10 @@ public class MultipartTemplatingAcceptanceTest {
     assertThat(
         response.content(),
         is(
-            "multipart:true\n"
-                + "text:content-type=text/plain; charset=UTF-8\n"
-                + "file:content-type=application/octet-stream"));
+            """
+                        multipart:true
+                        text:content-type=text/plain; charset=UTF-8
+                        file:content-type=application/octet-stream"""));
   }
 
   @Test
@@ -139,8 +143,10 @@ public class MultipartTemplatingAcceptanceTest {
         post("/templated")
             .willReturn(
                 ok(
-                    "multipart:{{request.multipart}}\n"
-                        + "{{#each request.parts as |part|}}{{part.name}}:{{part.headers.content-type}}:{{part.body}}/\n{{/each}}")));
+                    """
+                                multipart:{{request.multipart}}
+                                {{#each request.parts as |part|}}{{part.name}}:{{part.headers.content-type}}:{{part.body}}/
+                                {{/each}}""")));
     WireMockResponse response =
         client.post(
             "/templated",
@@ -153,9 +159,11 @@ public class MultipartTemplatingAcceptanceTest {
     assertThat(
         response.content(),
         is(
-            "multipart:true\n"
-                + "file:application/octet-stream:ABCD/\n"
-                + "text:text/plain; charset=UTF-8:hello/\n"));
+            """
+                        multipart:true
+                        text:text/plain; charset=UTF-8:hello/
+                        file:application/octet-stream:ABCD/
+                        """));
   }
 
   @Test
@@ -164,8 +172,10 @@ public class MultipartTemplatingAcceptanceTest {
         post("/templated")
             .willReturn(
                 ok(
-                    "multipart:{{request.multipart}}\n"
-                        + "{{#each request.parts as |part|}}{{part}}\n{{/each}}")));
+                    """
+                                multipart:{{request.multipart}}
+                                {{#each request.parts as |part|}}{{part}}
+                                {{/each}}""")));
     WireMockResponse response =
         client.post(
             "/templated",
@@ -178,22 +188,25 @@ public class MultipartTemplatingAcceptanceTest {
     assertThat(
         response.content(),
         is(
-            "multipart:true\n"
-                + "[name='file', headers={content-disposition=form-data; name=\"file\"; filename=\"abcd.bin\", content-type=application/octet-stream}, body=ABCD]\n"
-                + "[name='text', headers={content-disposition=form-data; name=\"text\", content-type=text/plain; charset=UTF-8}, body=hello]\n"));
+            """
+                        multipart:true
+                        [name='text', headers={content-disposition=form-data; name="text", content-type=text/plain; charset=UTF-8}, body=hello]
+                        [name='file', headers={content-disposition=form-data; name="file"; filename="abcd.bin", content-type=application/octet-stream}, body=ABCD]
+                        """));
   }
 
   @Test
-  void acceptsAMultipartRelatedRFC2387Request() throws Exception {
+  void acceptsAMultipartRelatedRFC2387Request() {
     final String boundary = "boundary_example";
 
     final String expectBody =
-        "{\n"
-            + "  \"error\": {\n"
-            + "    \"code\": 404,\n"
-            + "    \"message\": \"parent not found.\"\n"
-            + "  }\n"
-            + "}";
+        """
+                    {
+                      "error": {
+                        "code": 404,
+                        "message": "parent not found."
+                      }
+                    }""";
 
     wm.stubFor(
         post(urlPathMatching("/templated"))

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/ExtensionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/ExtensionsTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension;
+
+import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.tomakehurst.wiremock.admin.model.*;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.global.GlobalSettings;
+import com.github.tomakehurst.wiremock.matching.RequestPattern;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import com.github.tomakehurst.wiremock.recording.RecordSpec;
+import com.github.tomakehurst.wiremock.recording.RecordSpecBuilder;
+import com.github.tomakehurst.wiremock.recording.RecordingStatusResult;
+import com.github.tomakehurst.wiremock.recording.SnapshotRecordResult;
+import com.github.tomakehurst.wiremock.stubbing.StubImport;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import com.github.tomakehurst.wiremock.verification.*;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ExtensionsTest {
+
+  @Test
+  void extensionsAreReturnedInRegistrationOrder() {
+
+    WireMockConfiguration options =
+        WireMockConfiguration.options()
+            .extensions(() -> "e1", () -> "e2")
+            .extensions(() -> "e3")
+            .extensions(() -> "e4", () -> "e5")
+            .extensions(
+                services -> List.of(() -> "e6", () -> "e7"), services -> List.of(() -> "e8"));
+
+    Extensions extensions =
+        new Extensions(
+            options.getDeclaredExtensions(),
+            new FakeAdmin(),
+            options,
+            options.getStores(),
+            options.filesRoot().child(FILES_ROOT));
+
+    extensions.load();
+
+    List<String> allExtensions = extensions.ofType(Extension.class).keySet().stream().toList();
+
+    assertEquals(
+        List.of("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "response-template", "webhook"),
+        allExtensions);
+  }
+
+  private static class FakeAdmin implements Admin {
+    @Override
+    public void addStubMapping(StubMapping stubMapping) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void editStubMapping(StubMapping stubMapping) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeStubMapping(StubMapping stubbMapping) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeStubMapping(UUID id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ListStubMappingsResult listAllStubMappings() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SingleStubMappingResult getStubMapping(UUID id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void saveMappings() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void resetRequests() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void resetScenarios() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void resetMappings() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void resetAll() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void resetToDefaultMappings() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public GetServeEventsResult getServeEvents() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public GetServeEventsResult getServeEvents(ServeEventQuery query) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SingleServedStubResult getServedStub(UUID id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VerificationResult countRequestsMatching(RequestPattern requestPattern) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FindRequestsResult findRequestsMatching(RequestPattern requestPattern) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FindRequestsResult findUnmatchedRequests() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeServeEvent(UUID eventId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FindServeEventsResult removeServeEventsMatching(RequestPattern requestPattern) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FindServeEventsResult removeServeEventsForStubsMatchingMetadata(
+        StringValuePattern pattern) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FindNearMissesResult findTopNearMissesFor(LoggedRequest loggedRequest) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FindNearMissesResult findTopNearMissesFor(RequestPattern requestPattern) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FindNearMissesResult findNearMissesForUnmatchedRequests() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public GetScenariosResult getAllScenarios() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void resetScenario(String name) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setScenarioState(String name, String state) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateGlobalSettings(GlobalSettings settings) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SnapshotRecordResult snapshotRecord() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SnapshotRecordResult snapshotRecord(RecordSpec spec) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SnapshotRecordResult snapshotRecord(RecordSpecBuilder spec) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void startRecording(String targetBaseUrl) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void startRecording(RecordSpec spec) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void startRecording(RecordSpecBuilder recordSpec) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SnapshotRecordResult stopRecording() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RecordingStatusResult getRecordingStatus() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Options getOptions() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void shutdownServer() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ListStubMappingsResult findUnmatchedStubs() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ListStubMappingsResult findAllStubsByMetadata(StringValuePattern pattern) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeStubsByMetadata(StringValuePattern pattern) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void importStubs(StubImport stubImport) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeStubMappings(List<StubMapping> stubMappings) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public GetGlobalSettingsResult getGlobalSettings() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestLine.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestLine.java
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import java.net.URI;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -62,7 +63,9 @@ public class RequestLine {
     Map<String, ListOrSingle<String>> adaptedQuery =
         rawQuery.entrySet().stream()
             .map(entry -> Map.entry(entry.getKey(), ListOrSingle.of(entry.getValue().values())))
-            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+            .collect(
+                Collectors.toMap(
+                    Entry::getKey, Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
 
     return new RequestLine(
         request.getMethod(),


### PR DESCRIPTION
Makes behaviour deterministic, particularly when registering extensions.

<!-- Please describe your pull request here. -->

## References

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
