### PR TITLE
publish test fixtures.

### DIFF
--- a/buildSrc/src/main/kotlin/wiremock.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/wiremock.common-conventions.gradle.kts
@@ -209,9 +209,6 @@ publishing {
     }
   }
 
-  (components["java"] as AdhocComponentWithVariants).withVariantsFromConfiguration(configurations.testFixturesApiElements.get()) { skip() }
-  (components["java"] as AdhocComponentWithVariants).withVariantsFromConfiguration(configurations.testFixturesRuntimeElements.get()) { skip() }
-
   getComponents().withType<AdhocComponentWithVariants>().forEach { c ->
     c.withVariantsFromConfiguration(configurations.shadowRuntimeElements.get()) {
       skip()
@@ -223,6 +220,8 @@ publishing {
       pom {
         pomInfo()
       }
+      suppressPomMetadataWarningsFor("testFixturesApiElements")
+      suppressPomMetadataWarningsFor("testFixturesRuntimeElements")
     }
   }
 }


### PR DESCRIPTION
we stopped publishing these at commit
04e3b51017c03813111a39f573b72280e46fc4bc to fix publishing (not sure exactly what it fixed). removing the skip doesnt show any issues when publishing locally, so hopefully it's fine now.

<!-- Please describe your pull request here. -->

## References

https://github.com/wiremock/wiremock/pull/2661
