### PR TITLE
Removed redundant uuid field from stub mapping

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -95,9 +95,6 @@ class AdminApiTest extends AcceptanceTestBase {
             + "  \"mappings\" : [ {                           \n"
             + "    \"id\" : \""
             + stubMapping.getId()
-            + "\",  \n"
-            + "    \"uuid\" : \""
-            + stubMapping.getId()
             + "\",\n"
             + "    \"request\" : {                            \n"
             + "      \"url\" : \"/my-test-url\",              \n"
@@ -188,9 +185,6 @@ class AdminApiTest extends AcceptanceTestBase {
     JSONAssert.assertEquals(
         "{                                          \n"
             + "    \"id\": \""
-            + id
-            + "\",              \n"
-            + "    \"uuid\": \""
             + id
             + "\",              \n"
             + "    \"request\" : {                        \n"
@@ -1096,12 +1090,12 @@ class AdminApiTest extends AcceptanceTestBase {
     return new TypeSafeMatcher<>() {
       @Override
       protected boolean matchesSafely(StubMapping stub) {
-        return stub.getId() != null && stub.getUuid() != null;
+        return stub.getId() != null;
       }
 
       @Override
       public void describeTo(Description description) {
-        description.appendText("a stub with a non-null ID and UUID");
+        description.appendText("a stub with a non-null ID");
       }
     };
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/EditMappingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/EditMappingAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ public class EditMappingAcceptanceTest extends AcceptanceTestBase {
 
   public static final String MAPPING_REQUEST_WITH_UUID =
       "{ 	"
-          + "	\"uuid\":\"bff18359-a74e-4c3e-95f0-dab304cd3a5a\",	\n"
+          + "	\"id\":\"bff18359-a74e-4c3e-95f0-dab304cd3a5a\",	\n"
           + "	\"request\": {										\n"
           + "		\"method\": \"GET\",							\n"
           + "		\"url\": \"/a/registered/resource\"				\n"
@@ -43,7 +43,7 @@ public class EditMappingAcceptanceTest extends AcceptanceTestBase {
 
   public static final String MODIFY_MAPPING_REQUEST_WITH_UUID =
       "{ 	"
-          + "	\"uuid\":\"bff18359-a74e-4c3e-95f0-dab304cd3a5a\",	\n"
+          + "	\"id\":\"bff18359-a74e-4c3e-95f0-dab304cd3a5a\",	\n"
           + "	\"request\": {										\n"
           + "		\"method\": \"GET\",							\n"
           + "		\"url\": \"/a/registered/resource\"				\n"

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Thomas Akehurst
+ * Copyright (C) 2016-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public class InMemoryStubMappingsTest {
     inMemoryStubMappings.addMapping(existingMapping);
 
     StubMapping newMapping = aMapping(1, "/priority1/2");
-    newMapping.setUuid(existingMapping.getUuid());
+    newMapping.setId(existingMapping.getId());
 
     inMemoryStubMappings.editMapping(newMapping);
 
@@ -91,7 +91,7 @@ public class InMemoryStubMappingsTest {
       inMemoryStubMappings.editMapping(newMapping);
       fail("Expected Exception");
     } catch (RuntimeException e) {
-      assertThat(e.getMessage(), containsString(newMapping.getUuid().toString()));
+      assertThat(e.getMessage(), containsString(newMapping.getId().toString()));
     }
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2024 Thomas Akehurst
+ * Copyright (C) 2011-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -373,7 +373,6 @@ class StubMappingJsonRecorderTest {
   private static final String GZIP_REQUEST_MAPPING =
       "{ 													             \n"
           + "   \"id\": \"41544750-0c69-3fd7-93b1-f79499f987c3\",            \n"
-          + "   \"uuid\": \"41544750-0c69-3fd7-93b1-f79499f987c3\",          \n"
           + "	\"request\": {									             \n"
           + "		\"method\": \"GET\",						             \n"
           + "		\"url\": \"/gzipped/content\"				             \n"
@@ -460,8 +459,7 @@ class StubMappingJsonRecorderTest {
           + "	\"response\": {									            	\n"
           + "		\"status\": 200,							            	\n"
           + "		\"bodyFileName\": \"body-multipart-content-1$2!3.txt\"  	\n"
-          + "	},												            	\n"
-          + "	\"uuid\": \"41544750-0c69-3fd7-93b1-f79499f987c3\"				\n"
+          + "	}												            	\n"
           + "}																	";
 
   @Test
@@ -496,16 +494,15 @@ class StubMappingJsonRecorderTest {
   }
 
   private static final String BAD_MULTIPART_REQUEST_MAPPING =
-      "{ 													             \n"
-          + "	\"id\": \"41544750-0c69-3fd7-93b1-f79499f987c3\",				\n"
-          + "	\"uuid\": \"41544750-0c69-3fd7-93b1-f79499f987c3\",				\n"
+      "{ 													                 \n"
+          + "	\"id\": \"41544750-0c69-3fd7-93b1-f79499f987c3\",			 \n"
           + "	\"request\": {									             \n"
           + "		\"url\": \"/multipart/content\",                         \n"
           + "		\"method\": \"POST\" 						             \n"
           + "	},												             \n"
           + "	\"response\": {									             \n"
           + "		\"status\": 200, 							             \n"
-          + "		\"bodyFileName\": \"body-multipart-content-1$2!3.txt\"        \n"
+          + "		\"bodyFileName\": \"body-multipart-content-1$2!3.txt\"   \n"
           + "	}												             \n"
           + "}";
 

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
@@ -311,7 +311,7 @@ class BasicMappingBuilder implements ScenarioMappingBuilder {
     mapping.setScenarioName(scenarioName);
     mapping.setRequiredScenarioState(requiredScenarioState);
     mapping.setNewScenarioState(newScenarioState);
-    mapping.setUuid(id);
+    mapping.setId(id);
     mapping.setName(name);
     mapping.setPersistent(isPersistent);
 

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/stubbing/AbstractStubMappings.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/stubbing/AbstractStubMappings.java
@@ -162,7 +162,7 @@ public abstract class AbstractStubMappings implements StubMappings {
     if (store.get(mapping.getId()).isPresent()) {
       String msg =
           "ID of the provided stub mapping '"
-              + mapping.getUuid()
+              + mapping.getId()
               + "' is already taken by another stub mapping";
       notifier().error(msg);
       throw new InvalidInputException(
@@ -200,7 +200,7 @@ public abstract class AbstractStubMappings implements StubMappings {
     final Optional<StubMapping> optionalExistingMapping = store.get(stubMapping.getId());
 
     if (optionalExistingMapping.isEmpty()) {
-      String msg = "StubMapping with UUID: " + stubMapping.getUuid() + " not found";
+      String msg = "StubMapping with UUID: " + stubMapping.getId() + " not found";
       notifier().error(msg);
       throw new NotFoundException(msg);
     }

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/stubbing/SortedConcurrentMappingSet.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/stubbing/SortedConcurrentMappingSet.java
@@ -58,7 +58,7 @@ public class SortedConcurrentMappingSet implements Iterable<StubMapping> {
   }
 
   public boolean remove(final UUID mappingId) {
-    return mappingSet.removeIf(mapping -> mappingId != null && mappingId.equals(mapping.getUuid()));
+    return mappingSet.removeIf(mapping -> mappingId != null && mappingId.equals(mapping.getId()));
   }
 
   public boolean replace(StubMapping existingStubMapping, StubMapping newStubMapping) {

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
@@ -31,13 +31,15 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-@JsonPropertyOrder({"id", "name", "request", "newRequest", "response", "uuid"})
-@JsonIgnoreProperties({"$schema"}) // Allows this to be added as a hint to IDEs like VS Code
+@JsonPropertyOrder({"id", "name", "request", "newRequest", "response"})
+@JsonIgnoreProperties({
+  "$schema", "uuid"
+}) // $schema allows this to be added as a hint to IDEs like VS Code
 public class StubMapping {
 
   public static final int DEFAULT_PRIORITY = 5;
 
-  private UUID uuid = UUID.randomUUID();
+  private UUID id = UUID.randomUUID();
   private String name;
 
   private Boolean persistent;
@@ -78,16 +80,12 @@ public class StubMapping {
     return Json.write(mapping);
   }
 
-  public UUID getUuid() {
-    return uuid;
-  }
-
   public void setId(UUID uuid) {
-    this.uuid = uuid;
+    this.id = uuid;
   }
 
   public UUID getId() {
-    return uuid;
+    return id;
   }
 
   public String getName() {
@@ -96,10 +94,6 @@ public class StubMapping {
 
   public void setName(String name) {
     this.name = name;
-  }
-
-  public void setUuid(UUID uuid) {
-    this.uuid = uuid;
   }
 
   public boolean shouldBePersisted() {
@@ -280,7 +274,7 @@ public class StubMapping {
     if (o == null || getClass() != o.getClass()) return false;
     StubMapping that = (StubMapping) o;
     return isDirty == that.isDirty
-        && Objects.equals(uuid, that.uuid)
+        && Objects.equals(id, that.id)
         && Objects.equals(request, that.request)
         && Objects.equals(response, that.response)
         && Objects.equals(priority, that.priority)
@@ -294,7 +288,7 @@ public class StubMapping {
   @Override
   public int hashCode() {
     return Objects.hash(
-        uuid,
+        id,
         request,
         response,
         priority,

--- a/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
+++ b/wiremock-common/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
@@ -167,7 +167,7 @@ public class StubMappingJsonRecorder implements RequestListener {
     ResponseDefinition responseToWrite = responseDefinitionBuilder.build();
 
     StubMapping mapping = new StubMapping(requestPattern, responseToWrite);
-    mapping.setUuid(UUID.nameUUIDFromBytes(fileId.getBytes()));
+    mapping.setId(UUID.nameUUIDFromBytes(fileId.getBytes()));
 
     filesBlobStore.put(bodyFileName, body);
     mappingsBlobStore.put(mappingFileName, Strings.bytesFromString(write(mapping)));


### PR DESCRIPTION
The `uuid` field has long been redundant, as it is a just an alias for the better-named `id`.