### PR TITLE
fix: allow the url encoding helper to handle block usage

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -586,15 +586,27 @@ public class ResponseTemplateTransformerTest {
   }
 
   @Test
-  public void urlEncodeValue() {
+  public void urlEncodeValueInline() {
     String body = transform("{{{urlEncode 'one two'}}}");
     assertThat(body, is("one+two"));
   }
 
   @Test
-  public void urlDecodeValue() {
+  public void urlEncodeValueBlock() {
+    String body = transform("{{#urlEncode}}Content to encode{{/urlEncode}}");
+    assertThat(body, is("Content+to+encode"));
+  }
+
+  @Test
+  public void urlDecodeValueInline() {
     String body = transform("{{{urlEncode 'one+two' decode=true}}}");
     assertThat(body, is("one two"));
+  }
+
+  @Test
+  public void urlDecodeValueBlock() {
+    String body = transform("{{#urlEncode decode=true}}Content%20to%20decode{{/urlEncode}}");
+    assertThat(body, is("Content to decode"));
   }
 
   @Test

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/UrlEncodingHelper.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/UrlEncodingHelper.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.TagType;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -26,13 +27,17 @@ public class UrlEncodingHelper implements Helper<Object> {
 
   @Override
   public Object apply(Object context, Options options) throws IOException {
+    String value =
+        options.tagType == TagType.SECTION ? options.fn(context).toString() : context.toString();
+
     Object encodingObj = options.hash.get("encoding");
     String encoding = encodingObj != null ? encodingObj.toString() : "utf-8";
+
     if (Boolean.TRUE.equals(options.hash.get("decode"))) {
-      return decode(context.toString(), encoding);
+      return decode(value, encoding);
     }
 
-    return encode(context.toString(), encoding);
+    return encode(value, encoding);
   }
 
   private String encode(String value, String encoding) throws IOException {


### PR DESCRIPTION
This PR fixes the urlEncoding template helper to allow it to be used as a block helper as well as an inline helper.  The docs already suggest that it can be used as a block helper so no documentation updates are required.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
