### PR TITLE
[3.x] Add Jetty 12.1.x support (as separate module)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'wiremock'
 if (JavaVersion.current() >= JavaVersion.VERSION_17) {
   include 'wiremock-jetty12'
+  include 'wiremock-jetty12.1'
 }

--- a/wiremock-jetty12.1/build.gradle
+++ b/wiremock-jetty12.1/build.gradle
@@ -1,0 +1,140 @@
+buildscript {
+  repositories {
+    maven {
+      url "https://oss.sonatype.org"
+    }
+    mavenCentral()
+  }
+}
+
+plugins {
+  id 'java-library'
+  id 'java-test-fixtures'
+  id 'signing'
+  id 'maven-publish'
+  id 'com.diffplug.spotless' version '6.25.0'
+  id "org.sonarqube" version "6.2.0.5505"
+  id 'jacoco'
+  id 'idea'
+}
+
+group 'org.wiremock'
+
+java {
+  sourceCompatibility = 17
+  targetCompatibility = 17
+  withSourcesJar()
+  withJavadocJar()
+}
+
+project.ext {
+  versions = [
+    jetty        : '12.1.3',
+    junitJupiter : '5.10.2'
+  ]
+}
+
+dependencies {
+
+  api platform("org.eclipse.jetty:jetty-bom:$versions.jetty")
+  api platform("org.eclipse.jetty.ee11:jetty-ee11-bom:$versions.jetty")
+
+  api project(':'), {
+    exclude group: 'org.eclipse.jetty'
+    exclude group: 'org.eclipse.jetty.http2'
+  }
+
+  api "org.eclipse.jetty:jetty-server"
+  api "org.eclipse.jetty:jetty-proxy"
+  api "org.eclipse.jetty:jetty-alpn-server"
+  api "org.eclipse.jetty:jetty-alpn-java-server"
+  api "org.eclipse.jetty:jetty-alpn-java-client"
+  api "org.eclipse.jetty:jetty-alpn-client"
+  api "org.eclipse.jetty.ee11:jetty-ee11-servlet"
+  api "org.eclipse.jetty.ee11:jetty-ee11-servlets"
+  api "org.eclipse.jetty.ee11:jetty-ee11-webapp"
+  api "org.eclipse.jetty.http2:jetty-http2-server:$versions.jetty"
+  api "org.eclipse.jetty:jetty-alpn-java-server:$versions.jetty"
+
+  testImplementation "org.eclipse.jetty.http2:jetty-http2-client:$versions.jetty"
+  testImplementation "org.eclipse.jetty.http2:jetty-http2-client-transport:$versions.jetty"
+  testImplementation "org.eclipse.jetty:jetty-alpn-java-client:$versions.jetty"
+
+  testImplementation(testFixtures(project(":")), {
+    exclude group: 'org.eclipse.jetty'
+    exclude group: 'org.eclipse.jetty.http2'
+  })
+}
+
+idea {
+  module {
+    jdkName = '1.17'
+  }
+}
+
+jar {
+  archiveBaseName.set('wiremock-jetty12.1')
+  manifest {
+    attributes("Implementation-Version": project.version)
+    attributes("Implementation-Title": "WireMock with Jetty 12.1")
+  }
+}
+
+javadoc {
+  exclude "**/CertificateAuthority.java"
+  options.addStringOption('Xdoclint:none', '-quiet')
+}
+
+signing {
+  required {
+    !version.toString().contains("SNAPSHOT") && (gradle.taskGraph.hasTask("uploadArchives") || gradle.taskGraph.hasTask("publish"))
+  }
+  def signingKey = providers.environmentVariable("OSSRH_GPG_SECRET_KEY").orElse("").get()
+  def signingPassphrase = providers.environmentVariable("OSSRH_GPG_SECRET_KEY_PASSWORD").orElse("").get()
+  if (!signingKey.isEmpty() && !signingPassphrase.isEmpty()) {
+    useInMemoryPgpKeys(signingKey, signingPassphrase)
+  }
+  sign publishing.publications
+}
+
+if (JavaVersion.current().getMajorVersion() == '17') {
+  publishing {
+    repositories {
+      maven {
+        name = "GitHubPackages"
+        url = "https://maven.pkg.github.com/wiremock/wiremock"
+        credentials {
+          username = System.getenv("GITHUB_ACTOR")
+          password = System.getenv("GITHUB_TOKEN")
+        }
+      }
+    }
+
+    publications {
+      mavenJava(MavenPublication) { publication ->
+        artifactId = "${jar.getArchiveBaseName().get()}"
+        from components.java
+
+        pom.withXml {
+          asNode().appendNode('description', 'WireMock with Jetty 12.1 as its HTTP server')
+          asNode().children().last() + pomInfo
+        }
+      }
+    }
+  }
+}
+
+task localRelease {
+  dependsOn clean, assemble, publishToMavenLocal
+}
+
+test {
+  useJUnitPlatform()
+
+  maxParallelForks = runningOnCI ? 1 : 3
+
+  testLogging {
+    events "FAILED", "SKIPPED"
+    exceptionFormat "full"
+  }
+}

