### PR TITLE
fix: Handle unchecked exceptions in TemplateEngine

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
@@ -342,6 +342,21 @@ public class ResponseTemplatingAcceptanceTest {
 
       assertMessageSubEventPresent(wm, "ERROR", "1:2: java.lang.ArithmeticException: / by zero");
     }
+
+    @Test
+    void uncheckedExceptionThrownWhileRenderingIsSurfacedAndReportedViaSubEvent() {
+      wm.stubFor(
+          get("/bad")
+              .willReturn(
+                  ok("{{add (jsonPath request.body '$.num1') (jsonPath request.body '$.num2')}}")));
+
+      WireMockResponse response = client.get("/bad");
+
+      assertThat(response.statusCode(), is(500));
+      assertThat(response.content(), is("1:2: could not find helper: 'add'"));
+
+      assertMessageSubEventPresent(wm, "ERROR", "1:2: could not find helper: 'add'");
+    }
   }
 
   @Nested

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -40,6 +40,8 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ExecutionError;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -121,8 +123,8 @@ public class TemplateEngine {
 
     try {
       return cache.get(key, () -> new HandlebarsOptimizedTemplate(handlebars, content));
-    } catch (ExecutionException e) {
-      return Exceptions.throwUnchecked(e, HandlebarsOptimizedTemplate.class);
+    } catch (ExecutionException | UncheckedExecutionException | ExecutionError e) {
+      return Exceptions.throwUnchecked(e.getCause(), null);
     }
   }
 


### PR DESCRIPTION
Things like unknown helper were being surfaced as `UncheckedExecutionException`, which we did not catch, so it hit the top of the stack rather than being caught and rendered correctly in `ResponseTemplateTransformer`.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
