### PR TITLE
explicit deserialization of StubMappingOrMappings.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
   testImplementation(libs.commons.lang)
 
   testImplementation(platform(libs.jackson.bom))
+  testImplementation(libs.jackson.core)
   testImplementation(libs.jackson.annotations)
 
   testImplementation(libs.jakarta.servlet.api)

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingOrMappingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingOrMappingsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.stubbing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.github.tomakehurst.wiremock.common.Json;
+import org.junit.jupiter.api.Test;
+
+public class StubMappingOrMappingsTest {
+
+  @Test
+  public void jacksonEmitsCorrectPointerWhenDeserializingCollection() {
+    var stubMappingsJson =
+        """
+        {
+          "mappings": [
+            {
+              "request": {
+                "method": "GET"
+              }
+            },
+            {
+              "response": {
+                "status": "not a number"
+              }
+            }
+          ]
+        }
+        """;
+    MismatchedInputException mismatchedInputException =
+        assertThrows(
+            MismatchedInputException.class,
+            () -> Json.getObjectMapper().readValue(stubMappingsJson, StubMappingCollection.class));
+    assertThat(
+        ((JsonParser) mismatchedInputException.getProcessor())
+            .getParsingContext()
+            .pathAsPointer()
+            .toString(),
+        is("/mappings/1/response/status"));
+  }
+
+  @Test
+  public void jacksonEmitsCorrectPointerWhenDeserializingMapping() {
+    var stubMappingJson =
+        """
+        {
+          "response": {
+            "status": "not a number"
+          }
+        }
+        """;
+    MismatchedInputException mismatchedInputException =
+        assertThrows(
+            MismatchedInputException.class,
+            () -> Json.getObjectMapper().readValue(stubMappingJson, StubMapping.class));
+    assertThat(
+        ((JsonParser) mismatchedInputException.getProcessor())
+            .getParsingContext()
+            .pathAsPointer()
+            .toString(),
+        is("/response/status"));
+  }
+}

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
@@ -36,6 +36,7 @@ import java.util.function.Consumer;
 @JsonIgnoreProperties({
   "$schema", "uuid"
 }) // $schema allows this to be added as a hint to IDEs like VS Code
+@JsonDeserialize() // stops infinite recursion when deserializing as StubMappingOrMappings
 public final class StubMapping implements StubMappingOrMappings {
 
   public static final int DEFAULT_PRIORITY = 5;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingCollection.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingCollection.java
@@ -16,9 +16,11 @@
 package com.github.tomakehurst.wiremock.stubbing;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 
 @JsonIgnoreProperties({"$schema", "meta", "uuid"})
+@JsonDeserialize() // stops infinite recursion when deserializing as StubMappingOrMappings
 public class StubMappingCollection implements StubMappingOrMappings {
 
   private List<StubMapping> mappings;


### PR DESCRIPTION
jackson's deduction based deserialization causes strange pointer behaviour on the parser context and makes extracting a helpful error message difficult on failure.