--- a/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/HttpProxyDetectingHandler.java
+++ b/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/HttpProxyDetectingHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1;
+
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Callback;
+
+/**
+ * The Jetty 11 implementation was relying on relative request URI presence to detect the proxying
+ * request. Jetty 12 does not do that anymore and URI is always converted to absolute form. To keep
+ * proxy detection working, the Jetty 12 specific implementation does compare connector and URI
+ * ports (which are different in case of proxying request).
+ */
+public class HttpProxyDetectingHandler extends Handler.Abstract {
+
+  public static final String IS_HTTP_PROXY_REQUEST_ATTRIBUTE = "wiremock.isHttpProxyRequest";
+
+  private final ServerConnector httpConnector;
+
+  public HttpProxyDetectingHandler(ServerConnector httpConnector) {
+    this.httpConnector = httpConnector;
+  }
+
+  @Override
+  public boolean handle(Request request, Response response, Callback callback) throws Exception {
+    final int httpPort = httpConnector.getLocalPort();
+
+    if (httpPort != request.getHttpURI().getPort()
+        && "http".equals(request.getHttpURI().getScheme())) {
+      request.setAttribute(IS_HTTP_PROXY_REQUEST_ATTRIBUTE, true);
+    }
+
+    return false;
+  }
+}

--- a/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/HttpsProxyDetectingHandler.java
+++ b/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/HttpsProxyDetectingHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Callback;
+
+public class HttpsProxyDetectingHandler extends Handler.Abstract {
+
+  public static final String IS_HTTPS_PROXY_REQUEST_ATTRIBUTE = "wiremock.isHttpsProxyRequest";
+
+  private final ServerConnector mitmProxyConnector;
+
+  public HttpsProxyDetectingHandler(ServerConnector mitmProxyConnector) {
+    this.mitmProxyConnector = mitmProxyConnector;
+  }
+
+  @Override
+  public boolean handle(Request request, Response response, Callback callback) throws Exception {
+    final int httpsProxyPort = mitmProxyConnector.getLocalPort();
+
+    int localPort = -1;
+    SocketAddress local = request.getConnectionMetaData().getLocalSocketAddress();
+    if (local instanceof InetSocketAddress) {
+      localPort = ((InetSocketAddress) local).getPort();
+    }
+
+    if (localPort == httpsProxyPort) {
+      request.setAttribute(IS_HTTPS_PROXY_REQUEST_ATTRIBUTE, true);
+    }
+    return false;
+  }
+}

