### PR TITLE
Add release drafter for the 3.x branch

### DIFF
--- a/.github/workflows/changelog-draft-3-release.yml
+++ b/.github/workflows/changelog-draft-3-release.yml
@@ -1,4 +1,4 @@
-name: Release Drafter
+name: Release Drafter 3.x
 
 on:
   push:


### PR DESCRIPTION
This will make it easier to continue to do 3.x releases when we need to update dependencies or backport a fix etc

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
