### PR TITLE
fix: immutable collections in data classes.

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
@@ -21,6 +21,7 @@ import static com.github.tomakehurst.wiremock.http.ResponseDefinition.copyOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -29,6 +30,7 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -157,5 +159,72 @@ public class ResponseDefinitionTest {
 
     assertThat(json, not(containsString("transformers")));
     assertThat(json, not(containsString("transformerParameters")));
+  }
+
+  @Test
+  public void removeProxyRequestHeadersListIsImmutable() {
+    var removeProxyRequestHeaders = new ArrayList<String>();
+    var builder1 = new ResponseDefinition.Builder();
+    removeProxyRequestHeaders.add("header-1");
+    builder1.setRemoveProxyRequestHeaders(removeProxyRequestHeaders);
+
+    var responseDefinition1 = builder1.build();
+    assertThat(responseDefinition1.getRemoveProxyRequestHeaders(), contains("header-1"));
+
+    removeProxyRequestHeaders.clear();
+
+    assertThat(responseDefinition1.getRemoveProxyRequestHeaders(), contains("header-1"));
+
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> responseDefinition1.getRemoveProxyRequestHeaders().add("header-2"));
+
+    assertThat(responseDefinition1.getRemoveProxyRequestHeaders(), contains("header-1"));
+
+    builder1.getRemoveProxyRequestHeaders().clear();
+
+    assertThat(responseDefinition1.getRemoveProxyRequestHeaders(), contains("header-1"));
+
+    var builder2 = responseDefinition1.toBuilder();
+    builder2.getRemoveProxyRequestHeaders().add("header-2");
+    var responseDefinition2 = builder2.build();
+
+    assertThat(responseDefinition1.getRemoveProxyRequestHeaders(), contains("header-1"));
+
+    assertThat(
+        responseDefinition2.getRemoveProxyRequestHeaders(), contains("header-1", "header-2"));
+  }
+
+  @Test
+  public void transformersListIsImmutable() {
+    var transformers = new ArrayList<String>();
+    var builder1 = new ResponseDefinition.Builder();
+    transformers.add("transformer-1");
+    builder1.setTransformers(transformers);
+
+    var responseDefinition1 = builder1.build();
+    assertThat(responseDefinition1.getTransformers(), contains("transformer-1"));
+
+    transformers.clear();
+
+    assertThat(responseDefinition1.getTransformers(), contains("transformer-1"));
+
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> responseDefinition1.getTransformers().add("transformer-2"));
+
+    assertThat(responseDefinition1.getTransformers(), contains("transformer-1"));
+
+    builder1.getTransformers().clear();
+
+    assertThat(responseDefinition1.getTransformers(), contains("transformer-1"));
+
+    var builder2 = responseDefinition1.toBuilder();
+    builder2.getTransformers().add("transformer-2");
+    var responseDefinition2 = builder2.build();
+
+    assertThat(responseDefinition1.getTransformers(), contains("transformer-1"));
+
+    assertThat(responseDefinition2.getTransformers(), contains("transformer-1", "transformer-2"));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingTest.java
@@ -20,13 +20,19 @@ import static java.util.stream.Collectors.toMap;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.extension.PostServeActionDefinition;
+import com.github.tomakehurst.wiremock.extension.ServeEventListenerDefinition;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
+import java.util.ArrayList;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -165,5 +171,127 @@ public class StubMappingTest {
               }
             }
             """));
+  }
+
+  @Test
+  public void postServeActionsListIsImmutable() {
+    var postServeActionDefinitions = new ArrayList<PostServeActionDefinition>();
+    var builder1 = StubMapping.builder();
+    postServeActionDefinitions.add(
+        new PostServeActionDefinition("def-1", Parameters.one("param1", "value1")));
+    builder1.setPostServeActions(postServeActionDefinitions);
+
+    var stub1 = builder1.build();
+    assertThat(stub1.getPostServeActions(), hasSize(1));
+    assertThat(stub1.getPostServeActions().get(0).getName(), is("def-1"));
+    assertThat(
+        stub1.getPostServeActions().get(0).getParameters(), is(Parameters.one("param1", "value1")));
+
+    postServeActionDefinitions.clear();
+
+    assertThat(stub1.getPostServeActions(), hasSize(1));
+    assertThat(stub1.getPostServeActions().get(0).getName(), is("def-1"));
+    assertThat(
+        stub1.getPostServeActions().get(0).getParameters(), is(Parameters.one("param1", "value1")));
+
+    builder1.getPostServeActions().clear();
+
+    assertThat(stub1.getPostServeActions(), hasSize(1));
+    assertThat(stub1.getPostServeActions().get(0).getName(), is("def-1"));
+    assertThat(
+        stub1.getPostServeActions().get(0).getParameters(), is(Parameters.one("param1", "value1")));
+
+    assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            stub1
+                .getPostServeActions()
+                .add(new PostServeActionDefinition("def-2", Parameters.empty())));
+
+    assertThat(stub1.getPostServeActions(), hasSize(1));
+    assertThat(stub1.getPostServeActions().get(0).getName(), is("def-1"));
+    assertThat(
+        stub1.getPostServeActions().get(0).getParameters(), is(Parameters.one("param1", "value1")));
+
+    var builder2 = stub1.toBuilder();
+    builder2.getPostServeActions().add(new PostServeActionDefinition("def-2", Parameters.empty()));
+    var stub2 = builder2.build();
+
+    assertThat(stub1.getPostServeActions(), hasSize(1));
+    assertThat(stub1.getPostServeActions().get(0).getName(), is("def-1"));
+    assertThat(
+        stub1.getPostServeActions().get(0).getParameters(), is(Parameters.one("param1", "value1")));
+
+    assertThat(stub2.getPostServeActions(), hasSize(2));
+    assertThat(stub2.getPostServeActions().get(0).getName(), is("def-1"));
+    assertThat(
+        stub2.getPostServeActions().get(0).getParameters(), is(Parameters.one("param1", "value1")));
+    assertThat(stub2.getPostServeActions().get(1).getName(), is("def-2"));
+    assertThat(stub2.getPostServeActions().get(1).getParameters(), is(Parameters.empty()));
+  }
+
+  @Test
+  public void serveEventListenersListIsImmutable() {
+    var serveEventListenerDefinitions = new ArrayList<ServeEventListenerDefinition>();
+    var builder1 = StubMapping.builder();
+    serveEventListenerDefinitions.add(
+        new ServeEventListenerDefinition("def-1", Parameters.one("param1", "value1")));
+    builder1.setServeEventListeners(serveEventListenerDefinitions);
+
+    var stub1 = builder1.build();
+    assertThat(stub1.getServeEventListeners(), hasSize(1));
+    assertThat(stub1.getServeEventListeners().get(0).getName(), is("def-1"));
+    assertThat(
+        stub1.getServeEventListeners().get(0).getParameters(),
+        is(Parameters.one("param1", "value1")));
+
+    serveEventListenerDefinitions.clear();
+
+    assertThat(stub1.getServeEventListeners(), hasSize(1));
+    assertThat(stub1.getServeEventListeners().get(0).getName(), is("def-1"));
+    assertThat(
+        stub1.getServeEventListeners().get(0).getParameters(),
+        is(Parameters.one("param1", "value1")));
+
+    assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            stub1
+                .getServeEventListeners()
+                .add(new ServeEventListenerDefinition("def-2", Parameters.empty())));
+
+    assertThat(stub1.getServeEventListeners(), hasSize(1));
+    assertThat(stub1.getServeEventListeners().get(0).getName(), is("def-1"));
+    assertThat(
+        stub1.getServeEventListeners().get(0).getParameters(),
+        is(Parameters.one("param1", "value1")));
+
+    builder1.getServeEventListeners().clear();
+
+    assertThat(stub1.getServeEventListeners(), hasSize(1));
+    assertThat(stub1.getServeEventListeners().get(0).getName(), is("def-1"));
+    assertThat(
+        stub1.getServeEventListeners().get(0).getParameters(),
+        is(Parameters.one("param1", "value1")));
+
+    var builder2 = stub1.toBuilder();
+    builder2
+        .getServeEventListeners()
+        .add(new ServeEventListenerDefinition("def-2", Parameters.empty()));
+    var stub2 = builder2.build();
+
+    assertThat(stub1.getServeEventListeners(), hasSize(1));
+    assertThat(stub1.getServeEventListeners().get(0).getName(), is("def-1"));
+    assertThat(
+        stub1.getServeEventListeners().get(0).getParameters(),
+        is(Parameters.one("param1", "value1")));
+
+    assertThat(stub2.getServeEventListeners(), hasSize(2));
+    assertThat(stub2.getServeEventListeners().get(0).getName(), is("def-1"));
+    assertThat(
+        stub2.getServeEventListeners().get(0).getParameters(),
+        is(Parameters.one("param1", "value1")));
+    assertThat(stub2.getServeEventListeners().get(1).getName(), is("def-2"));
+    assertThat(stub2.getServeEventListeners().get(1).getParameters(), is(Parameters.empty()));
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -30,6 +30,7 @@ import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.extension.Parameters;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -121,14 +122,15 @@ public class ResponseDefinition {
 
     this.headers = headers;
     this.additionalProxyRequestHeaders = additionalProxyRequestHeaders;
-    this.removeProxyRequestHeaders = removeProxyRequestHeaders;
+    this.removeProxyRequestHeaders =
+        removeProxyRequestHeaders != null ? List.copyOf(removeProxyRequestHeaders) : null;
     this.fixedDelayMilliseconds = fixedDelayMilliseconds;
     this.delayDistribution = delayDistribution;
     this.chunkedDribbleDelay = chunkedDribbleDelay;
     this.proxyBaseUrl = proxyBaseUrl == null ? null : proxyBaseUrl.trim();
     this.proxyUrlPrefixToRemove = proxyUrlPrefixToRemove;
     this.fault = fault;
-    this.transformers = transformers;
+    this.transformers = transformers != null ? List.copyOf(transformers) : null;
     this.transformerParameters = transformerParameters;
     this.browserProxyUrl = browserProxyUrl;
     this.wasConfigured = wasConfigured == null || wasConfigured;
@@ -453,14 +455,18 @@ public class ResponseDefinition {
       this.bodyFileName = original.bodyFileName;
       this.headers = original.headers;
       this.additionalProxyRequestHeaders = original.additionalProxyRequestHeaders;
-      this.removeProxyRequestHeaders = original.removeProxyRequestHeaders;
+      this.removeProxyRequestHeaders =
+          original.removeProxyRequestHeaders != null
+              ? new ArrayList<>(original.removeProxyRequestHeaders)
+              : null;
       this.fixedDelayMilliseconds = original.fixedDelayMilliseconds;
       this.delayDistribution = original.delayDistribution;
       this.chunkedDribbleDelay = original.chunkedDribbleDelay;
       this.proxyBaseUrl = original.proxyBaseUrl;
       this.proxyUrlPrefixToRemove = original.proxyUrlPrefixToRemove;
       this.fault = original.fault;
-      this.transformers = original.transformers;
+      this.transformers =
+          original.transformers != null ? new ArrayList<>(original.transformers) : null;
       this.transformerParameters = original.transformerParameters;
       this.browserProxyUrl = original.browserProxyUrl;
       this.wasConfigured = original.wasConfigured;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -37,6 +37,7 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.http.RequestPathParamsDecorator;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import com.google.common.collect.ImmutableMap;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -128,15 +129,15 @@ public class RequestPattern implements NamedValueMatcher<Request> {
     this.clientIp = clientIp;
     this.url = getFirstNonNull(url, UrlPattern.ANY);
     this.method = getFirstNonNull(method, RequestMethod.ANY);
-    this.headers = headers;
-    this.pathParams = pathParams;
-    this.formParams = formParams;
-    this.queryParams = queryParams;
-    this.cookies = cookies;
+    this.headers = headers != null ? ImmutableMap.copyOf(headers) : null;
+    this.pathParams = pathParams != null ? ImmutableMap.copyOf(pathParams) : null;
+    this.formParams = formParams != null ? ImmutableMap.copyOf(formParams) : null;
+    this.queryParams = queryParams != null ? ImmutableMap.copyOf(queryParams) : null;
+    this.cookies = cookies != null ? ImmutableMap.copyOf(cookies) : null;
     this.basicAuthCredentials = basicAuthCredentials;
-    this.bodyPatterns = bodyPatterns;
+    this.bodyPatterns = bodyPatterns != null ? List.copyOf(bodyPatterns) : null;
     this.customMatcherDefinition = customMatcherDefinition;
-    this.multipartPatterns = multiPattern;
+    this.multipartPatterns = multiPattern != null ? List.copyOf(multiPattern) : null;
     this.hasInlineCustomMatcher = customMatcher != null;
 
     this.matcher =
@@ -595,14 +596,29 @@ public class RequestPattern implements NamedValueMatcher<Request> {
       this.clientIp = existing.getClientIp();
       this.url = existing.getUrlMatcher();
       this.method = existing.getMethod();
-      this.headers = existing.getHeaders();
-      this.pathParams = existing.getPathParameters();
-      this.queryParams = existing.getQueryParameters();
-      this.formParams = existing.getFormParameters();
-      this.cookies = existing.getCookies();
+      this.headers =
+          existing.getHeaders() != null ? new LinkedHashMap<>(existing.getHeaders()) : null;
+      this.pathParams =
+          existing.getPathParameters() != null
+              ? new LinkedHashMap<>(existing.getPathParameters())
+              : null;
+      this.queryParams =
+          existing.getQueryParameters() != null
+              ? new LinkedHashMap<>(existing.getQueryParameters())
+              : null;
+      this.formParams =
+          existing.getFormParameters() != null
+              ? new LinkedHashMap<>(existing.getFormParameters())
+              : null;
+      this.cookies =
+          existing.getCookies() != null ? new LinkedHashMap<>(existing.getCookies()) : null;
       this.basicAuthCredentials = existing.getBasicAuthCredentials();
-      this.bodyPatterns = existing.getBodyPatterns();
-      this.multipartPatterns = existing.getMultipartPatterns();
+      this.bodyPatterns =
+          existing.getBodyPatterns() != null ? new ArrayList<>(existing.getBodyPatterns()) : null;
+      this.multipartPatterns =
+          existing.getMultipartPatterns() != null
+              ? new ArrayList<>(existing.getMultipartPatterns())
+              : null;
       this.customMatcherDefinition = existing.getCustomMatcher();
       this.matcher = existing.getMatcher();
       this.hasInlineCustomMatcher = existing.hasInlineCustomMatcher();

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
@@ -26,6 +26,7 @@ import com.github.tomakehurst.wiremock.extension.PostServeActionDefinitionListDe
 import com.github.tomakehurst.wiremock.extension.ServeEventListenerDefinition;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -81,8 +82,9 @@ public final class StubMapping implements StubMappingOrMappings {
     this.scenarioName = scenarioName;
     this.requiredScenarioState = requiredScenarioState;
     this.newScenarioState = newScenarioState;
-    this.postServeActions = postServeActions;
-    this.serveEventListeners = serveEventListeners;
+    this.postServeActions = postServeActions != null ? List.copyOf(postServeActions) : null;
+    this.serveEventListeners =
+        serveEventListeners != null ? List.copyOf(serveEventListeners) : null;
     this.metadata = metadata;
     this.insertionIndex = insertionIndex;
   }
@@ -262,8 +264,12 @@ public final class StubMapping implements StubMappingOrMappings {
       this.scenarioName = existing.scenarioName;
       this.requiredScenarioState = existing.requiredScenarioState;
       this.newScenarioState = existing.newScenarioState;
-      this.postServeActions = existing.postServeActions;
-      this.serveEventListeners = existing.serveEventListeners;
+      this.postServeActions =
+          existing.postServeActions != null ? new ArrayList<>(existing.postServeActions) : null;
+      this.serveEventListeners =
+          existing.serveEventListeners != null
+              ? new ArrayList<>(existing.serveEventListeners)
+              : null;
       this.metadata = existing.metadata;
       this.insertionIndex = existing.insertionIndex;
     }


### PR DESCRIPTION
mutation of "immutable" data classes was possible due to the collections
 (lists and maps) not being defensibly made immutable.
## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