--- a/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/Jetty12HttpServer.java
+++ b/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/Jetty12HttpServer.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright (C) 2019-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+import static com.github.tomakehurst.wiremock.common.ResourceUtil.getResource;
+import static com.github.tomakehurst.wiremock.core.WireMockApp.ADMIN_CONTEXT_ROOT;
+import static com.github.tomakehurst.wiremock.jetty11.Jetty11Utils.createHttpConfig;
+import static com.github.tomakehurst.wiremock.jetty11.SslContexts.buildManInTheMiddleSslContextFactory;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+
+import com.github.tomakehurst.wiremock.common.AsynchronousResponseSettings;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.common.HttpsSettings;
+import com.github.tomakehurst.wiremock.common.JettySettings;
+import com.github.tomakehurst.wiremock.common.Notifier;
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.core.WireMockApp;
+import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
+import com.github.tomakehurst.wiremock.http.RequestHandler;
+import com.github.tomakehurst.wiremock.http.StubRequestHandler;
+import com.github.tomakehurst.wiremock.jetty.JettyFaultInjectorFactory;
+import com.github.tomakehurst.wiremock.jetty.JettyHttpServer;
+import com.github.tomakehurst.wiremock.jetty.JettyHttpUtils;
+import com.github.tomakehurst.wiremock.jetty11.Jetty11Utils;
+import com.github.tomakehurst.wiremock.jetty11.SslContexts;
+import com.github.tomakehurst.wiremock.servlet.ContentTypeSettingFilter;
+import com.github.tomakehurst.wiremock.servlet.FaultInjectorFactory;
+import com.github.tomakehurst.wiremock.servlet.MultipartRequestConfigurer;
+import com.github.tomakehurst.wiremock.servlet.NotMatchedServlet;
+import com.github.tomakehurst.wiremock.servlet.TrailingSlashFilter;
+import com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet;
+import jakarta.servlet.DispatcherType;
+import java.util.*;
+import java.util.stream.Stream;
+import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
+import org.eclipse.jetty.ee11.servlet.DefaultServlet;
+import org.eclipse.jetty.ee11.servlet.FilterHolder;
+import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee11.servlet.ServletContextRequest;
+import org.eclipse.jetty.ee11.servlet.ServletHolder;
+import org.eclipse.jetty.ee11.servlets.CrossOriginFilter;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
+import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
+import org.eclipse.jetty.io.NetworkTrafficListener;
+import org.eclipse.jetty.server.*;
+import org.eclipse.jetty.server.handler.gzip.GzipHandler;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+public class Jetty12HttpServer extends JettyHttpServer {
+
+  private ServerConnector mitmProxyConnector;
+
+  public Jetty12HttpServer(
+      Options options,
+      AdminRequestHandler adminRequestHandler,
+      StubRequestHandler stubRequestHandler) {
+    super(options, adminRequestHandler, stubRequestHandler);
+  }
+
+  @Override
+  protected ServerConnector createHttpConnector(
+      String bindAddress, int port, JettySettings jettySettings, NetworkTrafficListener listener) {
+
+    HttpConfiguration httpConfig = createHttpConfig(jettySettings);
+
+    ConnectionFactory[] connectionFactories =
+        Stream.of(
+                new HttpConnectionFactory(httpConfig),
+                options.getHttp2PlainDisabled()
+                    ? null
+                    : new HTTP2CServerConnectionFactory(httpConfig))
+            .filter(Objects::nonNull)
+            .toArray(ConnectionFactory[]::new);
+
+    return Jetty11Utils.createServerConnector(
+        jettyServer, bindAddress, jettySettings, port, listener, connectionFactories);
+  }
+
+  @Override
+  protected ServerConnector createHttpsConnector(
+      String bindAddress,
+      HttpsSettings httpsSettings,
+      JettySettings jettySettings,
+      NetworkTrafficListener listener) {
+
+    HttpConfiguration httpConfig = createHttpConfig(jettySettings);
+
+    ConnectionFactory[] connectionFactories;
+
+    if (!options.getHttp2TlsDisabled()) {
+
+      SslContextFactory.Server http2SslContextFactory =
+          SslContexts.buildHttp2SslContextFactory(httpsSettings);
+
+      HttpConnectionFactory http = new HttpConnectionFactory(httpConfig);
+      HTTP2ServerConnectionFactory h2 = new HTTP2ServerConnectionFactory(httpConfig);
+
+      try {
+        ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory();
+
+        SslConnectionFactory ssl =
+            new SslConnectionFactory(http2SslContextFactory, alpn.getProtocol());
+
+        connectionFactories = new ConnectionFactory[] {ssl, alpn, h2, http};
+      } catch (IllegalStateException e) {
+        SslConnectionFactory ssl =
+            new SslConnectionFactory(http2SslContextFactory, http.getProtocol());
+
+        connectionFactories = new ConnectionFactory[] {ssl, http};
+      }
+    } else {
+      final SslContextFactory.Server sslContextFactory =
+          SslContexts.buildHttp1_1SslContextFactory(httpsSettings);
+      final SslConnectionFactory ssl = new SslConnectionFactory(sslContextFactory, "http/1.1");
+      final HttpConnectionFactory http = new HttpConnectionFactory(httpConfig);
+      connectionFactories = new ConnectionFactory[] {ssl, http};
+    }
+
+    return Jetty11Utils.createServerConnector(
+        jettyServer,
+        bindAddress,
+        jettySettings,
+        httpsSettings.port(),
+        listener,
+        connectionFactories);
+  }
+
+  @Override
+  protected void applyAdditionalServerConfiguration(Server jettyServer, Options options) {
+    if (options.browserProxySettings().enabled()) {
+      final SslConnectionFactory ssl =
+          new SslConnectionFactory(
+              buildManInTheMiddleSslContextFactory(
+                  options.httpsSettings(), options.browserProxySettings(), options.notifier()),
+              /*
+              If the proxy CONNECT request is made over HTTPS, and the
+              actual content request is made using HTTP/2 tunneled over
+              HTTPS, and an exception is thrown, the server blocks for 30
+              seconds before flushing the response.
+
+              To fix this, force HTTP/1.1 over TLS when tunneling HTTPS.
+
+              This also means the HTTP mitmProxyConnector does not need the alpn &
+              h2 connection factories as it will not use them.
+
+              Unfortunately it has proven too hard to write a test to
+              demonstrate the bug; it requires an HTTP client capable of
+              doing ALPN & HTTP/2, which will only offer HTTP/1.1 in the
+              ALPN negotiation when using HTTPS for the initial CONNECT
+              request but will then offer both HTTP/1.1 and HTTP/2 for the
+              actual request (this is how curl 7.64.1 behaves!). Neither
+              Apache HTTP 4, 5, 5 Async, OkHttp, nor the Jetty client
+              could do this. It might be possible to write one using
+              Netty, but it would be hard and time consuming.
+               */
+              HttpVersion.HTTP_1_1.asString());
+
+      JettySettings jettySettings = options.jettySettings();
+      HttpConfiguration httpConfig = createHttpConfig(jettySettings);
+      HttpConnectionFactory http = new HttpConnectionFactory(httpConfig);
+      mitmProxyConnector =
+          new NetworkTrafficServerConnector(jettyServer, null, null, null, 2, 2, ssl, http);
+
+      mitmProxyConnector.setPort(0);
+      mitmProxyConnector.setShutdownIdleTimeout(
+          jettySettings.getShutdownIdleTimeout().orElse(100L));
+
+      jettyServer.addConnector(mitmProxyConnector);
+    }
+  }
+
+  @Override
+  protected Handler createHandler(
+      Options options,
+      AdminRequestHandler adminRequestHandler,
+      StubRequestHandler stubRequestHandler) {
+    Notifier notifier = options.notifier();
+    ServletContextHandler adminContext = addAdminContext(adminRequestHandler, notifier);
+    ServletContextHandler mockServiceContext =
+        addMockServiceContext(
+            adminContext,
+            stubRequestHandler,
+            // Setting the files to the real path here since Jetty 12 does not include
+            // the servlet context path in forwarded request (and at the moment, there
+            // is not way to tell it to do so), the RequestDispatcher.FORWARD_SERVLET_PATH is
+            // ignored (only RequestDispatcher.INCLUDE_SERVLET_PATH is taken into account but
+            // that requires change from to RequestDispatcher#forward() to
+            // RequestDispatcher#include()).
+            options.filesRoot().child(WireMockApp.FILES_ROOT),
+            options.getAsynchronousResponseSettings(),
+            options.getChunkedEncodingPolicy(),
+            options.getStubCorsEnabled(),
+            options.browserProxySettings().enabled(),
+            notifier);
+
+    final List<Handler> handlers = new ArrayList<>();
+    Handler.Abstract asyncTimeoutSettingHandler =
+        new Handler.Abstract() {
+          @Override
+          public boolean handle(Request request, Response response, Callback callback) {
+            if (request instanceof ServletContextRequest) {
+              final ServletContextRequest r = (ServletContextRequest) request;
+              r.getState().setTimeout(options.timeout());
+            }
+            return false;
+          }
+        };
+    handlers.addAll(Arrays.asList(extensionHandlers()));
+    handlers.add(adminContext);
+    handlers.add(asyncTimeoutSettingHandler);
+
+    if (options.getGzipDisabled()) {
+      handlers.add(mockServiceContext);
+    } else {
+      addGZipHandler(mockServiceContext, handlers);
+    }
+
+    if (options.browserProxySettings().enabled()) {
+      handlers.add(0, new HttpProxyDetectingHandler(httpConnector));
+      handlers.add(0, new HttpsProxyDetectingHandler(mitmProxyConnector));
+      handlers.add(0, new ManInTheMiddleSslConnectHandler(mitmProxyConnector));
+    }
+
+    return new Handler.Sequence(handlers);
+  }
+
+  protected void decorateAdminServiceContextBeforeConfig(
+      ServletContextHandler adminServiceContext) {}
+
+  protected void decorateAdminServiceContextAfterConfig(
+      ServletContextHandler adminServiceContext) {}
+
+  private void addCorsFilter(ServletContextHandler context) {
+    context.addFilter(buildCorsFilter(), "/*", EnumSet.of(DispatcherType.REQUEST));
+  }
+
+  private ServletContextHandler addAdminContext(
+      AdminRequestHandler adminRequestHandler, Notifier notifier) {
+    ServletContextHandler adminContext = new ServletContextHandler();
+    adminContext.setServer(jettyServer);
+    adminContext.setContextPath(ADMIN_CONTEXT_ROOT);
+
+    decorateAdminServiceContextBeforeConfig(adminContext);
+
+    adminContext.setInitParameter("org.eclipse.jetty.servlet.Default.maxCacheSize", "0");
+
+    String javaVendor = System.getProperty("java.vendor");
+    if (javaVendor != null && javaVendor.toLowerCase().contains("android")) {
+      // Special case for Android, fixes IllegalArgumentException("resource assets not found."):
+      //  The Android ClassLoader apparently does not resolve directories.
+      //  Furthermore, lib assets will be merged into a single asset directory when a jar file is
+      // assimilated into an apk.
+      //  As resources can be addressed like "assets/swagger-ui/index.html", a static path element
+      // will suffice.
+      adminContext.setInitParameter("org.eclipse.jetty.servlet.Default.resourceBase", "assets");
+    } else {
+      adminContext.setInitParameter(
+          "org.eclipse.jetty.servlet.Default.resourceBase",
+          getResource(JettyHttpServer.class, "assets").toString());
+    }
+
+    getResource(JettyHttpServer.class, "assets/swagger-ui/index.html");
+    // Jetty 12 changed the way welcome files are being served (the context path is not being
+    // taken into account anymore). It is possible to somewhat change this behavior by altering
+    // welcome mode of ServletResourceService but this parameter is only partially supported by
+    // DefaultServlet (not all modes) and in general needs servlet subclassing. Taking an easier
+    // approach here with extended welcome files list.
+    adminContext.setWelcomeFiles(new String[] {"index.html", "index.jsp", "swagger-ui/index.html"});
+
+    adminContext.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
+    ServletHolder swaggerUiServletHolder =
+        adminContext.addServlet(DefaultServlet.class, "/swagger-ui/*");
+    swaggerUiServletHolder.setAsyncSupported(false);
+    adminContext.addServlet(DefaultServlet.class, "/recorder/*");
+
+    ServletHolder servletHolder =
+        adminContext.addServlet(WireMockHandlerDispatchingServlet.class, "/");
+    servletHolder.setInitParameter(
+        RequestHandler.HANDLER_CLASS_KEY, AdminRequestHandler.class.getName());
+    adminContext.setAttribute(AdminRequestHandler.class.getName(), adminRequestHandler);
+    adminContext.setAttribute(Notifier.KEY, notifier);
+
+    adminContext.setAttribute(MultipartRequestConfigurer.KEY, buildMultipartRequestConfigurer());
+
+    adminContext.addServlet(NotMatchedServlet.class, "/not-matched");
+
+    addCorsFilter(adminContext);
+
+    decorateAdminServiceContextAfterConfig(adminContext);
+
+    return adminContext;
+  }
+
+  private ServletContextHandler addMockServiceContext(
+      ServletContextHandler adminContext,
+      StubRequestHandler stubRequestHandler,
+      FileSource fileSource,
+      AsynchronousResponseSettings asynchronousResponseSettings,
+      Options.ChunkedEncodingPolicy chunkedEncodingPolicy,
+      boolean stubCorsEnabled,
+      boolean browserProxyingEnabled,
+      Notifier notifier) {
+    ServletContextHandler mockServiceContext = new ServletContextHandler();
+    mockServiceContext.setServer(jettyServer);
+    mockServiceContext.setContextPath("/");
+
+    decorateMockServiceContextBeforeConfig(mockServiceContext);
+
+    mockServiceContext.setInitParameter("org.eclipse.jetty.servlet.Default.maxCacheSize", "0");
+    mockServiceContext.setInitParameter(
+        "org.eclipse.jetty.servlet.Default.resourceBase", fileSource.getPath());
+    mockServiceContext.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
+
+    mockServiceContext.addServlet(DefaultServlet.class, FILES_URL_MATCH);
+
+    final Jetty12HttpUtils utils = new Jetty12HttpUtils();
+    mockServiceContext.setAttribute(JettyHttpUtils.class.getName(), utils);
+
+    mockServiceContext.setAttribute(
+        JettyFaultInjectorFactory.class.getName(), new JettyFaultInjectorFactory(utils));
+    mockServiceContext.setAttribute(StubRequestHandler.class.getName(), stubRequestHandler);
+    mockServiceContext.setAttribute(Notifier.KEY, notifier);
+    mockServiceContext.setAttribute(
+        Options.ChunkedEncodingPolicy.class.getName(), chunkedEncodingPolicy);
+    mockServiceContext.setAttribute("browserProxyingEnabled", browserProxyingEnabled);
+    ServletHolder servletHolder =
+        mockServiceContext.addServlet(WireMockHandlerDispatchingServlet.class, "/");
+    servletHolder.setInitOrder(1);
+    servletHolder.setInitParameter(
+        RequestHandler.HANDLER_CLASS_KEY, StubRequestHandler.class.getName());
+    servletHolder.setInitParameter(
+        FaultInjectorFactory.INJECTOR_CLASS_KEY, JettyFaultInjectorFactory.class.getName());
+    servletHolder.setInitParameter(
+        WireMockHandlerDispatchingServlet.SHOULD_FORWARD_TO_FILES_CONTEXT, "true");
+
+    if (asynchronousResponseSettings.isEnabled()) {
+      scheduledExecutorService = newScheduledThreadPool(asynchronousResponseSettings.getThreads());
+      mockServiceContext.setAttribute(
+          WireMockHandlerDispatchingServlet.ASYNCHRONOUS_RESPONSE_EXECUTOR,
+          scheduledExecutorService);
+    }
+
+    mockServiceContext.setAttribute(
+        MultipartRequestConfigurer.KEY, buildMultipartRequestConfigurer());
+
+    MimeTypes.Mutable mimeTypes = mockServiceContext.getMimeTypes();
+    // For files without extension, use "application/json" as the default in case
+    // file extension is not provided(and content type could not be detected).
+    mimeTypes.addMimeMapping("*", "application/json");
+    mimeTypes.addMimeMapping("json", "application/json");
+    mimeTypes.addMimeMapping("html", "text/html");
+    mimeTypes.addMimeMapping("xml", "application/xml");
+    mimeTypes.addMimeMapping("txt", "text/plain");
+
+    mockServiceContext.setWelcomeFiles(
+        new String[] {"index.json", "index.html", "index.xml", "index.txt"});
+
+    // Jetty 12 does not currently support cross context dispatch, we
+    // need to use the adminContext explicitly.
+    NotFoundHandler errorHandler = new NotFoundHandler(adminContext);
+    mockServiceContext.setErrorHandler(errorHandler);
+
+    mockServiceContext.addFilter(
+        ContentTypeSettingFilter.class, FILES_URL_MATCH, EnumSet.of(DispatcherType.FORWARD));
+    mockServiceContext.addFilter(
+        TrailingSlashFilter.class, FILES_URL_MATCH, EnumSet.allOf(DispatcherType.class));
+
+    if (stubCorsEnabled) {
+      addCorsFilter(mockServiceContext);
+    }
+
+    decorateMockServiceContextAfterConfig(mockServiceContext);
+
+    return mockServiceContext;
+  }
+
+  protected void decorateMockServiceContextBeforeConfig(ServletContextHandler mockServiceContext) {}
+
+  protected void decorateMockServiceContextAfterConfig(ServletContextHandler mockServiceContext) {}
+
+  private void addGZipHandler(ServletContextHandler mockServiceContext, List<Handler> handlers) {
+    try {
+      GzipHandler gzipHandler = new GzipHandler();
+      gzipHandler.addIncludedMethods(GZIPPABLE_METHODS);
+      gzipHandler.setHandler(mockServiceContext);
+      gzipHandler.setVary(null);
+      handlers.add(gzipHandler);
+    } catch (Exception e) {
+      throwUnchecked(e);
+    }
+  }
+
+  private FilterHolder buildCorsFilter() {
+    FilterHolder filterHolder = new FilterHolder(CrossOriginFilter.class);
+    filterHolder.setInitParameters(
+        Map.of(
+            "chainPreflight",
+            "false",
+            "allowedOrigins",
+            "*",
+            "allowedHeaders",
+            "*",
+            "allowedMethods",
+            "OPTIONS,GET,POST,PUT,PATCH,DELETE"));
+    return filterHolder;
+  }
+}

