### PR TITLE
Jackson 3 support WIP

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 jetty = "12.1.5"
-jackson = "2.20.1"
+jackson = "3.0.3"
 xmlUnit = "2.11.0"
 jsonUnit = "5.1.0"
 junitJupiter = "5.14.2"
@@ -39,11 +39,10 @@ jetty-io = { module = "org.eclipse.jetty:jetty-io" }
 jetty-util = { module = "org.eclipse.jetty:jetty-util" }
 
 # Jackson dependencies
-jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
-jackson-core = { module = "com.fasterxml.jackson.core:jackson-core" }
+jackson-bom = { module = "tools.jackson:jackson-bom", version.ref = "jackson" }
+jackson-core = { module = "tools.jackson.core:jackson-core" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations" }
-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
-jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" }
+jackson-databind = { module = "tools.jackson.core:jackson-databind" }
 
 # Guava
 guava = { module = "com.google.guava:guava", version = "33.5.0-jre" }
@@ -93,7 +92,7 @@ handlebars-helpers = { module = "com.github.jknack:handlebars-helpers", version.
 commons-fileupload = { module = "commons-fileupload:commons-fileupload", version = "1.6.0" }
 
 # JSON Schema
-json-schema-validator = { module = "com.networknt:json-schema-validator", version = "1.5.9" }
+json-schema-validator = { module = "com.networknt:json-schema-validator", version = "3.0.0" }
 
 # Testing
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }

--- a/src/test/java/com/github/tomakehurst/wiremock/ContentPatternsJsonValidityTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ContentPatternsJsonValidityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Thomas Akehurst
+ * Copyright (C) 2024-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,13 @@ import static com.github.tomakehurst.wiremock.common.DateTimeUnit.DAYS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.testsupport.TestFiles;
 import com.networknt.schema.*;
+import com.networknt.schema.Error;
+import com.networknt.schema.dialect.Dialects;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.commons.lang3.RandomUtils;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
@@ -36,21 +37,22 @@ import org.junit.jupiter.api.Test;
 
 public class ContentPatternsJsonValidityTest {
 
-  static JsonSchemaFactory schemaFactory;
-  static SchemaValidatorsConfig config;
-  static JsonSchema schema;
+  static SchemaRegistry schemaFactory;
+  static SchemaRegistryConfig config;
+  static Schema schema;
 
   @BeforeAll
   static void init() {
-    config = SchemaValidatorsConfig.builder().build();
+    config = SchemaRegistryConfig.builder().build();
 
     schemaFactory =
-        JsonSchemaFactory.getInstance(WireMock.JsonSchemaVersion.V202012.toVersionFlag());
+        SchemaRegistry.withDialect(
+            Dialects.getDraft202012(), builder -> builder.schemaRegistryConfig(config));
 
     schema =
         schemaFactory.getSchema(
-            SchemaLocation.of(TestFiles.fileUri("swagger/schemas/content-pattern.yaml").toString()),
-            config);
+            SchemaLocation.of(
+                TestFiles.fileUri("swagger/schemas/content-pattern.yaml").toString()));
   }
 
   @Test
@@ -378,11 +380,11 @@ public class ContentPatternsJsonValidityTest {
     assertThat(validate("{ \"lessThanEqualNumber\": \"not a number\" }"), Matchers.not(empty()));
   }
 
-  private static Set<ValidationMessage> validate(Object obj) {
+  private static List<Error> validate(Object obj) {
     return schema.validate(Json.write(obj), InputFormat.JSON);
   }
 
-  private static Set<ValidationMessage> validate(String json) {
+  private static List<Error> validate(String json) {
     return schema.validate(json, InputFormat.JSON);
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2025 Thomas Akehurst
+ * Copyright (C) 2011-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -550,7 +550,7 @@ public class StandaloneAcceptanceTest extends AcceptanceTestBase {
         allOf(
             containsString("Error loading file"),
             containsString("bad-mapping.json"),
-            containsString("Unrecognized field \"requesttttt\""),
+            containsString("Unrecognized property \"requesttttt\""),
             containsString("class com.github.tomakehurst.wiremock.stubbing.StubMapping"),
             containsString("not marked as ignorable")));
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2025 Thomas Akehurst
+ * Copyright (C) 2012-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
@@ -34,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 
 class ResponseDefinitionBuilderTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1308,7 +1308,7 @@ public class ResponseTemplateTransformerTest {
     String result = transform("{{#parseJson 'json'}}{ \"thing{{/parseJson}}");
 
     assertEquals(
-        "[ERROR] Unexpected end-of-input in field name\n"
+        "[ERROR] Unexpected end-of-input in property name\n"
             + " at [Source: (String)\"{ \"thing\"; line: 1, column: 9]",
         result);
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2024 Thomas Akehurst
+ * Copyright (C) 2015-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.IntNode;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.JsonException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.IntNode;
 
 class BodyTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -320,7 +320,7 @@ public class MatchesXPathPatternTest {
             .match("<something>{ bad json</something>");
     checkJsonError(
         matchResult,
-        "Unexpected character ('b' (code 98)): was expecting double-quote to start field name\n at [Source: (String)\"{ bad json\"; line: 1, column: 3]");
+        "Unexpected character ('b' (code 98)): was expecting double-quote to start property name\n at [Source: (String)\"{ bad json\"; line: 1, column: 3]");
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/schema/WireMockMessageStubMappingJsonSchemaRegressionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/schema/WireMockMessageStubMappingJsonSchemaRegressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Thomas Akehurst
+ * Copyright (C) 2025-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,18 +22,19 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.common.Json;
-import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.SchemaValidatorsConfig;
-import com.networknt.schema.SpecVersion;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SchemaRegistryConfig;
+import com.networknt.schema.dialect.Dialect;
+import com.networknt.schema.dialect.Dialects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 
 class WireMockMessageStubMappingJsonSchemaRegressionTest {
 
@@ -46,15 +47,16 @@ class WireMockMessageStubMappingJsonSchemaRegressionTest {
     JsonNode schemaJson = Json.node(loadResourceAsString(SCHEMA_PATH));
     assertNotNull(schemaJson, "Schema file not found: " + SCHEMA_PATH);
 
-    SchemaValidatorsConfig schemaValidatorsConfig = SchemaValidatorsConfig.builder().build();
-    SpecVersion.VersionFlag version =
-        SpecVersion.VersionFlag.fromId(schemaJson.get("$schema").textValue()).orElseThrow();
+    SchemaRegistryConfig schemaValidatorsConfig = SchemaRegistryConfig.builder().build();
+    Dialect version = Dialects.getDraft202012();
 
-    final JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(version);
+    final SchemaRegistry schemaFactory =
+        SchemaRegistry.withDialect(
+            version, builder -> builder.schemaRegistryConfig(schemaValidatorsConfig));
 
     JsonNode metaSchemaJson =
         Json.node(loadResourceAsString(URI.create(version.getId()).getPath().substring(1)));
-    final JsonSchema metaSchema = schemaFactory.getSchema(metaSchemaJson, schemaValidatorsConfig);
+    final Schema metaSchema = schemaFactory.getSchema(metaSchemaJson);
 
     assertThat(metaSchema.validate(schemaJson), is(empty()));
   }
@@ -99,4 +101,3 @@ class WireMockMessageStubMappingJsonSchemaRegressionTest {
     }
   }
 }
-

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2025 Thomas Akehurst
+ * Copyright (C) 2012-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Body;
@@ -37,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.JsonNode;
 
 public class ResponseDefinitionTest {
 

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2024 Thomas Akehurst
+ * Copyright (C) 2012-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,18 +24,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.common.Dates;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.http.Cookie;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.json.JsonMapper;
 
 @SuppressWarnings("rawtypes")
 public class LoggedRequestTest {
@@ -198,8 +197,9 @@ public class LoggedRequestTest {
   }
 
   @Test
-  void queryParametersAreDeserialized() throws IOException {
-    LoggedRequest req = new ObjectMapper().readValue(JSON_PARAMS_EXAMPLE, LoggedRequest.class);
+  void queryParametersAreDeserialized() {
+    LoggedRequest req =
+        JsonMapper.builder().build().readValue(JSON_PARAMS_EXAMPLE, LoggedRequest.class);
 
     assertEquals("test-param-1", req.queryParameter("test-param-1").key());
     assertEquals("value-1", req.queryParameter("test-param-1").firstValue());

--- a/wiremock-core/build.gradle.kts
+++ b/wiremock-core/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
         exclude(group = "org.mozilla", module = "rhino")
         exclude(group = "org.apache.commons", module = "commons-lang3")
     }
-    implementation(libs.jackson.datatype.jsr310)
     implementation(libs.json.path) {
         exclude(group = "org.ow2.asm", module = "asm")
     }

--- a/wiremock-core/buildSchema.gradle
+++ b/wiremock-core/buildSchema.gradle
@@ -1,17 +1,18 @@
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.ArrayNode
-import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.databind.node.ArrayNode
+import tools.jackson.databind.node.ObjectNode
+import tools.jackson.dataformat.yaml.YAMLMapper
 
 buildscript {
   repositories {
     mavenCentral()
   }
   dependencies {
-    classpath "com.fasterxml.jackson.core:jackson-core:2.18.3"
-    classpath "com.fasterxml.jackson.core:jackson-databind:2.18.3"
-    classpath "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.3"
+    classpath "tools.jackson.core:jackson-core:3.0.3"
+    classpath "tools.jackson.core:jackson-databind:3.0.3"
+    classpath "tools.jackson.dataformat:jackson-dataformat-yaml:3.0.3"
   }
 }
 
@@ -78,7 +79,7 @@ sourceSets {
  * </pre>
  */
 private String doBuildStubMappingSchema() {
-  def jsonMapper = new ObjectMapper()
+  def jsonMapper = JsonMapper.builder().build();
   def document = jsonMapper.createObjectNode()
   document.put("title", "WireMock stub mapping")
   document.put("type", "object")
@@ -86,7 +87,7 @@ private String doBuildStubMappingSchema() {
   // Only draft-07 is supported by schema-store.org so we bump up to this despite strictly being on 04 within our OpenAPI version
   document.put("\$schema", "http://json-schema.org/draft-07/schema#")
 
-  def yamlMapper = new ObjectMapper(YAMLFactory.builder().build())
+  def yamlMapper = YAMLMapper.builder().build()
 
   def schemas = new ArrayList<Tuple>()
   file('src/main/resources/swagger/schemas').listFiles().toList().sort { it.name }.each { file ->
@@ -160,14 +161,14 @@ private static String removePrefix(String input, String prefix) {
 }
 
 private String doBuildMessageStubMappingSchema() {
-  def jsonMapper = new ObjectMapper()
+  def jsonMapper = JsonMapper.builder().build()
   def document = jsonMapper.createObjectNode()
   document.put("title", "WireMock message stub mapping")
   document.put("type", "object")
 
   document.put("\$schema", "http://json-schema.org/draft-07/schema#")
 
-  def yamlMapper = new ObjectMapper(YAMLFactory.builder().build())
+  def yamlMapper = YAMLMapper.builder().build()
 
   def schemas = new ArrayList<Tuple>()
   file('src/main/resources/swagger/schemas').listFiles().toList().sort { it.name }.each { file ->

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -171,7 +171,7 @@ public class WireMockServer implements Container, Stubbing, Admin {
 
   public void start() {
     // Try to ensure this is warmed up on the main thread so that it's inherited by worker threads
-    Json.getObjectMapper();
+    Json.getJsonMapper();
     try {
       httpServer.start();
     } catch (Exception e) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2025 Thomas Akehurst
+ * Copyright (C) 2011-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ import static com.github.tomakehurst.wiremock.common.ContentTypes.*;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.util.Arrays.asList;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.*;
 import java.util.*;
+import tools.jackson.databind.JsonNode;
 
 @SuppressWarnings("UnusedReturnValue")
 public class ResponseDefinitionBuilder {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -59,7 +59,8 @@ import com.github.tomakehurst.wiremock.verification.MessageServeEvent;
 import com.github.tomakehurst.wiremock.verification.NearMiss;
 import com.github.tomakehurst.wiremock.verification.VerificationResult;
 import com.github.tomakehurst.wiremock.verification.diff.Diff;
-import com.networknt.schema.SpecVersion;
+import com.networknt.schema.dialect.Dialect;
+import com.networknt.schema.dialect.Dialects;
 import java.io.File;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -1327,13 +1328,13 @@ public class WireMock {
 
     public static final JsonSchemaVersion DEFAULT = V202012;
 
-    public SpecVersion.VersionFlag toVersionFlag() {
+    public Dialect toVersionFlag() {
       return switch (this) {
-        case V4 -> SpecVersion.VersionFlag.V4;
-        case V6 -> SpecVersion.VersionFlag.V6;
-        case V7 -> SpecVersion.VersionFlag.V7;
-        case V201909 -> SpecVersion.VersionFlag.V201909;
-        case V202012 -> SpecVersion.VersionFlag.V202012;
+        case V4 -> Dialects.getDraft4();
+        case V6 -> Dialects.getDraft6();
+        case V7 -> Dialects.getDraft7();
+        case V201909 -> Dialects.getDraft201909();
+        case V202012 -> Dialects.getDraft202012();
       };
     }
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/ContentTypes.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/ContentTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ import static com.github.tomakehurst.wiremock.common.Strings.substringAfterLast;
 import static com.github.tomakehurst.wiremock.common.TextType.JSON;
 import static java.util.Arrays.asList;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.common.xml.Xml;
 import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.databind.JsonNode;
 
 public class ContentTypes {
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/ListOrSingle.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/ListOrSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@ package com.github.tomakehurst.wiremock.common;
 
 import static java.util.Arrays.asList;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(using = ListOrSingleSerialiser.class)
 @JsonDeserialize(using = ListOrStringDeserialiser.class)

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/ListOrSingleSerialiser.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/ListOrSingleSerialiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,21 +15,20 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.type.CollectionType;
-import com.fasterxml.jackson.databind.type.TypeFactory;
-import java.io.IOException;
 import java.util.List;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.type.CollectionType;
+import tools.jackson.databind.type.TypeFactory;
 
-public class ListOrSingleSerialiser extends JsonSerializer<ListOrSingle<Object>> {
+public class ListOrSingleSerialiser extends ValueSerializer<ListOrSingle<Object>> {
 
   @Override
   public void serialize(
-      ListOrSingle<Object> value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException, JsonProcessingException {
+      ListOrSingle<Object> value, JsonGenerator gen, SerializationContext serializers)
+      throws JacksonException {
     if (value.isEmpty()) {
       gen.writeStartArray();
       gen.writeEndArray();
@@ -38,12 +37,13 @@ public class ListOrSingleSerialiser extends JsonSerializer<ListOrSingle<Object>>
 
     Object firstValue = value.getFirst();
     if (value.isSingle()) {
-      JsonSerializer<Object> serializer = serializers.findValueSerializer(firstValue.getClass());
+      ValueSerializer<Object> serializer = serializers.findValueSerializer(firstValue.getClass());
       serializer.serialize(firstValue, gen, serializers);
     } else {
       CollectionType type =
-          TypeFactory.defaultInstance().constructCollectionType(List.class, firstValue.getClass());
-      JsonSerializer<Object> serializer = serializers.findValueSerializer(type);
+          TypeFactory.createDefaultInstance()
+              .constructCollectionType(List.class, firstValue.getClass());
+      ValueSerializer<Object> serializer = serializers.findValueSerializer(type);
       serializer.serialize(value, gen, serializers);
     }
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/ListOrStringDeserialiser.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/ListOrStringDeserialiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,29 +15,26 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.node.ArrayNode;
 
-public class ListOrStringDeserialiser<T> extends JsonDeserializer<ListOrSingle<T>> {
+public class ListOrStringDeserialiser<T> extends ValueDeserializer<ListOrSingle<T>> {
 
   @Override
   @SuppressWarnings("unchecked")
   public ListOrSingle<T> deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException, JsonProcessingException {
+      throws JacksonException {
     JsonNode rootNode = parser.readValueAsTree();
     if (rootNode.isArray()) {
       ArrayNode arrayNode = (ArrayNode) rootNode;
       List<T> items = new ArrayList<>();
-      for (Iterator<JsonNode> i = arrayNode.elements(); i.hasNext(); ) {
-        JsonNode node = i.next();
+      for (JsonNode node : arrayNode.values()) {
         Object value = getValue(node);
         items.add((T) value);
       }
@@ -49,10 +46,10 @@ public class ListOrStringDeserialiser<T> extends JsonDeserializer<ListOrSingle<T
   }
 
   private static Object getValue(JsonNode node) {
-    return node.isTextual()
-        ? node.textValue()
+    return node.isString()
+        ? node.stringValue()
         : node.isNumber()
             ? node.numberValue()
-            : node.isBoolean() ? node.booleanValue() : node.textValue();
+            : node.isBoolean() ? node.booleanValue() : node.stringValue();
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/BinaryEntityDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/BinaryEntityDefinition.java
@@ -20,10 +20,10 @@ import static java.util.Arrays.asList;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.tomakehurst.wiremock.common.Json;
 import java.util.Base64;
 import java.util.Objects;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as = BinaryEntityDefinition.class)
 public class BinaryEntityDefinition extends EntityDefinition {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinition.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.common.entity;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(using = EntityDefinitionDeserializer.class)
 @JsonSubTypes(

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinitionDeserializer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinitionDeserializer.java
@@ -15,11 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.common.entity;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import java.io.IOException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 public class EntityDefinitionDeserializer extends StdDeserializer<EntityDefinition> {
 
@@ -28,18 +27,17 @@ public class EntityDefinitionDeserializer extends StdDeserializer<EntityDefiniti
   }
 
   @Override
-  public EntityDefinition deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException {
+  public EntityDefinition deserialize(JsonParser parser, DeserializationContext ctxt) {
     JsonNode node = parser.readValueAsTree();
 
     Class<? extends EntityDefinition> targetClass;
-    if (node.isTextual()) {
+    if (node.isString()) {
       targetClass = StringEntityDefinition.class;
     } else if (node.isObject()) {
       JsonNode encodingNode = node.get("encoding");
       if (encodingNode != null
-          && encodingNode.isTextual()
-          && EncodingType.BINARY.value().equals(encodingNode.textValue())) {
+          && encodingNode.isString()
+          && EncodingType.BINARY.value().equals(encodingNode.stringValue())) {
         targetClass = BinaryEntityDefinition.class;
       } else {
         // Default to TextEntityDefinition for text encoding or when encoding is not specified

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/StringEntityDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/StringEntityDefinition.java
@@ -17,8 +17,8 @@ package com.github.tomakehurst.wiremock.common.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Objects;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as = StringEntityDefinition.class)
 public class StringEntityDefinition extends EntityDefinition {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/TextEntityDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/TextEntityDefinition.java
@@ -20,9 +20,9 @@ import static java.util.Arrays.asList;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.tomakehurst.wiremock.common.Json;
 import java.util.Objects;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as = TextEntityDefinition.class)
 public class TextEntityDefinition extends EntityDefinition {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/PostServeActionDefinitionListDeserializer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/PostServeActionDefinitionListDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Thomas Akehurst
+ * Copyright (C) 2025-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,21 @@
  */
 package com.github.tomakehurst.wiremock.extension;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.github.tomakehurst.wiremock.common.Json;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
 public class PostServeActionDefinitionListDeserializer
-    extends JsonDeserializer<List<PostServeActionDefinition>> {
+    extends ValueDeserializer<List<PostServeActionDefinition>> {
 
   @Override
   public List<PostServeActionDefinition> deserialize(
-      JsonParser parser, DeserializationContext context) throws IOException {
+      JsonParser parser, DeserializationContext context) {
 
     JsonToken currentToken = parser.currentToken();
 
@@ -44,7 +43,7 @@ public class PostServeActionDefinitionListDeserializer
   }
 
   @SuppressWarnings("unchecked")
-  private List<PostServeActionDefinition> deserializeFromMap(JsonParser parser) throws IOException {
+  private List<PostServeActionDefinition> deserializeFromMap(JsonParser parser) {
     Map<String, Object> map = parser.readValueAs(Map.class);
 
     List<PostServeActionDefinition> result = new ArrayList<>();
@@ -56,8 +55,7 @@ public class PostServeActionDefinitionListDeserializer
     return result;
   }
 
-  private List<PostServeActionDefinition> deserializeFromArray(JsonParser parser)
-      throws IOException {
+  private List<PostServeActionDefinition> deserializeFromArray(JsonParser parser) {
     @SuppressWarnings("unchecked")
     List<Map<String, Object>> list = parser.readValueAs(List.class);
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HelperUtils.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HelperUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 Thomas Akehurst
+ * Copyright (C) 2021-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,19 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
 import com.github.tomakehurst.wiremock.common.Json;
 import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.AbstractJsonProvider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.json.JsonMapper;
 
 public class HelperUtils {
 
@@ -60,5 +71,58 @@ public class HelperUtils {
           // Explicitly use Jackson for JSON parsing because the default provider allows invalid
           // JSON to be parsed as a JSON string in certain circumstances, which, in my opinion,
           // creates a confusing user experience.
-          .jsonProvider(new JacksonJsonProvider(Json.getObjectMapper()));
+          .jsonProvider(new Jackson3JsonProvider(Json.getJsonMapper()));
+
+  // TODO: Replace this if JsonPath adds support for Jackson 3.
+  private static class Jackson3JsonProvider extends AbstractJsonProvider {
+
+    private final JsonMapper jsonMapper;
+
+    Jackson3JsonProvider(JsonMapper jsonMapper) {
+      this.jsonMapper = jsonMapper;
+    }
+
+    @Override
+    public Object parse(String json) throws InvalidJsonException {
+      try {
+        return jsonMapper.readValue(json, Object.class);
+      } catch (JacksonException e) {
+        throw new InvalidJsonException(e);
+      }
+    }
+
+    @Override
+    public Object parse(InputStream jsonStream, String charset) throws InvalidJsonException {
+      try {
+        return jsonMapper.readValue(new InputStreamReader(jsonStream, charset), Object.class);
+      } catch (JacksonException | UnsupportedEncodingException e) {
+        throw new InvalidJsonException(e);
+      }
+    }
+
+    @Override
+    public String toJson(Object obj) {
+      StringWriter writer = new StringWriter();
+      try {
+        JsonGenerator generator = jsonMapper.createGenerator(writer);
+        jsonMapper.writeValue(generator, obj);
+        writer.flush();
+        writer.close();
+        generator.close();
+        return writer.getBuffer().toString();
+      } catch (IOException | JacksonException e) {
+        throw new InvalidJsonException(e);
+      }
+    }
+
+    @Override
+    public Object createArray() {
+      return new LinkedList<>();
+    }
+
+    @Override
+    public Object createMap() {
+      return new LinkedHashMap<>();
+    }
+  }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonMergeHelper.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonMergeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Thomas Akehurst
+ * Copyright (C) 2024-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,13 @@
  */
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.jknack.handlebars.Options;
 import com.github.jknack.handlebars.TagType;
 import com.github.tomakehurst.wiremock.common.Json;
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Map;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 class JsonMergeHelper extends HandlebarsHelper<Object> {
 
@@ -64,12 +63,11 @@ class JsonMergeHelper extends HandlebarsHelper<Object> {
         options.hash.containsKey("removeNulls") && (boolean) options.hash.get("removeNulls");
 
     merge((ObjectNode) baseJson, (ObjectNode) jsonToMerge, removeNulls);
-    return Json.getObjectMapper().writeValueAsString(baseJson);
+    return Json.getJsonMapper().writeValueAsString(baseJson);
   }
 
   private void merge(ObjectNode base, ObjectNode other, boolean removeNulls) {
-    for (Iterator<Map.Entry<String, JsonNode>> it = other.fields(); it.hasNext(); ) {
-      Map.Entry<String, JsonNode> child = it.next();
+    for (Map.Entry<String, JsonNode> child : other.properties()) {
       String fieldName = child.getKey();
       JsonNode childNodeToMerge = child.getValue();
       if (childNodeToMerge instanceof ObjectNode) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelper.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 Thomas Akehurst
+ * Copyright (C) 2021-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.github.jknack.handlebars.Options;
 import com.github.jknack.handlebars.TagType;
 import com.github.tomakehurst.wiremock.common.Json;
@@ -23,6 +22,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.core.type.TypeReference;
 
 public class ParseJsonHelper extends HandlebarsHelper<Object> {
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDate.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 Thomas Akehurst
+ * Copyright (C) 2018-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,18 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.util.ISO8601Utils;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Locale;
 import java.util.TimeZone;
 
 public class RenderableDate extends Date {
   private static final long DIVIDE_MILLISECONDS_TO_SECONDS = 1000L;
+  private static final TimeZone TIMEZONE_UTC = TimeZone.getTimeZone("UTC");
 
   private final String format;
   private final ZoneId timezone;
@@ -59,8 +62,8 @@ public class RenderableDate extends Date {
     }
 
     return timezone != null
-        ? ISO8601Utils.format(this, false, TimeZone.getTimeZone(timezone))
-        : ISO8601Utils.format(this, false);
+        ? format(this, false, TimeZone.getTimeZone(timezone), Locale.US)
+        : format(this, false, TIMEZONE_UTC, Locale.US);
   }
 
   private String formatCustom() {
@@ -69,5 +72,47 @@ public class RenderableDate extends Date {
 
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
     return formatter.format(zonedDateTime);
+  }
+
+  /**
+   * Originally copied from <a
+   * href="https://github.com/FasterXML/jackson-databind/blob/b02bf81563a9382cfb163b2e6d43872ca5a07d45/src/main/java/com/fasterxml/jackson/databind/util/ISO8601Utils.java#L58-L98">Jackson
+   * Databind 2</a>.
+   *
+   * <p>Format date into yyyy-MM-ddThh:mm:ss[.sss][Z|[+-]hh:mm]
+   *
+   * @param date the date to format
+   * @param millis true to include millis precision otherwise false
+   * @param tz timezone to use for the formatting (UTC will produce 'Z')
+   * @return the date formatted as yyyy-MM-ddThh:mm:ss[.sss][Z|[+-]hh:mm]
+   */
+  private static String format(Date date, boolean millis, TimeZone tz, Locale loc) {
+    Calendar calendar = new GregorianCalendar(tz, loc);
+    calendar.setTime(date);
+
+    // estimate capacity of buffer as close as we can (yeah, that's pedantic ;)
+    StringBuilder sb = new StringBuilder(30);
+    sb.append(
+        String.format(
+            "%04d-%02d-%02dT%02d:%02d:%02d",
+            calendar.get(Calendar.YEAR),
+            calendar.get(Calendar.MONTH) + 1,
+            calendar.get(Calendar.DAY_OF_MONTH),
+            calendar.get(Calendar.HOUR_OF_DAY),
+            calendar.get(Calendar.MINUTE),
+            calendar.get(Calendar.SECOND)));
+    if (millis) {
+      sb.append(String.format(".%03d", calendar.get(Calendar.MILLISECOND)));
+    }
+
+    int offset = tz.getOffset(calendar.getTimeInMillis());
+    if (offset != 0) {
+      int hours = Math.abs((offset / (60 * 1000)) / 60);
+      int minutes = Math.abs((offset / (60 * 1000)) % 60);
+      sb.append(String.format("%c%02d:%02d", (offset < 0 ? '-' : '+'), hours, minutes));
+    } else {
+      sb.append('Z');
+    }
+    return sb.toString();
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2025 Thomas Akehurst
+ * Copyright (C) 2015-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@ import static com.github.tomakehurst.wiremock.common.Encoding.decodeBase64;
 import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
 import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.NullNode;
 import com.github.tomakehurst.wiremock.common.ContentTypes;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Strings;
 import java.util.Arrays;
 import java.util.Objects;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.NullNode;
 
 public class Body {
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2025 Thomas Akehurst
+ * Copyright (C) 2011-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@ package com.github.tomakehurst.wiremock.http;
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 import static java.util.Arrays.asList;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
@@ -27,6 +25,8 @@ import com.google.common.collect.MultimapBuilder;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(using = HttpHeadersJsonSerializer.class)
 @JsonDeserialize(using = HttpHeadersJsonDeserializer.class)

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeadersJsonSerializer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeadersJsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2025 Thomas Akehurst
+ * Copyright (C) 2012-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,20 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-public class HttpHeadersJsonSerializer extends JsonSerializer<HttpHeaders> {
+public class HttpHeadersJsonSerializer extends ValueSerializer<HttpHeaders> {
 
   @Override
-  public void serialize(HttpHeaders headers, JsonGenerator jgen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(HttpHeaders headers, JsonGenerator jgen, SerializationContext provider) {
     jgen.writeStartObject();
     for (HttpHeader header : headers.all()) {
       if (header.isSingleValued()) {
-        jgen.writeStringField(header.key(), header.firstValue());
+        jgen.writeStringProperty(header.key(), header.firstValue());
       } else {
-        jgen.writeArrayFieldStart(header.key());
+        jgen.writeArrayPropertyStart(header.key());
         for (String value : header.values()) {
           jgen.writeString(value);
         }
@@ -41,7 +39,7 @@ public class HttpHeadersJsonSerializer extends JsonSerializer<HttpHeaders> {
   }
 
   @Override
-  public boolean isEmpty(SerializerProvider provider, HttpHeaders value) {
+  public boolean isEmpty(SerializationContext provider, HttpHeaders value) {
     return value.size() == 0;
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2025 Thomas Akehurst
+ * Copyright (C) 2011-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,12 @@
 package com.github.tomakehurst.wiremock.http;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.MultiRequestMethodPattern;
 import com.github.tomakehurst.wiremock.matching.NamedValueMatcher;
-
 import java.util.*;
 import java.util.stream.Collectors;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(using = RequestMethodJsonDeserializer.class)
 public class RequestMethod implements NamedValueMatcher<RequestMethod> {
@@ -39,7 +38,8 @@ public class RequestMethod implements NamedValueMatcher<RequestMethod> {
   public static final RequestMethod GET_OR_HEAD = isOneOf(GET, HEAD);
   public static final RequestMethod QUERY = new RequestMethod("QUERY");
 
-  private static final List<RequestMethod> METHODS_WITH_ENTITY = Arrays.asList(PUT, PATCH, POST, QUERY);
+  private static final List<RequestMethod> METHODS_WITH_ENTITY =
+      Arrays.asList(PUT, PATCH, POST, QUERY);
 
   private final String name;
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2025 Thomas Akehurst
+ * Copyright (C) 2011-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.Json;
@@ -36,6 +35,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import org.jspecify.annotations.NonNull;
+import tools.jackson.databind.JsonNode;
 
 @JsonInclude(Include.NON_NULL)
 public class ResponseDefinition {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/ContentPattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/ContentPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package com.github.tomakehurst.wiremock.matching;
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.checkNotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Objects;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(using = ContentPatternDeserialiser.class)
 public abstract class ContentPattern<T> implements NamedValueMatcher<T> {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/ContentPatternDeserialiser.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/ContentPatternDeserialiser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,17 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
-public class ContentPatternDeserialiser extends JsonDeserializer<ContentPattern<?>> {
+public class ContentPatternDeserialiser extends ValueDeserializer<ContentPattern<?>> {
 
   @Override
   public ContentPattern<?> deserialize(JsonParser parser, DeserializationContext context)
-      throws IOException, JsonProcessingException {
+      throws JacksonException {
     JsonNode rootNode = parser.readValueAsTree();
 
     if (rootNode.has("binaryEqualTo")) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToJsonPattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToJsonPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.github.tomakehurst.wiremock.matching;
 import static com.github.tomakehurst.wiremock.stubbing.SubEvent.JSON_ERROR;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.JsonException;
 import com.github.tomakehurst.wiremock.stubbing.SubEvent;
@@ -28,6 +27,7 @@ import net.javacrumbs.jsonunit.core.internal.Diff;
 import net.javacrumbs.jsonunit.core.listener.Difference;
 import net.javacrumbs.jsonunit.core.listener.DifferenceContext;
 import net.javacrumbs.jsonunit.core.listener.DifferenceListener;
+import tools.jackson.databind.JsonNode;
 
 public class EqualToJsonPattern extends StringValuePattern {
 
@@ -151,7 +151,7 @@ public class EqualToJsonPattern extends StringValuePattern {
   }
 
   private static int deepSize(Object nodeObj) {
-    JsonNode jsonNode = Json.getObjectMapper().convertValue(nodeObj, JsonNode.class);
+    JsonNode jsonNode = Json.getJsonMapper().convertValue(nodeObj, JsonNode.class);
     return Json.deepSize(jsonNode);
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/ExactMatchMultiValuePattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/ExactMatchMultiValuePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Thomas Akehurst
+ * Copyright (C) 2023-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package com.github.tomakehurst.wiremock.matching;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.tomakehurst.wiremock.http.MultiValue;
 import java.util.List;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as = ExactMatchMultiValuePattern.class)
 public class ExactMatchMultiValuePattern extends MultipleMatchMultiValuePattern {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/IncludesMatchMultiValuePattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/IncludesMatchMultiValuePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Thomas Akehurst
+ * Copyright (C) 2023-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package com.github.tomakehurst.wiremock.matching;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as = IncludesMatchMultiValuePattern.class)
 public class IncludesMatchMultiValuePattern extends MultipleMatchMultiValuePattern {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/JsonPathPatternJsonSerializer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/JsonPathPatternJsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,20 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.util.NameTransformer;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.util.NameTransformer;
 
 public class JsonPathPatternJsonSerializer
     extends PathPatternJsonSerializer<MatchesJsonPathPattern> {
 
   @Override
-  public JsonSerializer<MatchesJsonPathPattern> unwrappingSerializer(NameTransformer unwrapper) {
+  public ValueSerializer<MatchesJsonPathPattern> unwrappingSerializer(NameTransformer unwrapper) {
     return new UnwrappedJsonPathPatternJsonSerializer();
   }
 
   @Override
   protected void serializeAdditionalFields(
-      MatchesJsonPathPattern value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {}
+      MatchesJsonPathPattern value, JsonGenerator gen, SerializationContext serializers) {}
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ import static com.github.tomakehurst.wiremock.common.RequestCache.Key.keyFor;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
 import com.github.tomakehurst.wiremock.common.RequestCache;
@@ -33,6 +31,8 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(using = JsonPathPatternJsonSerializer.class)
 public class MatchesJsonPathPattern extends PathPattern {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonN
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
 import com.github.tomakehurst.wiremock.common.xml.*;
 import com.github.tomakehurst.wiremock.stubbing.SubEvent;
 import java.util.*;
 import java.util.stream.Collectors;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize(using = XPathPatternJsonSerializer.class)
 public class MatchesXPathPattern extends PathPattern {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/MultiValuePattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/MultiValuePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@ package com.github.tomakehurst.wiremock.matching;
 
 import static java.util.Collections.min;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.http.MultiValue;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(using = MultiValuePatternDeserializer.class)
 public abstract class MultiValuePattern implements NamedValueMatcher<MultiValue> {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/MultiValuePatternDeserializer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/MultiValuePatternDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Thomas Akehurst
+ * Copyright (C) 2023-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,26 +15,22 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
-public class MultiValuePatternDeserializer extends JsonDeserializer<MultiValuePattern> {
+public class MultiValuePatternDeserializer extends ValueDeserializer<MultiValuePattern> {
 
   @Override
-  public MultiValuePattern deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException {
+  public MultiValuePattern deserialize(JsonParser parser, DeserializationContext ctxt) {
     JsonNode rootNode = parser.readValueAsTree();
-    final ObjectMapper mapper = (ObjectMapper) parser.getCodec();
     if (rootNode.has(ExactMatchMultiValuePattern.JSON_KEY)) {
-      return mapper.treeToValue(rootNode, ExactMatchMultiValuePattern.class);
+      return ctxt.readTreeAsValue(rootNode, ExactMatchMultiValuePattern.class);
     } else if (rootNode.has(IncludesMatchMultiValuePattern.JSON_KEY)) {
-      return mapper.treeToValue(rootNode, IncludesMatchMultiValuePattern.class);
+      return ctxt.readTreeAsValue(rootNode, IncludesMatchMultiValuePattern.class);
     } else {
-      return mapper.treeToValue(rootNode, SingleMatchMultiValuePattern.class);
+      return ctxt.readTreeAsValue(rootNode, SingleMatchMultiValuePattern.class);
     }
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/PathPatternJsonSerializer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/PathPatternJsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,34 +15,32 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.ser.BeanSerializerFactory;
 
-public abstract class PathPatternJsonSerializer<T extends PathPattern> extends JsonSerializer<T> {
+public abstract class PathPatternJsonSerializer<T extends PathPattern> extends ValueSerializer<T> {
 
   @Override
-  public void serialize(T value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+  public void serialize(T value, JsonGenerator gen, SerializationContext serializers) {
     gen.writeStartObject();
     this.serializePathPattern(value, gen, serializers);
     gen.writeEndObject();
   }
 
-  protected void serializePathPattern(T value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+  protected void serializePathPattern(
+      T value, JsonGenerator gen, SerializationContext serializers) {
     if (value.isSimple()) {
-      gen.writeStringField(value.getName(), value.getExpected());
+      gen.writeStringProperty(value.getName(), value.getExpected());
     } else {
       AdvancedPathPattern advancedPathPattern =
           new AdvancedPathPattern(value.getExpected(), value.getValuePattern());
-      gen.writeFieldName(value.getName());
+      gen.writeName(value.getName());
 
       JavaType javaType = serializers.getConfig().constructType(advancedPathPattern.getClass());
-      JsonSerializer<Object> serializer =
+      ValueSerializer<Object> serializer =
           BeanSerializerFactory.instance.createSerializer(serializers, javaType);
       serializer.serialize(advancedPathPattern, gen, serializers);
     }
@@ -50,5 +48,5 @@ public abstract class PathPatternJsonSerializer<T extends PathPattern> extends J
   }
 
   protected abstract void serializeAdditionalFields(
-      T value, JsonGenerator gen, SerializerProvider serializers) throws IOException;
+      T value, JsonGenerator gen, SerializationContext serializers);
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/SingleMatchMultiValuePattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/SingleMatchMultiValuePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Thomas Akehurst
+ * Copyright (C) 2023-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@ import static java.util.Collections.singletonList;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.tomakehurst.wiremock.http.MultiValue;
 import java.util.List;
 import java.util.Objects;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as = SingleMatchMultiValuePattern.class)
 public class SingleMatchMultiValuePattern extends MultiValuePattern {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@ package com.github.tomakehurst.wiremock.matching;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Objects;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(using = StringValuePatternJsonDeserializer.class)
 public abstract class StringValuePattern extends ContentPattern<String> {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/UnwrappedJsonPathPatternJsonSerializer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/UnwrappedJsonPathPatternJsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Thomas Akehurst
+ * Copyright (C) 2024-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,14 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
 
 public class UnwrappedJsonPathPatternJsonSerializer extends JsonPathPatternJsonSerializer {
 
   @Override
   public void serialize(
-      MatchesJsonPathPattern value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+      MatchesJsonPathPattern value, JsonGenerator gen, SerializationContext serializers) {
     this.serializePathPattern(value, gen, serializers);
   }
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/UnwrappedXPathPatternJsonSerializer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/UnwrappedXPathPatternJsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Thomas Akehurst
+ * Copyright (C) 2024-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,14 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import java.io.IOException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
 
 public class UnwrappedXPathPatternJsonSerializer extends XPathPatternJsonSerializer {
 
   @Override
   public void serialize(
-      MatchesXPathPattern value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+      MatchesXPathPattern value, JsonGenerator gen, SerializationContext serializers) {
     this.serializePathPattern(value, gen, serializers);
   }
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/XPathPatternJsonSerializer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/XPathPatternJsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,28 +15,26 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.util.NameTransformer;
-import java.io.IOException;
 import java.util.Map;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.util.NameTransformer;
 
 public class XPathPatternJsonSerializer extends PathPatternJsonSerializer<MatchesXPathPattern> {
 
   @Override
-  public JsonSerializer<MatchesXPathPattern> unwrappingSerializer(NameTransformer unwrapper) {
+  public ValueSerializer<MatchesXPathPattern> unwrappingSerializer(NameTransformer unwrapper) {
     return new UnwrappedXPathPatternJsonSerializer();
   }
 
   @Override
   protected void serializeAdditionalFields(
-      MatchesXPathPattern value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+      MatchesXPathPattern value, JsonGenerator gen, SerializationContext serializers) {
     if (value.getXPathNamespaces() != null && !value.getXPathNamespaces().isEmpty()) {
-      gen.writeObjectFieldStart("xPathNamespaces");
+      gen.writeObjectPropertyStart("xPathNamespaces");
       for (Map.Entry<String, String> namespace : value.getXPathNamespaces().entrySet()) {
-        gen.writeStringField(namespace.getKey(), namespace.getValue());
+        gen.writeStringProperty(namespace.getKey(), namespace.getValue());
       }
       gen.writeEndObject();
     }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/Message.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/Message.java
@@ -17,19 +17,18 @@ package com.github.tomakehurst.wiremock.message;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.tomakehurst.wiremock.common.InputStreamSource;
 import com.github.tomakehurst.wiremock.common.entity.CompressionType;
 import com.github.tomakehurst.wiremock.common.entity.EncodingType;
 import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.common.entity.FormatType;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(using = Message.MessageDeserializer.class)
 public class Message {
@@ -84,9 +83,9 @@ public class Message {
     return getBodyAsString();
   }
 
-  static class MessageDeserializer extends JsonDeserializer<Message> {
+  static class MessageDeserializer extends ValueDeserializer<Message> {
     @Override
-    public Message deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    public Message deserialize(JsonParser p, DeserializationContext ctxt) {
       String text = p.getValueAsString();
       if (text == null) {
         return new Message(null);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/MessageStubMappingCollection.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/MessageStubMappingCollection.java
@@ -16,8 +16,8 @@
 package com.github.tomakehurst.wiremock.message;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonIgnoreProperties({"$schema", "meta", "uuid"})
 @JsonDeserialize()

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/MessageStubMappingOrMappings.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/MessageStubMappingOrMappings.java
@@ -16,13 +16,12 @@
 package com.github.tomakehurst.wiremock.message;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import java.io.IOException;
 import java.util.List;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 @JsonDeserialize(using = MessageStubMappingOrMappingsJsonDeserializer.class)
 public interface MessageStubMappingOrMappings {
@@ -42,8 +41,7 @@ class MessageStubMappingOrMappingsJsonDeserializer
   }
 
   @Override
-  public MessageStubMappingOrMappings deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException {
+  public MessageStubMappingOrMappings deserialize(JsonParser parser, DeserializationContext ctxt) {
     JsonNode rootNode = parser.readValueAsTree();
     Class<? extends MessageStubMappingOrMappings> clazz;
     if (rootNode.has("messageMappings")) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/SingleMessageStubMappingWrapper.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/SingleMessageStubMappingWrapper.java
@@ -19,11 +19,11 @@ import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonN
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.tomakehurst.wiremock.common.Metadata;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize()
 class SingleMessageStubMappingWrapper implements MessageStubMappingOrMappings {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/ResponseDefinitionBodyMatcher.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/ResponseDefinitionBodyMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package com.github.tomakehurst.wiremock.recording;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.tomakehurst.wiremock.common.ContentTypes;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.ValueMatcher;
 import java.util.Objects;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 // Matches the size of the body of a ResponseDefinition, for use by the Snapshot API when
 // determining if the body

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/ResponseDefinitionBodyMatcherDeserializer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/ResponseDefinitionBodyMatcherDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,18 @@
  */
 package com.github.tomakehurst.wiremock.recording;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
 public class ResponseDefinitionBodyMatcherDeserializer
-    extends JsonDeserializer<ResponseDefinitionBodyMatcher> {
+    extends ValueDeserializer<ResponseDefinitionBodyMatcher> {
   @Override
   public ResponseDefinitionBodyMatcher deserialize(
-      JsonParser parser, DeserializationContext context) throws IOException {
+      JsonParser parser, DeserializationContext context) {
     JsonNode rootNode = parser.readValueAsTree();
     return new ResponseDefinitionBodyMatcher(
         parseJsonNode(rootNode.get("textSizeThreshold")),

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
@@ -19,7 +19,6 @@ import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonN
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Metadata;
 import com.github.tomakehurst.wiremock.common.Prioritisable;
@@ -34,6 +33,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
 import org.jspecify.annotations.NonNull;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonPropertyOrder({"id", "name", "request", "newRequest", "response"})
 @JsonIgnoreProperties({

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingCollection.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package com.github.tomakehurst.wiremock.stubbing;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonIgnoreProperties({"$schema", "meta", "uuid"})
 @JsonDeserialize() // stops infinite recursion when deserializing as StubMappingOrMappings

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingOrMappings.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingOrMappings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Thomas Akehurst
+ * Copyright (C) 2025-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 package com.github.tomakehurst.wiremock.stubbing;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import java.io.IOException;
 import java.util.List;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
 @JsonDeserialize(using = StubMappingOrMappingsJsonDeserializer.class)
 public interface StubMappingOrMappings {
@@ -42,7 +42,7 @@ class StubMappingOrMappingsJsonDeserializer extends StdDeserializer<StubMappingO
 
   @Override
   public StubMappingOrMappings deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException {
+      throws JacksonException {
     JsonNode rootNode = parser.readValueAsTree();
     Class<? extends StubMappingOrMappings> clazz;
     if (rootNode.has("mappings")) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Replaces Jackson 2 support with Jackson 3 support.

Some of the currently used libraries don't support Jackson 3, so there's some extra code to replace that.
1. JsonPath doesn't provide a Jackson 3 adapter, so a custom one needed to be created.
2. junitpioneer `@JsonSource` doesn't work with Jackson 3, so it was replaced with `@MethodSource`s.
3. JSON Schema Validator needed to be updated for Jackson 3 support.

Most of the tests are passing, but there's a few failing ones.
<img width="771" height="410" alt="image" src="https://github.com/user-attachments/assets/080cca7b-2bfa-49ab-bc5d-ad14123a0f96" />

I'm not sure if or when I may be able to come back and finish this, so I'm opening it as a draft in case anybody wants to take it on to fix the outstanding tests and confirm all of the changes are correct.

## References

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->
#3254

## Submitter checklist

Leaving this incomplete, whoever picks this up to finish the work will need to fill it in.

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
