### PR TITLE
Handle unsupported charsets

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,6 +100,12 @@ public class ContentTypeHeaderTest {
   @Test
   public void returnsDefaultCharsetWhenAbsent() {
     ContentTypeHeader header = ContentTypeHeader.absent();
+    assertThat(header.charset(), is(UTF_8));
+  }
+
+  @Test
+  public void returnsDefaultCharsetWhenIllegalEncoding() {
+    ContentTypeHeader header = new ContentTypeHeader("text/plain; charset=invalid");
     assertThat(header.charset(), is(UTF_8));
   }
 }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.http;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.Optional;
 
 public class ContentTypeHeader extends HttpHeader {
@@ -59,7 +60,11 @@ public class ContentTypeHeader extends HttpHeader {
 
   public Charset charset() {
     if (isPresent() && encodingPart().isPresent()) {
-      return Charset.forName(encodingPart().get());
+      try {
+        return Charset.forName(encodingPart().get());
+      } catch (UnsupportedCharsetException ignored) {
+        return UTF_8;
+      }
     }
 
     return UTF_8;


### PR DESCRIPTION
`ContentTypeHeader.charset()` is a convenience method that does not
return `null` or `Optional.absent()` when the header is absent, instead
defaulting to UTF-8; instead you can use
`ContentTypeHeader.encodingPart()` to get precise information about
whether it is absent and what it is.

As such it should not throw an exception for an unsupported charset but
fall back on the default, UTF-8.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
