### PR TITLE
Bring versions up to date

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,8 +22,6 @@ plugins {
   alias(libs.plugins.task.tree)
 }
 
-val standaloneOnly: Configuration by configurations.creating
-
 dependencies {
   api(project(":wiremock-common"))
   api(project(":wiremock-jetty"))
@@ -60,8 +58,6 @@ dependencies {
   compileOnly(platform(libs.junit.bom))
   compileOnly(libs.junit.jupiter.api)
   compileOnly(libs.junit.platform.commons)
-
-  add("standaloneOnly", libs.slf4j.nop)
 
   testFixturesApi(project(":wiremock-common"))
 
@@ -189,7 +185,6 @@ tasks.shadowJar {
   archiveClassifier = ""
   configurations = listOf(
     project.configurations.runtimeClasspath.get(),
-    standaloneOnly,
   )
 
   relocate("org.mortbay", "wiremock.org.mortbay")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,9 @@ jetty = "12.1.4"
 jackson = "2.20.1"
 xmlUnit = "2.11.0"
 jsonUnit = "5.0.0"
-junitJupiter = "5.13.4"
+junitJupiter = "5.14.1"
 handlebars = "4.5.0"
-slf4j = "1.7.36"
+slf4j = "2.0.17"
 hamcrest = "3.0"
 mockito = "5.20.0"
 jmh = "1.37"
@@ -98,7 +98,7 @@ hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest
 hamcrest-library = { module = "org.hamcrest:hamcrest-library", version.ref = "hamcrest" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
-jsonassert = { module = "org.skyscreamer:jsonassert", version = "1.5.1" }
+jsonassert = { module = "org.skyscreamer:jsonassert", version = "1.5.3" }
 jsonassert-toomuchcoding = { module = "com.toomuchcoding.jsonassert:jsonassert", version = "0.8.0" }
 awaitility = { module = "org.awaitility:awaitility", version = "4.3.0" }
 commons-io = { module = "commons-io:commons-io", version = "2.21.0" }


### PR DESCRIPTION
JUnit 5.13.4 -> 5.14.1
SLF4J 1.7.36 -> 2.0.17
jsonassert 1.5.1 -> 1.5.3

Also removes `standaloneOnly`; slf4j-nop is packaged in slf4j-api now, so no need to have it as a separate dependency, in fact with the package relocation it breaks the way SLF4J tries to notice that there are multiple implementations on the classpath.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