--- a/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/Jetty12HttpServerFactory.java
+++ b/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/Jetty12HttpServerFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.*;
+
+public class Jetty12HttpServerFactory implements HttpServerFactory, DefaultFactory {
+
+  @Override
+  public String getName() {
+    return "jetty12.1-http-server-factory";
+  }
+
+  @Override
+  public HttpServer buildHttpServer(
+      Options options,
+      AdminRequestHandler adminRequestHandler,
+      StubRequestHandler stubRequestHandler) {
+    return new Jetty12HttpServer(options, adminRequestHandler, stubRequestHandler);
+  }
+}

--- a/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/Jetty12HttpUtils.java
+++ b/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/Jetty12HttpUtils.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2015-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1;
+
+import static com.github.tomakehurst.wiremock.jetty12_1.HttpProxyDetectingHandler.IS_HTTP_PROXY_REQUEST_ATTRIBUTE;
+import static com.github.tomakehurst.wiremock.jetty12_1.HttpsProxyDetectingHandler.IS_HTTPS_PROXY_REQUEST_ATTRIBUTE;
+
+import com.github.tomakehurst.wiremock.jetty.JettyHttpUtils;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+import java.net.Socket;
+import java.nio.channels.SocketChannel;
+import org.eclipse.jetty.ee11.servlet.ServletApiResponse;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.io.SelectableChannelEndPoint;
+import org.eclipse.jetty.io.ssl.SslConnection;
+import org.eclipse.jetty.server.AbstractMetaDataConnection;
+import org.eclipse.jetty.server.Response;
+
+public class Jetty12HttpUtils implements JettyHttpUtils {
+  @Override
+  public Response unwrapResponse(HttpServletResponse httpServletResponse) {
+    if (httpServletResponse instanceof HttpServletResponseWrapper) {
+      ServletResponse unwrapped = ((HttpServletResponseWrapper) httpServletResponse).getResponse();
+      return (Response) unwrapped;
+    } else if (httpServletResponse instanceof ServletApiResponse) {
+      Response unwrapped = ((ServletApiResponse) httpServletResponse).getResponse();
+      return unwrapped;
+    }
+
+    return (Response) httpServletResponse;
+  }
+
+  @Override
+  public Socket socket(Response response) {
+    final AbstractMetaDataConnection connectionMetaData =
+        (AbstractMetaDataConnection) response.getRequest().getConnectionMetaData();
+    SelectableChannelEndPoint ep = (SelectableChannelEndPoint) connectionMetaData.getEndPoint();
+    return ((SocketChannel) ep.getChannel()).socket();
+  }
+
+  @Override
+  public Socket tlsSocket(Response response) {
+    final AbstractMetaDataConnection connectionMetaData =
+        (AbstractMetaDataConnection) response.getRequest().getConnectionMetaData();
+    final SslConnection.SslEndPoint sslEndpoint =
+        (SslConnection.SslEndPoint) connectionMetaData.getEndPoint();
+    final SelectableChannelEndPoint endpoint =
+        (SelectableChannelEndPoint) sslEndpoint.getSslConnection().getEndPoint();
+    return ((SocketChannel) endpoint.getChannel()).socket();
+  }
+
+  @Override
+  public void setStatusWithReason(
+      int status, String reason, HttpServletResponse httpServletResponse) {
+    // Servlet 6 is not accepting the reason / message anymore, consequently Jetty 12
+    // completely eliminated the possibility to pass reason / message along with a status
+    // in case of HTTP 1.x communication.
+    httpServletResponse.setStatus(status);
+  }
+
+  @Override
+  public EndPoint unwrapEndPoint(Response jettyResponse) {
+    final AbstractMetaDataConnection connectionMetaData =
+        (AbstractMetaDataConnection) jettyResponse.getRequest().getConnectionMetaData();
+    return connectionMetaData.getEndPoint();
+  }
+
+  @Override
+  public boolean isBrowserProxyRequest(HttpServletRequest request) {
+    return Boolean.TRUE.equals(request.getAttribute(IS_HTTPS_PROXY_REQUEST_ATTRIBUTE))
+        || Boolean.TRUE.equals(request.getAttribute(IS_HTTP_PROXY_REQUEST_ATTRIBUTE));
+  }
+}

