### PR TITLE
Make Uri -> java.net.URI conversion less confusing

### DIFF
--- a/wiremock-httpclient-apache5/src/main/java/com/github/tomakehurst/wiremock/http/client/apache5/ApacheBackedHttpClient.java
+++ b/wiremock-httpclient-apache5/src/main/java/com/github/tomakehurst/wiremock/http/client/apache5/ApacheBackedHttpClient.java
@@ -99,9 +99,9 @@ public class ApacheBackedHttpClient implements HttpClient {
 
   private static @NonNull URI safelyToUri(@NonNull AbsoluteUrl absoluteUrl) {
     try {
-      return absoluteUrl.toUri();
+      return absoluteUrl.toJavaUri();
     } catch (IllegalArgumentException e) {
-      return absoluteUrl.normalise().toUri();
+      return absoluteUrl.normalise().toJavaUri();
     }
   }
 

--- a/wiremock-url/wiremock-url/src/main/java/org/wiremock/url/Uri.java
+++ b/wiremock-url/wiremock-url/src/main/java/org/wiremock/url/Uri.java
@@ -167,7 +167,7 @@ public sealed interface Uri extends ParsedString permits AbsoluteUri, AbstractUr
    * @return this as a {@code java.net.URI}
    * @throws IllegalArgumentException if this is not a valid {@code java.net.URI}
    */
-  default URI toUri() throws IllegalArgumentException {
+  default URI toJavaUri() throws IllegalArgumentException {
     return URI.create(this.toString());
   }
 


### PR DESCRIPTION
`Uri.toUri()` is a confusing method name, `Uri.toJavaUri()` is much clearer.
