### PR TITLE
Allow postServe and serveEvents to use a request body contents from file

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaPostServeActionTest.java
@@ -84,6 +84,7 @@ public class WebhooksAcceptanceViaPostServeActionTest extends WebhooksAcceptance
           .options(
               options()
                   .dynamicPort()
+                  .withRootDirectoryChild("test-file-root")
                   .notifier(notifier)
                   .limitProxyTargets(
                       NetworkAddressRules.builder().deny("169.254.0.0-169.254.255.255").build()))
@@ -298,6 +299,94 @@ public class WebhooksAcceptanceViaPostServeActionTest extends WebhooksAcceptance
     assertThat(request.header("X-Single").firstValue(), is("3"));
     assertThat(request.header("X-Multi").values(), hasItems("6", "param-one-value"));
     assertThat(request.getBodyAsString(), is("Tom"));
+  }
+
+  @Test
+  public void appliesTemplatingToUrlMethodHeadersAndBodyFileNameViaDSL() throws Exception {
+    rule.stubFor(
+        post(urlPathEqualTo("/templating"))
+            .willReturn(ok())
+            .withPostServeAction(
+                "webhook",
+                webhook()
+                    .withBodyFile("myBodyFileName.json")
+                    .withMethod("{{jsonPath originalRequest.body '$.method'}}")
+                    .withUrl(
+                        targetServer.baseUrl()
+                            + "{{{jsonPath originalRequest.body '$.callbackPath'}}}")
+                    .withHeader("X-Single", "{{math 1 '+' 2}}")
+                    .withHeader("X-Multi", "{{math 3 'x' 2}}", "{{parameters.one}}")
+                    .withExtraParameter("one", "param-one-value")));
+
+    verify(0, postRequestedFor(anyUrl()));
+
+    client.postJson(
+        "/templating",
+        "{\n"
+            + "  \"callbackPath\": \"/callback/123\",\n"
+            + "  \"method\": \"POST\",\n"
+            + "  \"name\": \"Tom\"\n"
+            + "}");
+
+    waitForRequestToTargetServer();
+
+    LoggedRequest request =
+        targetServer.findAll(postRequestedFor(urlEqualTo("/callback/123"))).get(0);
+
+    assertThat(request.header("X-Single").firstValue(), is("3"));
+    assertThat(request.header("X-Multi").values(), hasItems("6", "param-one-value"));
+    assertThat(request.getBodyAsString(), is("{\"CONTENTS_OF_MYFILE\": \"Tom\"}\n"));
+  }
+
+  @Test
+  public void appliesTemplatingToUrlMethodHeadersAndBodyFileNameViaJSON() throws Exception {
+    client.postJson(
+        "/__admin/mappings",
+        "{\n"
+            + "  \"id\" : \"8a58e190-4a83-4244-a064-265fcca46884\",\n"
+            + "  \"request\" : {\n"
+            + "    \"urlPath\" : \"/templating\",\n"
+            + "    \"method\" : \"POST\"\n"
+            + "  },\n"
+            + "  \"response\" : {\n"
+            + "    \"status\" : 200\n"
+            + "  },\n"
+            + "  \"uuid\" : \"8a58e190-4a83-4244-a064-265fcca46884\",\n"
+            + "  \"postServeActions\" : [{\n"
+            + "    \"name\" : \"webhook\",\n"
+            + "    \"parameters\" : {\n"
+            + "      \"method\" : \"{{jsonPath originalRequest.body '$.method'}}\",\n"
+            + "      \"url\" : \""
+            + targetServer.baseUrl()
+            + "{{{jsonPath originalRequest.body '$.callbackPath'}}}\",\n"
+            + "      \"headers\" : {\n"
+            + "        \"X-Single\" : \"{{math 1 '+' 2}}\",\n"
+            + "        \"X-Multi\" : [ \"{{math 3 'x' 2}}\", \"{{parameters.one}}\" ]\n"
+            + "      },\n"
+            + "      \"bodyFileName\" : \"myBodyFileName.json\",\n"
+            + "      \"one\" : \"param-one-value\"\n"
+            + "    }\n"
+            + "  }]\n"
+            + "}\n");
+
+    verify(0, postRequestedFor(anyUrl()));
+
+    client.postJson(
+        "/templating",
+        "{\n"
+            + "  \"callbackPath\": \"/callback/123\",\n"
+            + "  \"method\": \"POST\",\n"
+            + "  \"name\": \"Tom\"\n"
+            + "}");
+
+    waitForRequestToTargetServer();
+
+    LoggedRequest request =
+        targetServer.findAll(postRequestedFor(urlEqualTo("/callback/123"))).get(0);
+
+    assertThat(request.header("X-Single").firstValue(), is("3"));
+    assertThat(request.header("X-Multi").values(), hasItems("6", "param-one-value"));
+    assertThat(request.getBodyAsString(), is("{\"CONTENTS_OF_MYFILE\": \"Tom\"}\n"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
@@ -90,6 +90,7 @@ public class WebhooksAcceptanceViaServeEventTest extends WebhooksAcceptanceTest 
           .options(
               options()
                   .dynamicPort()
+                  .withRootDirectoryChild("test-file-root")
                   .extensions(
                       new TemplateModelDataProviderExtension() {
                         @Override
@@ -378,6 +379,94 @@ public class WebhooksAcceptanceViaServeEventTest extends WebhooksAcceptanceTest 
     assertThat(request.header("X-Single").firstValue(), is("3"));
     assertThat(request.header("X-Multi").values(), hasItems("6", "param-one-value"));
     assertThat(request.getBodyAsString(), is("Tom"));
+  }
+
+  @Test
+  public void appliesTemplatingToUrlMethodHeadersAndBodyFileNameViaDSL() throws Exception {
+    rule.stubFor(
+        post(urlPathEqualTo("/templating"))
+            .willReturn(ok())
+            .withServeEventListener(
+                "webhook",
+                webhook()
+                    .withBodyFile("myBodyFileName.json")
+                    .withMethod("{{jsonPath originalRequest.body '$.method'}}")
+                    .withUrl(
+                        targetServer.baseUrl()
+                            + "{{{jsonPath originalRequest.body '$.callbackPath'}}}")
+                    .withHeader("X-Single", "{{math 1 '+' 2}}")
+                    .withHeader("X-Multi", "{{math 3 'x' 2}}", "{{parameters.one}}")
+                    .withExtraParameter("one", "param-one-value")));
+
+    verify(0, postRequestedFor(anyUrl()));
+
+    client.postJson(
+        "/templating",
+        "{\n"
+            + "  \"callbackPath\": \"/callback/123\",\n"
+            + "  \"method\": \"POST\",\n"
+            + "  \"name\": \"Tom\"\n"
+            + "}");
+
+    waitForRequestToTargetServer();
+
+    LoggedRequest request =
+        targetServer.findAll(postRequestedFor(urlEqualTo("/callback/123"))).get(0);
+
+    assertThat(request.header("X-Single").firstValue(), is("3"));
+    assertThat(request.header("X-Multi").values(), hasItems("6", "param-one-value"));
+    assertThat(request.getBodyAsString(), is("{\"CONTENTS_OF_MYFILE\": \"Tom\"}\n"));
+  }
+
+  @Test
+  public void appliesTemplatingToUrlMethodHeadersAndBodyFileNameViaJSON() throws Exception {
+    client.postJson(
+        "/__admin/mappings",
+        "{\n"
+            + "  \"id\" : \"8a58e190-4a83-4244-a064-265fcca46884\",\n"
+            + "  \"request\" : {\n"
+            + "    \"urlPath\" : \"/templating\",\n"
+            + "    \"method\" : \"POST\"\n"
+            + "  },\n"
+            + "  \"response\" : {\n"
+            + "    \"status\" : 200\n"
+            + "  },\n"
+            + "  \"uuid\" : \"8a58e190-4a83-4244-a064-265fcca46884\",\n"
+            + "  \"serveEventListeners\" : [{\n"
+            + "    \"name\" : \"webhook\",\n"
+            + "    \"parameters\" : {\n"
+            + "      \"method\" : \"{{jsonPath originalRequest.body '$.method'}}\",\n"
+            + "      \"url\" : \""
+            + targetServer.baseUrl()
+            + "{{{jsonPath originalRequest.body '$.callbackPath'}}}\",\n"
+            + "      \"headers\" : {\n"
+            + "        \"X-Single\" : \"{{math 1 '+' 2}}\",\n"
+            + "        \"X-Multi\" : [ \"{{math 3 'x' 2}}\", \"{{parameters.one}}\" ]\n"
+            + "      },\n"
+            + "      \"bodyFileName\" : \"myBodyFileName.json\",\n"
+            + "      \"one\" : \"param-one-value\"\n"
+            + "    }\n"
+            + "  }]\n"
+            + "}\n");
+
+    verify(0, postRequestedFor(anyUrl()));
+
+    client.postJson(
+        "/templating",
+        "{\n"
+            + "  \"callbackPath\": \"/callback/123\",\n"
+            + "  \"method\": \"POST\",\n"
+            + "  \"name\": \"Tom\"\n"
+            + "}");
+
+    waitForRequestToTargetServer();
+
+    LoggedRequest request =
+        targetServer.findAll(postRequestedFor(urlEqualTo("/callback/123"))).get(0);
+
+    assertThat(request.header("X-Single").firstValue(), is("3"));
+    assertThat(request.header("X-Multi").values(), hasItems("6", "param-one-value"));
+    assertThat(request.getBodyAsString(), is("{\"CONTENTS_OF_MYFILE\": \"Tom\"}\n"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesJsonSchemaPatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -427,7 +427,7 @@ public class MatchesJsonSchemaPatternTest {
         matchResult3.getSubEvents(),
         not(
             contains(
-                new TypeSafeMatcher<>() {
+                new TypeSafeMatcher<SubEvent>() {
                   @Override
                   protected boolean matchesSafely(SubEvent item) {
                     return item.getType().equals(SubEvent.ERROR);

--- a/src/test/resources/test-file-root/__files/myBodyFileName.json
+++ b/src/test/resources/test-file-root/__files/myBodyFileName.json
@@ -1,0 +1,1 @@
+{"CONTENTS_OF_MYFILE": "{{jsonPath originalRequest.body '$.name'}}"}

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -302,6 +302,11 @@ public class WireMockConfiguration implements Options {
     return this;
   }
 
+  public WireMockConfiguration withRootDirectoryChild(String path) {
+    filesRoot = new SingleRootFileSource(this.filesRoot.child(path).getPath());
+    return this;
+  }
+
   public WireMockConfiguration usingFilesUnderDirectory(String path) {
     return withRootDirectory(path);
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/HandlebarsOptimizedTemplate.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/HandlebarsOptimizedTemplate.java
@@ -18,8 +18,10 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating;
 import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.io.URLTemplateSource;
 import com.github.tomakehurst.wiremock.common.Exceptions;
 import com.github.tomakehurst.wiremock.common.RequestCache;
+import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -31,6 +33,14 @@ public class HandlebarsOptimizedTemplate {
   private String startContent;
   private String templateContent;
   private String endContent;
+
+  public HandlebarsOptimizedTemplate(final Handlebars handlebars, final File file)
+      throws IOException {
+    startContent = "";
+    templateContent = "";
+    endContent = "";
+    this.template = handlebars.compile(new URLTemplateSource(file.getName(), file.toURI().toURL()));
+  }
 
   public HandlebarsOptimizedTemplate(final Handlebars handlebars, final String content) {
     startContent = content;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/LazyTemplateEngine.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/LazyTemplateEngine.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
 import com.github.tomakehurst.wiremock.common.Lazy;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import java.io.IOException;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -35,6 +36,12 @@ public class LazyTemplateEngine extends TemplateEngine {
   @Override
   public HandlebarsOptimizedTemplate getUncachedTemplate(String content) {
     return templateEngineLazy.get().getUncachedTemplate(content);
+  }
+
+  @Override
+  public HandlebarsOptimizedTemplate getUncachedTemplateFromFile(String fileName)
+      throws IOException {
+    return templateEngineLazy.get().getUncachedTemplateFromFile(fileName);
   }
 
   @Override

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -42,6 +42,9 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -130,6 +133,16 @@ public class TemplateEngine {
 
   public HandlebarsOptimizedTemplate getUncachedTemplate(final String content) {
     return new HandlebarsOptimizedTemplate(handlebars, content);
+  }
+
+  public HandlebarsOptimizedTemplate getUncachedTemplateFromFile(final String fileName)
+      throws MalformedURLException, IOException {
+    try {
+      if (handlebars == null) throw new NullPointerException("no handle bars");
+      return new HandlebarsOptimizedTemplate(handlebars, new File(fileName));
+    } catch (Exception x) {
+      throw new IOException(fileName, x);
+    }
   }
 
   public Map<String, Object> buildModelForRequest(ServeEvent serveEvent) {
@@ -248,5 +261,9 @@ public class TemplateEngine {
 
   public Long getMaxCacheEntries() {
     return maxCacheEntries;
+  }
+
+  public Handlebars getHandleBars() {
+    return handlebars;
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/WebHookResponseModel.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/WebHookResponseModel.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating;
+
+import com.github.tomakehurst.wiremock.common.ListOrSingle;
+import java.util.Map;
+
+public record WebHookResponseModel(
+    int status, String statusMessage, Map<String, ListOrSingle<String>> headers, String body) {}

--- a/wiremock-core/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
+++ b/wiremock-core/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
@@ -38,6 +38,7 @@ public class WebhookDefinition {
   private String url;
   private List<HttpHeader> headers;
   private Body body = Body.none();
+  private String bodyFile;
   private DelayDistribution delay;
   private Parameters parameters;
 
@@ -47,6 +48,7 @@ public class WebhookDefinition {
         parameters.getString("url"),
         toHttpHeaders(parameters.getMetadata("headers", null)),
         parameters.getString("body", null),
+        parameters.getString("bodyFileName", null),
         parameters.getString("base64Body", null),
         getDelayDistribution(parameters.getMetadata("delay", null)),
         parameters);
@@ -90,6 +92,7 @@ public class WebhookDefinition {
       String url,
       HttpHeaders headers,
       String body,
+      String bodyFileName,
       String base64Body,
       DelayDistribution delay,
       Parameters parameters) {
@@ -101,6 +104,8 @@ public class WebhookDefinition {
       this.body = new Body(body);
     } else if (base64Body != null) {
       this.body = new Body(decodeBase64(base64Body));
+    } else if (bodyFileName != null) {
+      this.bodyFile = bodyFileName;
     }
 
     this.delay = delay;
@@ -132,6 +137,15 @@ public class WebhookDefinition {
 
   public String getBody() {
     return body.isBinary() ? null : body.asString();
+  }
+
+  public String getBodyFileName() {
+    return bodyFile;
+  }
+
+  @JsonIgnore
+  public boolean specifiesBodyFile() {
+    return bodyFile != null && body.isAbsent();
   }
 
   public DelayDistribution getDelay() {
@@ -194,6 +208,11 @@ public class WebhookDefinition {
 
   public WebhookDefinition withBinaryBody(byte[] body) {
     this.body = new Body(body);
+    return this;
+  }
+
+  public WebhookDefinition withBodyFile(String bodyFile) {
+    this.bodyFile = bodyFile;
     return this;
   }
 

--- a/wiremock-core/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/wiremock-core/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -17,8 +17,10 @@ package org.wiremock.webhooks;
 
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
+import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 import com.github.tomakehurst.wiremock.common.*;
 import com.github.tomakehurst.wiremock.core.Admin;
@@ -26,12 +28,16 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.extension.ServeEventListener;
 import com.github.tomakehurst.wiremock.extension.WireMockServices;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.HandlebarsOptimizedTemplate;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.WebHookResponseModel;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.http.client.HttpClient;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.SubEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.*;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -43,6 +49,8 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
   private final List<WebhookTransformer> transformers;
   private final TemplateEngine templateEngine;
   private final DataTruncationSettings dataTruncationSettings;
+  private final FileSource files;
+  private Parameters parameters;
 
   public Webhooks(
       WireMockServices wireMockServices,
@@ -54,6 +62,7 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
     this.transformers = transformers;
     this.templateEngine = wireMockServices.getTemplateEngine();
     this.dataTruncationSettings = wireMockServices.getOptions().getDataTruncationSettings();
+    this.files = wireMockServices.getOptions().filesRoot().child(FILES_ROOT);
   }
 
   @Override
@@ -77,6 +86,8 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
 
     WebhookDefinition definition;
     Request request;
+    this.parameters = parameters;
+
     try {
       definition = WebhookDefinition.from(parameters);
       for (WebhookTransformer transformer : transformers) {
@@ -144,6 +155,7 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
             ? webhookDefinition.getExtraParameters()
             : Collections.<String, Object>emptyMap());
     model.put("originalRequest", model.get("request"));
+    model.put("originalResponse", createResponseModel(serveEvent.getResponseDefinition()));
     model.remove("request");
 
     WebhookDefinition renderedWebhookDefinition =
@@ -161,9 +173,35 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
                                     .collect(toList())))
                     .collect(toList()));
 
-    if (webhookDefinition.getBody() != null) {
-      renderedWebhookDefinition =
-          webhookDefinition.withBody(renderTemplate(model, webhookDefinition.getBody()));
+    if (webhookDefinition.specifiesBodyFile()) {
+      try {
+        HandlebarsOptimizedTemplate filePathTemplate =
+            templateEngine.getUncachedTemplate(webhookDefinition.getBodyFileName());
+        String compiledFilePath = filePathTemplate.apply(model);
+
+        boolean disableBodyFileTemplating =
+            parameters.getBoolean("disableBodyFileTemplating", false);
+        if (disableBodyFileTemplating) {
+          webhookDefinition.withBodyFile(compiledFilePath);
+        } else {
+          TextFile file = files.getTextFileNamed(compiledFilePath);
+          HandlebarsOptimizedTemplate bodyTemplate =
+              templateEngine.getTemplate(
+                  // HttpTemplateCacheKey.forFileBody(responseDefinition, compiledFilePath),
+                  compiledFilePath, file.readContentsAsString());
+          webhookDefinition.withBody(bodyTemplate.apply(model));
+        }
+      } catch (Exception ex) {
+        StringWriter writer = new StringWriter();
+        writer.append(
+            webhookDefinition.getBodyFileName()
+                + " not found in fileSource path: "
+                + files.getPath());
+        ex.printStackTrace(new PrintWriter(writer));
+        renderedWebhookDefinition.withBody(writer.toString());
+      }
+    } else if (webhookDefinition.getBody() != null) {
+      renderedWebhookDefinition.withBody(renderTemplate(model, webhookDefinition.getBody()));
     }
 
     return renderedWebhookDefinition;
@@ -185,6 +223,22 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
     }
 
     return requestBuilder.build();
+  }
+
+  public static WebHookResponseModel createResponseModel(ResponseDefinition response) {
+    return new WebHookResponseModel(
+        response.getStatus(),
+        response.getStatusMessage(),
+        response.getHeaders() == null
+            ? Collections.emptyMap()
+            : response.getHeaders().all().stream()
+                .collect(toMap(HttpHeader::key, header -> ListOrSingle.of(header.getValues()))),
+        Body.fromOneOf(
+                response.getByteBody(),
+                response.getBody(),
+                response.getJsonBody(),
+                response.getBase64Body())
+            .asString());
   }
 
   @Override


### PR DESCRIPTION
Add bodyFileName
Add test case for postServe and serveEvent
Add test resource files root to test configuration Process the request with handlebars templating
Create a ResponseModel for accessing the original Response

<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