--- a/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/ManInTheMiddleSslConnectHandler.java
+++ b/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/ManInTheMiddleSslConnectHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1;
+
+import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
+
+import java.io.Closeable;
+import java.net.InetSocketAddress;
+import java.nio.channels.SocketChannel;
+import org.eclipse.jetty.server.*;
+import org.eclipse.jetty.server.handler.ConnectHandler;
+import org.eclipse.jetty.util.Promise;
+
+public class ManInTheMiddleSslConnectHandler extends ConnectHandler {
+
+  private final ServerConnector mitmProxyConnector;
+
+  public ManInTheMiddleSslConnectHandler(ServerConnector mitmProxyConnector) {
+    this.mitmProxyConnector = mitmProxyConnector;
+  }
+
+  @Override
+  protected void connectToServer(
+      Request request, String ignoredHost, int ignoredPort, Promise<SocketChannel> promise) {
+    SocketChannel channel = null;
+    try {
+      channel = SocketChannel.open();
+      channel.socket().setTcpNoDelay(true);
+      channel.configureBlocking(false);
+
+      String host = getFirstNonNull(mitmProxyConnector.getHost(), "localhost");
+      int port = mitmProxyConnector.getLocalPort();
+      InetSocketAddress address = newConnectAddress(host, port);
+
+      channel.connect(address);
+      promise.succeeded(channel);
+    } catch (Throwable x) {
+      close(channel);
+      promise.failed(x);
+    }
+  }
+
+  private void close(Closeable closeable) {
+    try {
+      if (closeable != null) closeable.close();
+    } catch (Throwable x) {
+      /* Ignore */
+    }
+  }
+}

