### PR TITLE
Catch DOM error making XML diff

### DIFF
--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.*;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xmlunit.XMLUnitException;
@@ -183,7 +184,7 @@ public class EqualToXmlPattern extends StringValuePattern {
           Diff diff = diffBuilder.build();
 
           return !diff.hasDifferences();
-        } catch (XMLUnitException e) {
+        } catch (XMLUnitException | DOMException e) {
           appendSubEvent(SubEvent.warning(e.getMessage()));
 
           notifier()


### PR DESCRIPTION
I cannot reproduce this, but we do see this exception hit the top of the
stack.

We should be able to work out why now as we will log the values in the
notifier.

```
org.w3c.dom.DOMException: INVALID_CHARACTER_ERR: An invalid or illegal XML character is specified.
	at java.xml/com.sun.org.apache.xerces.internal.dom.CoreDocumentImpl.createElement(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.dom.CoreDocumentImpl.importNode(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.dom.CoreDocumentImpl.cloneNode(Unknown Source)
	at java.xml/com.sun.org.apache.xerces.internal.dom.DocumentImpl.cloneNode(Unknown Source)
	at org.xmlunit.util.Nodes.stripWhitespace(Nodes.java:119)
	at org.xmlunit.input.WhitespaceStrippedSource.<init>(WhitespaceStrippedSource.java:54)
	at org.xmlunit.builder.DiffBuilder.wrap(DiffBuilder.java:451)
	at org.xmlunit.builder.DiffBuilder.build(DiffBuilder.java:440)
	at com.github.tomakehurst.wiremock.matching.EqualToXmlPattern$1.isExactMatch(EqualToXmlPattern.java:183)
	at com.github.tomakehurst.wiremock.matching.WeightedMatchResult.isExactMatch(WeightedMatchResult.java:41)
	at com.github.tomakehurst.wiremock.matching.WeightedAggregateMatchResult.lambda$new$0(WeightedAggregateMatchResult.java:44))
	at com.github.tomakehurst.wiremock.matching.WeightedAggregateMatchResult.lambda$new$1(WeightedAggregateMatchResult.java:42)
	at com.github.tomakehurst.wiremock.matching.WeightedAggregateMatchResult.isExactMatch(WeightedAggregateMatchResult.java:54)
	at com.github.tomakehurst.wiremock.matching.WeightedMatchResult.isExactMatch(WeightedMatchResult.java:41)
	at com.github.tomakehurst.wiremock.matching.WeightedAggregateMatchResult.lambda$new$0(WeightedAggregateMatchResult.java:44)
	at com.github.tomakehurst.wiremock.matching.WeightedAggregateMatchResult.lambda$new$1(WeightedAggregateMatchResult.java:42)
	at com.github.tomakehurst.wiremock.matching.WeightedAggregateMatchResult.isExactMatch(WeightedAggregateMatchResult.java:54)
	at com.github.tomakehurst.wiremock.matching.RequestPattern$1.match(RequestPattern.java:132)
	at com.github.tomakehurst.wiremock.matching.RequestPattern$1.match(RequestPattern.java:101)
	at com.github.tomakehurst.wiremock.matching.RequestPattern.match(RequestPattern.java:258)
	at com.github.tomakehurst.wiremock.store.StubMappingStore.lambda$findAllMatchingRequest$0(StubMappingStore.java:42)
	at com.github.tomakehurst.wiremock.stubbing.AbstractStubMappings.serveFor(AbstractStubMappings.java:87)
	at com.github.tomakehurst.wiremock.core.WireMockApp.serveStubFor(WireMockApp.java:293)
	at com.github.tomakehurst.wiremock.http.StubRequestHandler.handleRequest(StubRequestHandler.java:73)
	at com.github.tomakehurst.wiremock.http.AbstractRequestHandler.handle(AbstractRequestHandler.java:66)
	at com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet.service(WireMockHandlerDispatchingServlet.java:157)
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:723)
```

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
