### PR TITLE
Handle dodgy characters in URLs

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
@@ -34,14 +34,14 @@ public class UrlsTest {
 
   @Test
   public void copesWithEqualsInParamValues() {
-    params = Urls.splitQuery(URI.create("/thing?param1=one&param2=one==two=three"));
+    params = Urls.splitQueryFromUrl("/thing?param1=one&param2=one==two=three");
     assertThat(params.get("param1").firstValue(), is("one"));
     assertThat(params.get("param2").firstValue(), is("one==two=three"));
   }
 
   @Test
   public void returnsEmptyStringsAsValuesWhenOnlyKeysArePresent() {
-    params = Urls.splitQuery(URI.create("/thing?param1&param2&param3"));
+    params = Urls.splitQueryFromUrl("/thing?param1&param2&param3");
     assertThat(params.get("param1").firstValue(), is(""));
     assertThat(params.get("param2").firstValue(), is(""));
     assertThat(params.get("param3").firstValue(), is(""));
@@ -49,7 +49,7 @@ public class UrlsTest {
 
   @Test
   public void supportsMultiValuedParameters() {
-    params = Urls.splitQuery(URI.create("/thing?param1=1&param2=two&param1=2&param1=3"));
+    params = Urls.splitQueryFromUrl("/thing?param1=1&param2=two&param1=2&param1=3");
     assertThat(params.size(), is(2));
     assertThat(params.get("param1").isSingleValued(), is(false));
     assertThat(params.get("param1").values(), hasItems("1", "2", "3"));
@@ -59,9 +59,8 @@ public class UrlsTest {
   public void supportsOffsetDateTimeParameterValues() {
     OffsetDateTime offsetDateTime = OffsetDateTime.parse("2024-05-01T09:30:00.000Z");
     params =
-        Urls.splitQuery(
-            URI.create(
-                "/thing?date=2024-05-01T10:30:00.000+01:00&date=2024-05-01T08:30:00.000-01:00&date=2024-05-01T09:30:00.000Z"));
+        Urls.splitQueryFromUrl(
+            "/thing?date=2024-05-01T10:30:00.000+01:00&date=2024-05-01T08:30:00.000-01:00&date=2024-05-01T09:30:00.000Z");
     for (QueryParameter queryParameter : params.values()) {
       for (String parameterValue : queryParameter.values()) {
         assert (offsetDateTime.isEqual(OffsetDateTime.parse(parameterValue)));
@@ -71,8 +70,7 @@ public class UrlsTest {
 
   @Test
   public void doesNotAttemptToDoubleDecodeSplitQueryString() {
-    URI url = URI.create("/thing?q=a%25b");
-    Map<String, QueryParameter> query = Urls.splitQuery(url);
+    Map<String, QueryParameter> query = Urls.splitQueryFromUrl("/thing?q=a%25b");
     assertThat(query.get("q").firstValue(), is("a%b"));
   }
 
@@ -185,8 +183,7 @@ public class UrlsTest {
   @Test
   public void decodesInvalidIsoOffsetDateTimeLikeString() {
     var dateAsString = "2023-02-30T10:00:00+01:00";
-    var trickyDate = URI.create("/date?date=" + dateAsString);
-    params = Urls.splitQuery(trickyDate);
+    params = Urls.splitQueryFromUrl("/date?date=" + dateAsString);
     Assertions.assertEquals(
         URLDecoder.decode(dateAsString, StandardCharsets.UTF_8), params.get("date").firstValue());
   }
@@ -194,8 +191,7 @@ public class UrlsTest {
   @Test
   public void doesNotDecodeValidIsoOffsetDateTimeLikeString() {
     var dateAsString = "2023-02-28T10:00:00+01:00";
-    var trickyDate = URI.create("/date?date=" + dateAsString);
-    params = Urls.splitQuery(trickyDate);
+    params = Urls.splitQueryFromUrl("/date?date=" + dateAsString);
     Assertions.assertEquals(dateAsString, params.get("date").firstValue());
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import com.github.tomakehurst.wiremock.common.Urls;
 import com.github.tomakehurst.wiremock.common.url.PathParams;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import java.net.URI;
 import java.util.*;
 
 public class MockRequest implements Request {
@@ -233,7 +232,7 @@ public class MockRequest implements Request {
 
   @Override
   public QueryParameter queryParameter(String key) {
-    Map<String, QueryParameter> queryParams = Urls.splitQuery(URI.create(url));
+    Map<String, QueryParameter> queryParams = Urls.splitQueryFromUrl(url);
     return queryParams.get(key);
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/diff/DiffTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/diff/DiffTest.java
@@ -590,4 +590,21 @@ class DiffTest {
                 "ANY\n/things/4321/bookings/whatever\n\nPath parameter: thingId = 1234\n",
                 "ANY\n/things/4321/bookings/whatever\n\n4321\n")));
   }
+
+  @Test
+  void showsDiffForDodgyUrls() {
+    Diff diff =
+        new Diff(
+            newRequestPattern(GET, urlPathEqualTo("/news"))
+                .withQueryParam("page", equalTo("page"))
+                .build(),
+            mockRequest().method(POST).url("/news?page={page}"));
+
+    assertThat(
+        diff.toString(),
+        is(
+            junitStyleDiffMessage(
+                "GET\n/news?page={page}\n\nQuery: page = page\n",
+                "POST\n/news?page={page}\n\npage: {page}\n")));
+  }
 }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/common/Urls.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/common/Urls.java
@@ -45,6 +45,8 @@ public class Urls {
     return splitQuery(queryPart);
   }
 
+  // Only call this method if you already have a URI. If you have a String, call
+  // `splitQueryFromUrl(String)`
   public static Map<String, QueryParameter> splitQuery(URI uri) {
     if (uri == null) {
       return Collections.emptyMap();

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestLine.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestLine.java
@@ -21,7 +21,6 @@ import com.github.tomakehurst.wiremock.common.url.PathParams;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -58,8 +57,7 @@ public class RequestLine {
   }
 
   public static RequestLine fromRequest(final Request request) {
-    URI url = URI.create(request.getUrl());
-    Map<String, QueryParameter> rawQuery = Urls.splitQuery(url);
+    Map<String, QueryParameter> rawQuery = Urls.splitQueryFromUrl(request.getUrl());
     Map<String, ListOrSingle<String>> adaptedQuery =
         rawQuery.entrySet().stream()
             .map(entry -> Map.entry(entry.getKey(), ListOrSingle.of(entry.getValue().values())))

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
@@ -53,7 +53,6 @@ import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathTemplatePattern;
 import com.github.tomakehurst.wiremock.matching.UrlPattern;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -257,8 +256,7 @@ public class Diff {
   private void addQueryParametersSectionWithSpacerIfPresent(List<DiffLine<?>> diffLineList) {
     final Map<String, MultiValuePattern> queryParameters = requestPattern.getQueryParameters();
     if (queryParameters != null) {
-      Map<String, QueryParameter> requestQueryParams =
-          Urls.splitQuery(URI.create(request.getUrl()));
+      Map<String, QueryParameter> requestQueryParams = Urls.splitQueryFromUrl(request.getUrl());
 
       for (Map.Entry<String, MultiValuePattern> entry : queryParameters.entrySet()) {
         String key = entry.getKey();


### PR DESCRIPTION
Avoid creating a URI just to extract the query, it enforces limits on the format of the URI we do not like.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