--- a/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/NotFoundHandler.java
+++ b/wiremock-jetty12.1/src/main/java/com/github/tomakehurst/wiremock/jetty12_1/NotFoundHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1;
+
+import jakarta.servlet.ServletException;
+import org.eclipse.jetty.ee11.servlet.Dispatcher;
+import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee11.servlet.ServletContextRequest;
+import org.eclipse.jetty.ee11.servlet.ServletContextResponse;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.handler.ErrorHandler;
+import org.eclipse.jetty.util.Callback;
+
+public class NotFoundHandler extends ErrorHandler {
+
+  private final ErrorHandler DEFAULT_HANDLER = new ErrorHandler();
+
+  private final ServletContextHandler adminServiceHandler;
+
+  public NotFoundHandler(ServletContextHandler adminServiceHandler) {
+    this.adminServiceHandler = adminServiceHandler;
+  }
+
+  @Override
+  public boolean errorPageForMethod(String method) {
+    return true;
+  }
+
+  @Override
+  public boolean handle(Request request, Response response, Callback callback) throws Exception {
+    if (response.getStatus() == 404) {
+
+      // Jetty 12 does not currently support cross context dispatch
+      Dispatcher requestDispatcher =
+          (Dispatcher) adminServiceHandler.getServletContext().getRequestDispatcher("/not-matched");
+
+      try {
+        requestDispatcher.error(
+            ((ServletContextRequest) request).getServletApiRequest(),
+            ((ServletContextResponse) response).getServletApiResponse());
+        callback.succeeded();
+        return true;
+      } catch (ServletException e) {
+        callback.failed(e);
+      }
+    } else {
+      try {
+        return DEFAULT_HANDLER.handle(request, response, callback);
+      } catch (Exception e) {
+        callback.failed(e);
+      }
+    }
+
+    return false;
+  }
+}

