### PR TITLE
Handle dodgy form encoding

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -670,6 +670,15 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
   }
 
   @Test
+  void copesWithInvalidFormEncoding() {
+    stubFor(post(urlPathEqualTo("/form")).willReturn(aResponse().withStatus(200)));
+
+    WireMockResponse response =
+        testClient.postWithBody("/form", "%}#", "application/x-www-form-urlencoded", "utf-8");
+    assertThat(response.statusCode(), is(200));
+  }
+
+  @Test
   void copesWithEmptyRequestHeaderValueWhenMatchingOnEqualTo() {
     stubFor(
         get(urlPathEqualTo("/empty-header"))

--- a/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -326,8 +326,11 @@ public class WireMockHttpServletRequestAdapter implements Request {
     final String characterEncoding = request.getCharacterEncoding();
     final Charset charset =
         characterEncoding != null ? Charset.forName(characterEncoding) : Charset.defaultCharset();
-    UrlEncoded.decodeTo(getBodyAsString(), formParameterMultimap, charset);
-
+    try {
+      UrlEncoded.decodeTo(getBodyAsString(), formParameterMultimap, charset);
+    } catch (IllegalArgumentException ignored) {
+      return Collections.emptyMap();
+    }
     return formParameterMultimap.entrySet().stream()
         .collect(
             Collectors.toMap(


### PR DESCRIPTION
We should cope with requests that claim to be form encoded but are not

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
