### PR TITLE
Inject Automatic-Module-Name manifest header

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -181,6 +181,7 @@ tasks.jar {
   archiveBaseName.set("wiremock")
   manifest {
     attributes("Main-Class" to "wiremock.Run")
+    attributes("Automatic-Module-Name" to "org.wiremock")
   }
 }
 

--- a/wiremock-common/build.gradle.kts
+++ b/wiremock-common/build.gradle.kts
@@ -82,7 +82,11 @@ dependencies {
 
 tasks.jar {
     archiveBaseName.set("wiremock-common")
+    manifest {
+        attributes("Automatic-Module-Name" to "org.wiremock.common")
+    }
 }
+
 
 publishing {
     publications {

--- a/wiremock-jetty/build.gradle.kts
+++ b/wiremock-jetty/build.gradle.kts
@@ -1,4 +1,4 @@
-plugins {
+ plugins {
     id("wiremock.common-conventions")
 }
 
@@ -62,6 +62,9 @@ dependencies {
 
 tasks.jar {
     archiveBaseName.set("wiremock-jetty")
+    manifest {
+        attributes("Automatic-Module-Name" to "org.wiremock.jetty")
+    }
 }
 
 publishing {


### PR DESCRIPTION
This change adds a default `Automatic-Module-Name` attribute to the distributable JARS.

- `*:wiremock` will use `org.wiremock`
- `*:wiremock-common` will use `org.wiremock.common`
- `*:wiremock-jetty` will use `org.wiremock.jetty`

This works around an issue I have observed whilst trying to include a `module-info.java` in an internal application that depends on WireMock at runtime, where compilation of the JPMS descriptor fails as a reproducible name cannot be derived from the WireMock JARs themselves.

Eventually, this should be replaced with fully compliant module-info.java sources within WireMock, which allow limiting the scope of the WireMock classloader at runtime.