--- a/wiremock-jetty12.1/src/main/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.Extension
+++ b/wiremock-jetty12.1/src/main/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.Extension
@@ -1,0 +1,1 @@
+com.github.tomakehurst.wiremock.jetty12_1.Jetty12HttpServerFactory

--- a/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/Jetty12MultipartParser.java
+++ b/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/Jetty12MultipartParser.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2018-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.servlet.WireMockHttpServletMultipartAdapter;
+import jakarta.servlet.http.Part;
+import java.io.File;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.eclipse.jetty.client.BytesRequestContent;
+import org.eclipse.jetty.ee11.servlet.ServletMultiPartFormData.Parts;
+import org.eclipse.jetty.http.MultiPart;
+import org.eclipse.jetty.http.MultiPartFormData;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.util.Attributes;
+
+public class Jetty12MultipartParser
+    implements com.github.tomakehurst.wiremock.MultipartParserLoader.MultipartParser {
+  @SuppressWarnings("unchecked")
+  @Override
+  public Collection<Request.Part> parse(byte[] body, String contentType) {
+    String boundary = MultiPart.extractBoundary(contentType);
+
+    final File filesDirectory = new File(System.getProperty("java.io.tmpdir"));
+    final CompletableFuture<Collection<Part>> parts =
+        MultiPartFormData.from(
+                Attributes.NULL,
+                boundary,
+                parser -> {
+                  try {
+                    // No existing core parts, so we need to configure the parser.
+
+                    Content.Source source = new BytesRequestContent(body);
+                    parser.setFilesDirectory(filesDirectory.toPath());
+                    return parser.parse(source);
+                  } catch (Throwable failure) {
+                    return CompletableFuture.failedFuture(failure);
+                  }
+                })
+            .thenApply(
+                formDataParts -> new Parts(filesDirectory.toPath(), formDataParts).getParts());
+
+    try {
+      return parts.get().stream()
+          .map(WireMockHttpServletMultipartAdapter::from)
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      return throwUnchecked(e, Collection.class);
+    }
+  }
+}

--- a/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/Jetty12MultipartParserLoader.java
+++ b/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/Jetty12MultipartParserLoader.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1;
+
+import java.util.Optional;
+
+public class Jetty12MultipartParserLoader
+    implements com.github.tomakehurst.wiremock.MultipartParserLoader {
+  private static final String JETTY_12 = "12"; /* Jetty 12 */
+
+  @Override
+  public Optional<MultipartParser> getMultipartParser(String jettyMajorVersion) {
+    if (JETTY_12.equalsIgnoreCase(jettyMajorVersion)) {
+      return Optional.of(new Jetty12MultipartParser());
+    } else {
+      return Optional.empty();
+    }
+  }
+}

--- a/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/ProgrammaticHttpServerAcceptanceTest.java
+++ b/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/ProgrammaticHttpServerAcceptanceTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+import com.github.tomakehurst.wiremock.jetty12_1.server.CustomHttpServerFactory;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.testsupport.TestNotifier;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ProgrammaticHttpServerAcceptanceTest {
+
+  static TestNotifier notifier = new TestNotifier();
+
+  @RegisterExtension
+  public WireMockExtension wm =
+      WireMockExtension.newInstance()
+          .options(
+              wireMockConfig()
+                  .dynamicPort()
+                  .dynamicHttpsPort()
+                  .httpServerFactory(new CustomHttpServerFactory())
+                  .notifier(notifier))
+          .build();
+
+  @BeforeAll
+  static void init() {
+    notifier.reset();
+  }
+
+  @Test
+  public void correctServerLoaded() {
+    assertThat(notifier.getInfoMessages(), hasItem("Using HTTP server impl: CustomHttpServer"));
+  }
+}

--- a/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/server/CustomHttpServer.java
+++ b/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/server/CustomHttpServer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1.server;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
+import com.github.tomakehurst.wiremock.http.StubRequestHandler;
+import com.github.tomakehurst.wiremock.jetty12_1.Jetty12HttpServer;
+
+public class CustomHttpServer extends Jetty12HttpServer {
+  public CustomHttpServer(
+      Options options,
+      AdminRequestHandler adminRequestHandler,
+      StubRequestHandler stubRequestHandler) {
+    super(options, adminRequestHandler, stubRequestHandler);
+  }
+}

--- a/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/server/CustomHttpServerFactory.java
+++ b/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/server/CustomHttpServerFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1.server;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
+import com.github.tomakehurst.wiremock.http.HttpServer;
+import com.github.tomakehurst.wiremock.http.HttpServerFactory;
+import com.github.tomakehurst.wiremock.http.StubRequestHandler;
+
+public class CustomHttpServerFactory implements HttpServerFactory {
+
+  @Override
+  public String getName() {
+    return HttpServerFactory.super.getName();
+  }
+
+  @Override
+  public HttpServer buildHttpServer(
+      Options options,
+      AdminRequestHandler adminRequestHandler,
+      StubRequestHandler stubRequestHandler) {
+    return new CustomHttpServer(options, adminRequestHandler, stubRequestHandler);
+  }
+}

