### PR TITLE
Fix !3162 - Relocating jspecify to prevent duplicates on classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -220,6 +220,7 @@ tasks.shadowJar {
   relocate("org.yaml", "wiremock.org.yaml")
   relocate("com.ethlo", "wiremock.com.ethlo")
   relocate("com.networknt", "wiremock.com.networknt")
+  relocate("org.jspecify", "wiremock.org.jspecify")
 
   dependencies {
     exclude(dependency("junit:junit"))


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
