### PR TITLE
fix: Make shadowJar work again

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -250,7 +250,7 @@ publishing {
 
     create<MavenPublication>("standaloneJar") {
       artifactId = "${tasks.jar.get().archiveBaseName.get()}-standalone"
-      project.shadow.component(this)
+      from(components["shadow"])
 
       artifact(tasks.named("sourcesJar"))
       artifact(tasks.named("javadocJar"))

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
   implementation("com.diffplug.gradle.spotless:com.diffplug.gradle.spotless.gradle.plugin:6.25.0")
-  implementation("com.github.johnrengelman.shadow:com.github.johnrengelman.shadow.gradle.plugin:8.1.1")
+  implementation("com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:9.2.2")
   implementation("org.sonarqube:org.sonarqube.gradle.plugin:6.2.0.5505")
   implementation("com.vanniktech.maven.publish.base:com.vanniktech.maven.publish.base.gradle.plugin:0.33.0")
 }

--- a/buildSrc/src/main/kotlin/wiremock.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/wiremock.common-conventions.gradle.kts
@@ -11,7 +11,7 @@ plugins {
   signing
   `maven-publish`
   id("com.diffplug.spotless")
-  id("com.github.johnrengelman.shadow")
+  id("com.gradleup.shadow")
   id("org.sonarqube")
   id("com.vanniktech.maven.publish.base")
 }
@@ -191,12 +191,6 @@ publishing {
 
   (components["java"] as AdhocComponentWithVariants).withVariantsFromConfiguration(configurations.testFixturesApiElements.get()) { skip() }
   (components["java"] as AdhocComponentWithVariants).withVariantsFromConfiguration(configurations.testFixturesRuntimeElements.get()) { skip() }
-
-  getComponents().withType<AdhocComponentWithVariants>().forEach { c ->
-    c.withVariantsFromConfiguration(configurations.shadowRuntimeElements.get()) {
-      skip()
-    }
-  }
 
   publications {
     withType<MavenPublication> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -120,7 +120,7 @@ nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0
 vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech-maven-publish" }
 vanniktech-maven-publish-base = { id = "com.vanniktech.maven.publish.base", version.ref = "vanniktech-maven-publish" }
 spotless = { id = "com.diffplug.spotless", version = "8.0.0" }
-shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+shadow = { id = "com.gradleup.shadow", version = "9.2.2" }
 sonarqube = { id = "org.sonarqube", version = "7.0.0.6105" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 task-tree = { id = "com.dorongold.task-tree", version = "4.0.1" }

--- a/test-extension/build.gradle
+++ b/test-extension/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
 plugins {
   id 'java'
-  id 'com.github.johnrengelman.shadow'
+  id 'com.gradleup.shadow'
 }
 
 group 'org.wiremock.example'


### PR DESCRIPTION
Bit disturbing that this could break without a build breaking?!

The old shadowJar plugin does not work with Gradle 9.x.

ChatGPT's reasoning for this change:

🧩 What your old code did

Under the old plugin (`com.github.johnrengelman.shadow`):

```kotlin
create<MavenPublication>("standaloneJar") {
    project.shadow.component(this)
}
```

This line:

```koltin
project.shadow.component(this)
```

registered the *shadowed JAR* (the output of `shadowJar`) as a *Maven
publication component*.

That allowed you to publish the _fat JAR_ instead of the normal JAR
produced by the Java component. It came from the Shadow plugin’s
`ShadowExtension` (via `project.shadow`) which provided a `component()`
helper method.

Then this part:

```kotlin
getComponents().withType<AdhocComponentWithVariants>().forEach { c ->
    c.withVariantsFromConfiguration(configurations.shadowRuntimeElements.get()) {
        skip()
    }
}
```

prevented Gradle from publishing duplicate runtime variants — otherwise,
you’d end up with multiple variants for the same artifact (the plain JAR
and the shadowed JAR).

💥 Why it broke in `com.gradleup.shadow:9.2.2`

In the GradleUp fork (`com.gradleup.shadow`), the internal API was
cleaned up and made Gradle 8+–compatible, and the
`project.shadow.component(this)` helper was removed.

Now, the plugin registers its publication component directly under the
name `shadow`. You can access it just like any other Gradle component.

✅ The correct equivalent in `com.gradleup.shadow:9.2.2`

Use this instead:

```kotlin
publishing {
    publications {
        create<MavenPublication>("standaloneJar") {
            from(components["shadow"])
        }
    }

    // You no longer need the AdhocComponentWithVariants workaround
}
```

That’s it.

💡 Why you don’t need the `withVariantsFromConfiguration` block any more

In Shadow 9.x, the plugin handles variant publication correctly through
the `shadow` software component. It’s fully integrated with Gradle’s
`components` API, so you no longer have to skip variants manually.

The old `shadowRuntimeElements` workaround is obsolete — it was
necessary only when the Shadow plugin didn’t expose a proper publication
component.

<!-- Please describe your pull request here. -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