--- a/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/servlet/AltHttpServerFactory.java
+++ b/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/servlet/AltHttpServerFactory.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2016-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1.servlet;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+import static com.github.tomakehurst.wiremock.core.WireMockApp.ADMIN_CONTEXT_ROOT;
+
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.common.Notifier;
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.*;
+import com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet;
+import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee11.servlet.ServletHolder;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+
+public class AltHttpServerFactory implements HttpServerFactory {
+
+  @Override
+  public HttpServer buildHttpServer(
+      Options options,
+      AdminRequestHandler adminRequestHandler,
+      StubRequestHandler stubRequestHandler) {
+
+    final Server jettyServer = new Server(0);
+    ConsoleNotifier notifier = new ConsoleNotifier(false);
+    ServletContextHandler adminContext =
+        addAdminContext(jettyServer, adminRequestHandler, notifier);
+    ServletContextHandler mockServiceContext =
+        addMockServiceContext(jettyServer, stubRequestHandler, options.filesRoot(), notifier);
+
+    Handler.Abstract handler = new Handler.Sequence(adminContext, mockServiceContext);
+    jettyServer.setHandler(handler);
+
+    return new HttpServer() {
+
+      @Override
+      public void start() {
+        try {
+          jettyServer.start();
+        } catch (Exception e) {
+          throwUnchecked(e);
+        }
+      }
+
+      @Override
+      public void stop() {
+        try {
+          jettyServer.stop();
+        } catch (Exception e) {
+          throwUnchecked(e);
+        }
+      }
+
+      @Override
+      public boolean isRunning() {
+        return jettyServer.isRunning();
+      }
+
+      @Override
+      public int port() {
+        return ((ServerConnector) jettyServer.getConnectors()[0]).getLocalPort();
+      }
+
+      @Override
+      public int httpsPort() {
+        return 0;
+      }
+    };
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private ServletContextHandler addMockServiceContext(
+      Server jettyServer,
+      StubRequestHandler stubRequestHandler,
+      FileSource fileSource,
+      Notifier notifier) {
+    ServletContextHandler mockServiceContext = new ServletContextHandler();
+    mockServiceContext.setServer(jettyServer);
+    mockServiceContext.setContextPath("/");
+
+    mockServiceContext.setAttribute(StubRequestHandler.class.getName(), stubRequestHandler);
+    mockServiceContext.setAttribute(Notifier.KEY, notifier);
+    ServletHolder servletHolder =
+        mockServiceContext.addServlet(WireMockHandlerDispatchingServlet.class, "/");
+    servletHolder.setInitParameter(
+        RequestHandler.HANDLER_CLASS_KEY, StubRequestHandler.class.getName());
+    servletHolder.setInitParameter(
+        WireMockHandlerDispatchingServlet.SHOULD_FORWARD_TO_FILES_CONTEXT, "false");
+
+    return mockServiceContext;
+  }
+
+  private ServletContextHandler addAdminContext(
+      Server jettyServer, AdminRequestHandler adminRequestHandler, Notifier notifier) {
+    ServletContextHandler adminContext = new ServletContextHandler();
+    adminContext.setServer(jettyServer);
+    adminContext.setContextPath(ADMIN_CONTEXT_ROOT);
+
+    ServletHolder servletHolder =
+        adminContext.addServlet(WireMockHandlerDispatchingServlet.class, "/");
+    servletHolder.setInitParameter(
+        RequestHandler.HANDLER_CLASS_KEY, AdminRequestHandler.class.getName());
+    adminContext.setAttribute(AdminRequestHandler.class.getName(), adminRequestHandler);
+    adminContext.setAttribute(Notifier.KEY, notifier);
+    return adminContext;
+  }
+}

--- a/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/servlet/AlternativeServletContainerTest.java
+++ b/wiremock-jetty12.1/src/test/java/com/github/tomakehurst/wiremock/jetty12_1/servlet/AlternativeServletContainerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2016-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.jetty12_1.servlet;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class AlternativeServletContainerTest {
+
+  @RegisterExtension
+  public WireMockExtension wm =
+      WireMockExtension.newInstance()
+          .options(options().dynamicPort().httpServerFactory(new AltHttpServerFactory()))
+          .build();
+
+  private WireMockTestClient client;
+
+  @BeforeEach
+  public void init() {
+    client = new WireMockTestClient(wm.getPort());
+    WireMock.configureFor(wm.getPort());
+  }
+
+  @Test
+  public void supportsAlternativeHttpServerForBasicStub() {
+    stubFor(get(urlEqualTo("/alt-server")).willReturn(aResponse().withStatus(204)));
+
+    assertThat(client.get("/alt-server").statusCode(), is(204));
+  }
+}


### PR DESCRIPTION
Add Jetty 12.1.x support (as separate module) based on Jakarta EE 11 specs. 

Although switching the dependency from Jetty 12.0.x to 12.1.x "mostly works", the key difference is that Jetty 12.1.x supports Jakarta EE 11 (along with Jakarta EE 10) and new `wiremock-jetty12.1` module it.

This change tackles only 3.x branch since `master` has integrated `wiremock-jetty12` module into the main one. It is mostly copy/paste of  `wiremock-jetty12.1` with Jakarta EE 11 dependencies. 

## References
Closes https://github.com/wiremock/wiremock/issues/3139

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
