### PR TITLE
Upgraded to Jetty 12.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jetty = "12.0.29"
+jetty = "12.1.4"
 jackson = "2.20.1"
 xmlUnit = "2.11.0"
 jsonUnit = "5.0.0"

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -1010,8 +1010,12 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
     assertThat(testClient.get("/test?filter%5Bid%5D=1").statusCode(), is(200));
   }
 
+  /*
+  Note: this test case and the next one document a breaking change brought in by Jetty 12.1, whereby the content-type
+  header is normalised to lower case and without a space after the ; prior to being passed to WireMock's matchers.
+   */
   @Test
-  void matchesExactContentTypeEncodingSpecified() {
+  void doesNotMatchUnnormalisedRequestContentTypeHeaderValue() {
     String contentType = "application/json; charset=UTF-8";
     String url = "/request-content-type-case";
 
@@ -1019,11 +1023,28 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
 
     WireMockResponse response =
         testClient.post(url, new StringEntity("{}"), withHeader("Content-Type", contentType));
-    assertThat(response.statusCode(), is(200));
+    assertThat(response.statusCode(), is(404));
   }
 
   @Test
-  void returnsContentTypeHeaderEncodingInCorrectCase() {
+  void matchesNormalisedRequestContentTypeHeaderValue() {
+    String url = "/request-content-type-case";
+
+    stubFor(
+        post(url)
+            .withHeader("Content-Type", equalTo("application/json;charset=utf-8"))
+            .willReturn(ok()));
+
+    WireMockResponse response =
+        testClient.post(
+            url,
+            new StringEntity("{}"),
+            withHeader("Content-Type", "application/json; charset=UTF-8"));
+    assertThat(response.statusCode(), is(404));
+  }
+
+  @Test
+  void returnsContentTypeResponseHeaderEncodingInCorrectCase() {
     String contentType = "application/json; charset=UTF-8";
     String url = "/response-content-type-case";
 


### PR DESCRIPTION
Now depends on Jetty 12.1, up from 12.0.

This introduces a small breaking change - Jetty now normalises the `Content-Type` header so that e.g. `application/json; charset=UTF-8` becomes `application/json;charset=utf-8`.