### PR TITLE
Remove standalone only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,10 +45,6 @@ project.ext {
   ]
 }
 
-configurations {
-  standaloneOnly
-}
-
 dependencies {
   api platform("org.eclipse.jetty:jetty-bom:$versions.jetty")
   api "org.eclipse.jetty:jetty-server"
@@ -82,7 +78,6 @@ dependencies {
   }
 
   implementation "org.slf4j:slf4j-api:2.0.17"
-  standaloneOnly "org.slf4j:slf4j-nop:2.0.17"
 
   api "net.sf.jopt-simple:jopt-simple:5.0.4"
 
@@ -283,7 +278,6 @@ shadowJar {
   archiveClassifier.set('')
   configurations = [
     project.configurations.runtimeClasspath,
-    project.configurations.standaloneOnly
   ]
 
   relocate "org.mortbay", 'wiremock.org.mortbay'


### PR DESCRIPTION
slf4j-nop is packaged in slf4j-api now, so no need to have it as a
separate dependency, in fact with the package relocation it breaks the
way SLF4J tries to notice that there are multiple implementations on the
classpath.

Means we do not need the standaloneOnly configuration at all.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
