### PR TITLE
Fix: case sensitivity in proxy request header removal

### DIFF
--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -172,7 +172,9 @@ public class ProxyResponseRenderer implements ResponseRenderer {
     List<String> removeProxyRequestHeaders =
         response.getRemoveProxyRequestHeaders() == null
             ? Collections.emptyList()
-            : response.getRemoveProxyRequestHeaders();
+            : response.getRemoveProxyRequestHeaders().stream()
+                .map(String::toLowerCase)
+                .toList();
     for (String key : originalRequest.getAllHeaderKeys()) {
       String lowerCaseKey = key.toLowerCase();
       if (removeProxyRequestHeaders.contains(lowerCaseKey)) {


### PR DESCRIPTION
Ensure that header removal during proxying is case-insensitive by converting removeProxyRequestHeaders to lowercase before comparison.

This fixes issues where headers with different casing would not be properly removed from the proxied request.
