### PR TITLE
Fix: make StubMapping.toString return JSON again

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingTest.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.stubbing;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static java.util.stream.Collectors.toMap;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -134,5 +135,35 @@ public class StubMappingTest {
     assertThat(
         transformed.getResponse().getHeaders().getHeader("To-Remove").isPresent(), is(false));
     assertThat(transformed.getResponse().getHeaders().getHeader("To-Add").firstValue(), is("yyy"));
+  }
+
+  @Test
+  void stringFormIsJson() {
+    StubMapping stub = get("/foo").withHeader("One", equalTo("1")).willReturn(okJson("{}")).build();
+
+    assertThat(
+        stub.toString(),
+        jsonEquals(
+            """
+            {
+              "id": "${json-unit.any-string}",
+              "request": {
+                "headers": {
+                  "One": {
+                    "equalTo": "1"
+                  }
+                },
+                "method": "GET",
+                "url": "/foo"
+              },
+              "response": {
+                "body": "{}",
+                "headers": {
+                  "Content-Type": "application/json"
+                },
+                "status": 200
+              }
+            }
+            """));
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
@@ -226,46 +226,7 @@ public final class StubMapping implements StubMappingOrMappings {
 
   @Override
   public String toString() {
-    return "StubMapping["
-        + "id="
-        + id
-        + ", "
-        + "name="
-        + name
-        + ", "
-        + "persistent="
-        + persistent
-        + ", "
-        + "request="
-        + request
-        + ", "
-        + "response="
-        + response
-        + ", "
-        + "priority="
-        + priority
-        + ", "
-        + "scenarioName="
-        + scenarioName
-        + ", "
-        + "requiredScenarioState="
-        + requiredScenarioState
-        + ", "
-        + "newScenarioState="
-        + newScenarioState
-        + ", "
-        + "postServeActions="
-        + postServeActions
-        + ", "
-        + "serveEventListeners="
-        + serveEventListeners
-        + ", "
-        + "metadata="
-        + metadata
-        + ", "
-        + "insertionIndex="
-        + insertionIndex
-        + ']';
+    return Json.write(this);
   }
 
   public static class Builder {
@@ -288,7 +249,6 @@ public final class StubMapping implements StubMappingOrMappings {
     private Metadata metadata;
 
     private long insertionIndex;
-    private boolean isDirty;
 
     public Builder() {}
 
@@ -396,6 +356,7 @@ public final class StubMapping implements StubMappingOrMappings {
       return this;
     }
 
+    @SuppressWarnings("unused")
     public String getRequiredScenarioState() {
       return requiredScenarioState;
     }
@@ -405,6 +366,7 @@ public final class StubMapping implements StubMappingOrMappings {
       return this;
     }
 
+    @SuppressWarnings("unused")
     public String getNewScenarioState() {
       return newScenarioState;
     }
@@ -414,6 +376,7 @@ public final class StubMapping implements StubMappingOrMappings {
       return this;
     }
 
+    @SuppressWarnings("unused")
     public List<PostServeActionDefinition> getPostServeActions() {
       return postServeActions;
     }
@@ -446,10 +409,12 @@ public final class StubMapping implements StubMappingOrMappings {
       return this;
     }
 
+    @SuppressWarnings("unused")
     public long getInsertionIndex() {
       return insertionIndex;
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     public Builder setInsertionIndex(long insertionIndex) {
       this.insertionIndex = insertionIndex;
       return this;


### PR DESCRIPTION
It always used to

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
