### PR TITLE
Draft: feat: adding various string number matchers

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToNumberPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToNumberPatternTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2016-2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Json;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+public class EqualToNumberPatternTest {
+
+    @Test
+    public void failsForNoMatchOnEqualsInt() {
+        StringValuePattern pattern = WireMock.equalToNumber("5");
+        assertFalse(pattern.match("1").isExactMatch());
+        assertThat(pattern.match("1").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void failsForNoMatchOnEqualsIntContains() {
+        StringValuePattern pattern = WireMock.equalToNumber("1");
+        assertFalse(pattern.match("1111").isExactMatch());
+        assertThat(pattern.match("1111").getDistance(), is(0.04));
+    }
+
+    @Test
+    public void failsForNoMatchOnEqualsFloat() {
+        StringValuePattern pattern = WireMock.equalToNumber("5.5");
+        assertFalse(pattern.match("1.1").isExactMatch());
+        assertThat(pattern.match("1.1").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void succeedsForExactMatchOnEqualsInt() {
+        StringValuePattern pattern = WireMock.equalToNumber("1");
+        assertTrue(pattern.match("1").isExactMatch());
+        assertThat(pattern.match("1").getDistance(), is(0.0));
+    }
+
+    @Test
+    public void succeedsForExactMatchOnEqualsFloat() {
+        StringValuePattern pattern = WireMock.equalToNumber("1.1111");
+        assertTrue(pattern.match("1.1111").isExactMatch());
+        assertThat(pattern.match("1.1111").getDistance(), is(0.0));
+    }
+
+    @Test
+    public void correctlyDeserialisesEqualToNumberFromJson() {
+        StringValuePattern stringValuePattern = Json.read("{ \"equalToNumber\": \"1\" }", StringValuePattern.class);
+
+        assertThat(stringValuePattern, instanceOf(EqualToNumberPattern.class));
+        assertThat(stringValuePattern.getValue(), is("1"));
+    }
+
+    @Test
+    public void correctlyDeserialisesEqualToNumberFromJsonWithIgnoreCase() {
+        StringValuePattern stringValuePattern = Json.read("{ \"equalToNumber\": \"1\" }", StringValuePattern.class);
+
+        assertThat(stringValuePattern, instanceOf(EqualToNumberPattern.class));
+        assertThat(stringValuePattern.getValue(), is("1"));
+    }
+
+    @Test
+    public void correctlySerialisesToJson() throws Exception {
+        assertEquals(
+            "{ \"equalToNumber\": \"1\" }",
+            Json.write(new EqualToNumberPattern("1")),
+            false);
+    }
+
+    @Test
+    public void noMatchOnNullValue() {
+        assertThat(WireMock.equalToNumber("1").match(null).isExactMatch(), is(false));
+    }
+
+    @Test
+    public void noMatchOnStringValue() {
+        assertThat(WireMock.equalToNumber("1").match("a string").isExactMatch(), is(false));
+    }
+
+    @Test
+    public void noMatchOnExpectedString() {
+        assertThat(WireMock.equalToNumber("a string").match("1").isExactMatch(), is(false));
+    }
+
+    @Test
+    public void objectsShouldBeEqualOnSameExpectedValue() {
+        var a = new EqualToNumberPattern("1");
+        var b = new EqualToNumberPattern("1");
+        var c = new EqualToNumberPattern("2");
+
+        Assertions.assertEquals(a, b);
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+        Assertions.assertEquals(b, a);
+        Assertions.assertEquals(b.hashCode(), a.hashCode());
+        assertNotEquals(a, c);
+        assertNotEquals(a.hashCode(), c.hashCode());
+        assertNotEquals(b, c);
+        assertNotEquals(b.hashCode(), c.hashCode());
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/LargerThanEqualPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/LargerThanEqualPatternTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2016-2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Json;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+public class LargerThanEqualPatternTest {
+
+    @Test
+    public void failsForNoMatchOnLargerThanInt() {
+        StringValuePattern pattern = WireMock.largerThanEqual("5");
+        assertFalse(pattern.match("1").isExactMatch());
+        assertThat(pattern.match("1").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void succeedsForNoMatchEqualOnLargerThanInt() {
+        StringValuePattern pattern = WireMock.largerThanEqual("1");
+        assertTrue(pattern.match("1").isExactMatch());
+        assertThat(pattern.match("1").getDistance(), is(0.00));
+    }
+
+    @Test
+    public void failsForNoMatchOnLargerThanFloat() {
+        StringValuePattern pattern = WireMock.largerThanEqual("5.5");
+        assertFalse(pattern.match("1.1").isExactMatch());
+        assertThat(pattern.match("1.1").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void succeedsForNoMatchEqualOnLargerThanFloat() {
+        StringValuePattern pattern = WireMock.largerThanEqual("1.1");
+        assertTrue(pattern.match("1.1").isExactMatch());
+        assertThat(pattern.match("1.1").getDistance(), is(0.00));
+    }
+
+    @Test
+    public void succeedsForExactMatchOnLargerThanInt() {
+        StringValuePattern pattern = WireMock.largerThanEqual("1");
+        assertTrue(pattern.match("2").isExactMatch());
+        assertThat(pattern.match("2").getDistance(), is(0.0));
+    }
+
+    @Test
+    public void succeedsForExactMatchOnLargerThanFloat() {
+        StringValuePattern pattern = WireMock.largerThanEqual("1.1111");
+        assertTrue(pattern.match("1.1112").isExactMatch());
+        assertThat(pattern.match("1.1112").getDistance(), is(0.0));
+    }
+
+    @Test
+    public void correctlyDeserialisesEqualToFromJson() {
+        StringValuePattern stringValuePattern = Json.read("{ \"equalToNumber\": \"1\" }", StringValuePattern.class);
+
+        assertThat(stringValuePattern, instanceOf(EqualToNumberPattern.class));
+        assertThat(stringValuePattern.getValue(), is("1"));
+    }
+
+    @Test
+    public void correctlyDeserialisesEqualToFromJsonWithIgnoreCase() {
+        StringValuePattern stringValuePattern = Json.read("{ \"largerThanEqual\": \"1\" }", StringValuePattern.class);
+
+        assertThat(stringValuePattern, instanceOf(LargerThanEqualPattern.class));
+        assertThat(stringValuePattern.getValue(), is("1"));
+    }
+
+    @Test
+    public void correctlySerialisesToJson() throws Exception {
+        assertEquals("{ \"largerThanEqual\": \"1\" }", Json.write(new LargerThanEqualPattern("1")), false);
+    }
+
+    @Test
+    public void noMatchOnNullValue() {
+        assertThat(WireMock.largerThanEqual("1").match(null).isExactMatch(), is(false));
+    }
+
+    @Test
+    public void noMatchOnStringValue() {
+        assertThat(WireMock.largerThanEqual("1").match("a string").isExactMatch(), is(false));
+    }
+
+    @Test
+    public void noMatchOnExpectedString() {
+        assertThat(WireMock.largerThanEqual("a string").match("1").isExactMatch(), is(false));
+    }
+
+    @Test
+    public void objectsShouldBeEqualOnSameExpectedValue() {
+        var a = new LargerThanEqualPattern("1");
+        var b = new LargerThanEqualPattern("1");
+        var c = new LargerThanEqualPattern("2");
+
+        Assertions.assertEquals(a, b);
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+        Assertions.assertEquals(b, a);
+        Assertions.assertEquals(b.hashCode(), a.hashCode());
+        assertNotEquals(a, c);
+        assertNotEquals(a.hashCode(), c.hashCode());
+        assertNotEquals(b, c);
+        assertNotEquals(b.hashCode(), c.hashCode());
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/LargerThanPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/LargerThanPatternTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2016-2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Json;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+public class LargerThanPatternTest {
+
+    @Test
+    public void failsForNoMatchOnLargerThanInt() {
+        StringValuePattern pattern = WireMock.largerThan("5");
+        assertFalse(pattern.match("1").isExactMatch());
+        assertThat(pattern.match("1").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void failsForNoMatchEqualOnLargerThanInt() {
+        StringValuePattern pattern = WireMock.largerThan("1");
+        assertFalse(pattern.match("1").isExactMatch());
+        assertThat(pattern.match("1").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void failsForNoMatchOnLargerThanFloat() {
+        StringValuePattern pattern = WireMock.largerThan("5.5");
+        assertFalse(pattern.match("1.1").isExactMatch());
+        assertThat(pattern.match("1.1").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void failsForNoMatchEqualOnLargerThanFloat() {
+        StringValuePattern pattern = WireMock.largerThan("1.1");
+        assertFalse(pattern.match("1.1").isExactMatch());
+        assertThat(pattern.match("1.1").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void succeedsForExactMatchOnLargerThanInt() {
+        StringValuePattern pattern = WireMock.largerThan("1");
+        assertTrue(pattern.match("2").isExactMatch());
+        assertThat(pattern.match("2").getDistance(), is(0.0));
+    }
+
+    @Test
+    public void succeedsForExactMatchOnLargerThanFloat() {
+        StringValuePattern pattern = WireMock.largerThan("1.1111");
+        assertTrue(pattern.match("1.1112").isExactMatch());
+        assertThat(pattern.match("1.1112").getDistance(), is(0.0));
+    }
+
+    @Test
+    public void correctlyDeserialisesEqualToFromJson() {
+        StringValuePattern stringValuePattern = Json.read("{ \"equalToNumber\": \"1\" }", StringValuePattern.class);
+
+        assertThat(stringValuePattern, instanceOf(EqualToNumberPattern.class));
+        assertThat(stringValuePattern.getValue(), is("1"));
+    }
+
+    @Test
+    public void correctlyDeserialisesEqualToFromJsonWithIgnoreCase() {
+        StringValuePattern stringValuePattern = Json.read("{ \"largerThan\": \"1\" }", StringValuePattern.class);
+
+        assertThat(stringValuePattern, instanceOf(LargerThanPattern.class));
+        assertThat(stringValuePattern.getValue(), is("1"));
+    }
+
+    @Test
+    public void correctlySerialisesToJson() throws Exception {
+        assertEquals("{ \"largerThan\": \"1\" }", Json.write(new LargerThanPattern("1")), false);
+    }
+
+    @Test
+    public void noMatchOnNullValue() {
+        assertThat(WireMock.largerThan("1").match(null).isExactMatch(), is(false));
+    }
+
+    @Test
+    public void noMatchOnStringValue() {
+        assertThat(WireMock.largerThan("1").match("a string").isExactMatch(), is(false));
+    }
+
+    @Test
+    public void noMatchOnExpectedString() {
+        assertThat(WireMock.largerThan("a string").match("1").isExactMatch(), is(false));
+    }
+
+    @Test
+    public void objectsShouldBeEqualOnSameExpectedValue() {
+        var a = new LargerThanPattern("1");
+        var b = new LargerThanPattern("1");
+        var c = new LargerThanPattern("2");
+
+        Assertions.assertEquals(a, b);
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+        Assertions.assertEquals(b, a);
+        Assertions.assertEquals(b.hashCode(), a.hashCode());
+        assertNotEquals(a, c);
+        assertNotEquals(a.hashCode(), c.hashCode());
+        assertNotEquals(b, c);
+        assertNotEquals(b.hashCode(), c.hashCode());
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/LessThanEqualPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/LessThanEqualPatternTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2016-2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Json;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+public class LessThanEqualPatternTest {
+
+    @Test
+    public void failsForNoMatchOnLessThanEqualInt() {
+        StringValuePattern pattern = WireMock.lessThanEqual("1");
+        assertFalse(pattern.match("5").isExactMatch());
+        assertThat(pattern.match("5").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void succeedsForNoMatchEqualOnLessThanEqualInt() {
+        StringValuePattern pattern = WireMock.lessThanEqual("1");
+        assertTrue(pattern.match("1").isExactMatch());
+        assertThat(pattern.match("1").getDistance(), is(0.00));
+    }
+
+    @Test
+    public void failsForNoMatchOnLessThanEqualFloat() {
+        StringValuePattern pattern = WireMock.lessThanEqual("1.1");
+        assertFalse(pattern.match("5.5").isExactMatch());
+        assertThat(pattern.match("5.5").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void succeedsForNoMatchEqualOnLessThanEqualFloat() {
+        StringValuePattern pattern = WireMock.lessThanEqual("1.1");
+        assertTrue(pattern.match("1.1").isExactMatch());
+        assertThat(pattern.match("1.1").getDistance(), is(0.00));
+    }
+
+    @Test
+    public void succeedsForExactMatchOnLessThanEqualInt() {
+        StringValuePattern pattern = WireMock.lessThanEqual("2");
+        assertTrue(pattern.match("1").isExactMatch());
+        assertThat(pattern.match("1").getDistance(), is(0.0));
+    }
+
+    @Test
+    public void succeedsForExactMatchOnLessThanEqualFloat() {
+        StringValuePattern pattern = WireMock.lessThanEqual("1.1111");
+        assertTrue(pattern.match("1.111").isExactMatch());
+        assertThat(pattern.match("1.111").getDistance(), is(0.0));
+    }
+
+    @Test
+    public void correctlyDeserialisesEqualToFromJson() {
+        StringValuePattern stringValuePattern = Json.read("{ \"equalToNumber\": \"1\" }", StringValuePattern.class);
+
+        assertThat(stringValuePattern, instanceOf(EqualToNumberPattern.class));
+        assertThat(stringValuePattern.getValue(), is("1"));
+    }
+
+    @Test
+    public void correctlyDeserialisesEqualToFromJsonWithIgnoreCase() {
+        StringValuePattern stringValuePattern = Json.read("{ \"lessThanEqual\": \"1\" }", StringValuePattern.class);
+
+        assertThat(stringValuePattern, instanceOf(LessThanEqualPattern.class));
+        assertThat(stringValuePattern.getValue(), is("1"));
+    }
+
+    @Test
+    public void correctlySerialisesToJson() throws Exception {
+        assertEquals("{ \"lessThanEqual\": \"1\" }", Json.write(new LessThanEqualPattern("1")), false);
+    }
+
+    @Test
+    public void noMatchOnNullValue() {
+        assertThat(WireMock.lessThanEqual("1").match(null).isExactMatch(), is(false));
+    }
+
+    @Test
+    public void noMatchOnStringValue() {
+        assertThat(WireMock.lessThanEqual("1").match("a string").isExactMatch(), is(false));
+    }
+
+    @Test
+    public void noMatchOnExpectedString() {
+        assertThat(WireMock.lessThanEqual("a string").match("1").isExactMatch(), is(false));
+    }
+
+    @Test
+    public void objectsShouldBeEqualOnSameExpectedValue() {
+        var a = new LessThanEqualPattern("1");
+        var b = new LessThanEqualPattern("1");
+        var c = new LessThanEqualPattern("2");
+
+        Assertions.assertEquals(a, b);
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+        Assertions.assertEquals(b, a);
+        Assertions.assertEquals(b.hashCode(), a.hashCode());
+        assertNotEquals(a, c);
+        assertNotEquals(a.hashCode(), c.hashCode());
+        assertNotEquals(b, c);
+        assertNotEquals(b.hashCode(), c.hashCode());
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/LessThanPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/LessThanPatternTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2016-2023 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Json;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+public class LessThanPatternTest {
+
+    @Test
+    public void failsForNoMatchOnLessThanInt() {
+        StringValuePattern pattern = WireMock.lessThan("1");
+        assertFalse(pattern.match("5").isExactMatch());
+        assertThat(pattern.match("5").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void failsForNoMatchEqualOnLessThanInt() {
+        StringValuePattern pattern = WireMock.lessThan("1");
+        assertFalse(pattern.match("1").isExactMatch());
+        assertThat(pattern.match("1").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void failsForNoMatchOnLessThanFloat() {
+        StringValuePattern pattern = WireMock.lessThan("1.1");
+        assertFalse(pattern.match("5.5").isExactMatch());
+        assertThat(pattern.match("5.5").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void failsForNoMatchEqualOnLessThanFloat() {
+        StringValuePattern pattern = WireMock.lessThan("1.1");
+        assertFalse(pattern.match("1.1").isExactMatch());
+        assertThat(pattern.match("1.1").getDistance(), is(0.01));
+    }
+
+    @Test
+    public void succeedsForExactMatchOnLessThanInt() {
+        StringValuePattern pattern = WireMock.lessThan("2");
+        assertTrue(pattern.match("1").isExactMatch());
+        assertThat(pattern.match("1").getDistance(), is(0.0));
+    }
+
+    @Test
+    public void succeedsForExactMatchOnLessThanFloat() {
+        StringValuePattern pattern = WireMock.lessThan("1.1111");
+        assertTrue(pattern.match("1.111").isExactMatch());
+        assertThat(pattern.match("1.111").getDistance(), is(0.0));
+    }
+
+    @Test
+    public void correctlyDeserialisesEqualToFromJson() {
+        StringValuePattern stringValuePattern = Json.read("{ \"equalToNumber\": \"1\" }", StringValuePattern.class);
+
+        assertThat(stringValuePattern, instanceOf(EqualToNumberPattern.class));
+        assertThat(stringValuePattern.getValue(), is("1"));
+    }
+
+    @Test
+    public void correctlyDeserialisesEqualToFromJsonWithIgnoreCase() {
+        StringValuePattern stringValuePattern = Json.read("{ \"lessThan\": \"1\" }", StringValuePattern.class);
+
+        assertThat(stringValuePattern, instanceOf(LessThanPattern.class));
+        assertThat(stringValuePattern.getValue(), is("1"));
+    }
+
+    @Test
+    public void correctlySerialisesToJson() throws Exception {
+        assertEquals("{ \"lessThan\": \"1\" }", Json.write(new LessThanPattern("1")), false);
+    }
+
+    @Test
+    public void noMatchOnNullValue() {
+        assertThat(WireMock.lessThan("1").match(null).isExactMatch(), is(false));
+    }
+
+    @Test
+    public void noMatchOnStringValue() {
+        assertThat(WireMock.lessThan("1").match("a string").isExactMatch(), is(false));
+    }
+
+    @Test
+    public void noMatchOnExpectedString() {
+        assertThat(WireMock.lessThan("a string").match("1").isExactMatch(), is(false));
+    }
+
+    @Test
+    public void objectsShouldBeEqualOnSameExpectedValue() {
+        var a = new LessThanPattern("1");
+        var b = new LessThanPattern("1");
+        var c = new LessThanPattern("2");
+
+        Assertions.assertEquals(a, b);
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+        Assertions.assertEquals(b, a);
+        Assertions.assertEquals(b.hashCode(), a.hashCode());
+        assertNotEquals(a, c);
+        assertNotEquals(a.hashCode(), c.hashCode());
+        assertNotEquals(b, c);
+        assertNotEquals(b.hashCode(), c.hashCode());
+    }
+}

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -215,6 +215,26 @@ public class WireMock {
     return new EqualToPattern(value);
   }
 
+    public static StringValuePattern equalToNumber(String value) {
+        return new EqualToNumberPattern(value);
+    }
+
+    public static StringValuePattern largerThan(String value) {
+        return new LargerThanPattern(value);
+    }
+
+    public static StringValuePattern largerThanEqual(String value) {
+        return new LargerThanEqualPattern(value);
+    }
+
+    public static StringValuePattern lessThan(String value) {
+        return new LessThanPattern(value);
+    }
+
+    public static StringValuePattern lessThanEqual(String value) {
+        return new LessThanEqualPattern(value);
+    }
+
   public static BinaryEqualToPattern binaryEqualTo(byte[] content) {
     return new BinaryEqualToPattern(content);
   }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractNumberMatchResult.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractNumberMatchResult.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2021-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import static java.lang.Math.min;
+import static java.lang.Math.round;
+
+public abstract class AbstractNumberMatchResult extends MatchResult {
+
+    protected static final float EXACT_MATCH = 0.0f;
+    protected static final float NO_MATCH = 1.0f;
+    private static final double MAX_LOG_DIFF = 176.0;
+    private final String expectedValue;
+    private final String value;
+
+
+    public AbstractNumberMatchResult(String expectedValue, String value) {
+        this.expectedValue = expectedValue;
+        this.value = value;
+    }
+
+    private static double getShiftValue(double expectedDouble, double actualDouble) {
+        if (expectedDouble < 0.0 || actualDouble < 0.0) {
+            return min(expectedDouble, actualDouble);
+        } else {
+            return EXACT_MATCH;
+        }
+    }
+
+    private static boolean areValuesTooBig(double expectedDouble, double actualDouble) {
+        return expectedDouble == Double.POSITIVE_INFINITY ||
+            actualDouble == Double.POSITIVE_INFINITY ||
+            (expectedDouble == Double.MAX_VALUE && actualDouble == Double.MAX_VALUE);
+    }
+
+    private static double calculateDistance(double expectedDouble, double actualDouble) {
+        double logA = Math.log(expectedDouble);
+        double logB = Math.log(actualDouble);
+        double logDiff = Math.abs(logA - logB);
+        double normalized = logDiff / MAX_LOG_DIFF;
+
+        return round(min(normalized, 1.0) * 100) / 100.0;
+    }
+
+    abstract protected boolean isExactMatch(double expected, double actual);
+
+    @Override
+    public boolean isExactMatch() {
+        try {
+            var expectedDouble = Double.parseDouble(expectedValue);
+            var actualDouble = Double.parseDouble(value);
+
+            return isExactMatch(expectedDouble, actualDouble);
+        } catch (NumberFormatException | NullPointerException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public double getDistance() {
+        try {
+            var parsedExpected = Double.parseDouble(expectedValue);
+            var parsedActual = Double.parseDouble(value);
+            if (isExactMatch(parsedExpected, parsedActual)) {
+                return EXACT_MATCH;
+            }
+            var shiftValue = getShiftValue(parsedExpected, parsedActual);
+            var expectedDouble = parsedExpected + shiftValue;
+            var actualDouble = parsedActual + shiftValue;
+
+            if (areValuesTooBig(expectedDouble, actualDouble)) {
+                return NO_MATCH;
+            }
+            double actualDistance = calculateDistance(expectedDouble, actualDouble);
+            if (actualDistance == EXACT_MATCH) {
+                return 0.01;
+            } else {
+                return actualDistance;
+            }
+        } catch (NumberFormatException | NullPointerException e) {
+            return 1.0;
+        }
+    }
+}

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToNumberPattern.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToNumberPattern.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class EqualToNumberPattern extends StringValuePattern {
+
+    public EqualToNumberPattern(@JsonProperty("equalToNumber") String testValue) {
+        super(testValue);
+    }
+
+    public String getEqualToNumber() {
+        return expectedValue;
+    }
+
+    @Override
+    public MatchResult match(final String value) {
+        return new AbstractNumberMatchResult(expectedValue, value) {
+            @Override
+            protected boolean isExactMatch(double expected, double actual) {
+                return expected == actual;
+            }
+        };
+    }
+}

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/LargerThanEqualPattern.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/LargerThanEqualPattern.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LargerThanEqualPattern extends StringValuePattern {
+
+    public LargerThanEqualPattern(@JsonProperty("largerThanEqual") String testValue) {
+        super(testValue);
+    }
+
+    public String getLargerThanEqual() {
+        return expectedValue;
+    }
+
+    @Override
+    public MatchResult match(final String value) {
+        return new AbstractNumberMatchResult(expectedValue, value) {
+            @Override
+            protected boolean isExactMatch(double expected, double actual) {
+                return actual >= expected;
+            }
+        };
+    }
+}

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/LargerThanPattern.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/LargerThanPattern.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LargerThanPattern extends StringValuePattern {
+
+    public LargerThanPattern(@JsonProperty("largerThan") String testValue) {
+        super(testValue);
+    }
+
+    public String getLargerThan() {
+        return expectedValue;
+    }
+
+    @Override
+    public MatchResult match(final String value) {
+        return new AbstractNumberMatchResult(expectedValue, value) {
+            @Override
+            protected boolean isExactMatch(double expected, double actual) {
+                return actual > expected;
+            }
+        };
+    }
+}

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/LessThanEqualPattern.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/LessThanEqualPattern.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LessThanEqualPattern extends StringValuePattern {
+
+    public LessThanEqualPattern(@JsonProperty("lessThanEqual") String testValue) {
+        super(testValue);
+    }
+
+    public String getLessThanEqual() {
+        return expectedValue;
+    }
+
+    @Override
+    public MatchResult match(final String value) {
+        return new AbstractNumberMatchResult(expectedValue, value) {
+            @Override
+            protected boolean isExactMatch(double expected, double actual) {
+                return actual <= expected;
+            }
+        };
+    }
+}

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/LessThanPattern.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/LessThanPattern.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LessThanPattern extends StringValuePattern {
+
+    public LessThanPattern(@JsonProperty("lessThan") String testValue) {
+        super(testValue);
+    }
+
+    public String getLessThan() {
+        return expectedValue;
+    }
+
+    @Override
+    public MatchResult match(final String value) {
+        return new AbstractNumberMatchResult(expectedValue, value) {
+            @Override
+            protected boolean isExactMatch(double expected, double actual) {
+                return actual < expected;
+            }
+        };
+    }
+}

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
@@ -36,6 +36,7 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
   private static final Map<String, Class<? extends StringValuePattern>> PATTERNS =
       Map.ofEntries(
           Map.entry("equalTo", EqualToPattern.class),
+          Map.entry("equalToNumber", EqualToNumberPattern.class),
           Map.entry("equalToJson", EqualToJsonPattern.class),
           Map.entry("matchesJsonPath", MatchesJsonPathPattern.class),
           Map.entry("matchesJsonSchema", MatchesJsonSchemaPattern.class),
@@ -53,7 +54,12 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
           Map.entry("absent", AbsentPattern.class),
           Map.entry("and", LogicalAnd.class),
           Map.entry("or", LogicalOr.class),
-          Map.entry("matchesPathTemplate", PathTemplatePattern.class));
+          Map.entry("matchesPathTemplate", PathTemplatePattern.class),
+          Map.entry("largerThan", LargerThanPattern.class),
+          Map.entry("largerThanEqual", LargerThanEqualPattern.class),
+          Map.entry("lessThan", LessThanPattern.class),
+          Map.entry("lessThanEqual", LessThanEqualPattern.class)
+      );
 
   @Override
   public StringValuePattern deserialize(JsonParser parser, DeserializationContext context)


### PR DESCRIPTION
# Conflicts:
#	wiremock-common/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java

Adding matchers for numeric comparison:

- `equalToNumber`
- `largerThan` + `largerThanEqual`
- `lessThan` + `lessThanEqual`

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
