### PR TITLE
Improve wiremock-url performance

### DIFF
--- a/wiremock-url/wiremock-url/src/main/java/org/wiremock/url/Path.java
+++ b/wiremock-url/wiremock-url/src/main/java/org/wiremock/url/Path.java
@@ -62,7 +62,7 @@ public interface Path extends PercentEncoded<Path>, ParsedString {
    * @return {@code true} if this is a base path
    */
   default boolean isBase() {
-    return isEmpty() || getLastSegment().isEmpty();
+    return isEmpty() || toString().endsWith("/");
   }
 
   /**
@@ -126,7 +126,7 @@ public interface Path extends PercentEncoded<Path>, ParsedString {
     if (isAbsolute()) {
       return this;
     } else {
-      return parse("/" + this);
+      return PathParser.INSTANCE.construct("/" + this);
     }
   }
 
@@ -136,7 +136,7 @@ public interface Path extends PercentEncoded<Path>, ParsedString {
       return this;
     } else {
       String pathStr = toString();
-      return parse(pathStr.substring(1));
+      return PathParser.INSTANCE.construct(pathStr.substring(1));
     }
   }
 
@@ -145,7 +145,7 @@ public interface Path extends PercentEncoded<Path>, ParsedString {
     if (isBase()) {
       return this;
     } else {
-      return parse(this + "/");
+      return PathParser.INSTANCE.construct(this + "/");
     }
   }
 
@@ -155,7 +155,7 @@ public interface Path extends PercentEncoded<Path>, ParsedString {
       return this;
     } else {
       String pathStr = toString();
-      return parse(pathStr.substring(0, pathStr.length() - 1));
+      return PathParser.INSTANCE.construct(pathStr.substring(0, pathStr.length() - 1));
     }
   }
 
@@ -195,7 +195,7 @@ public interface Path extends PercentEncoded<Path>, ParsedString {
     String pathStr = toString();
     String prefixStr = prefix.toString();
     if (pathStr.startsWith(prefixStr)) {
-      return parse(pathStr.substring(prefixStr.length()));
+      return PathParser.INSTANCE.construct(pathStr.substring(prefixStr.length()));
     } else {
       return this;
     }
@@ -208,6 +208,6 @@ public interface Path extends PercentEncoded<Path>, ParsedString {
     if (toAppend.isEmpty()) {
       return this;
     }
-    return parse(this.toLeafPath().toString() + toAppend.toAbsolutePath());
+    return PathParser.INSTANCE.construct(this.toLeafPath().toString() + toAppend.toAbsolutePath());
   }
 }

--- a/wiremock-url/wiremock-url/src/main/java/org/wiremock/url/PathParser.java
+++ b/wiremock-url/wiremock-url/src/main/java/org/wiremock/url/PathParser.java
@@ -47,6 +47,16 @@ public final class PathParser implements PercentEncodedStringParser<Path> {
     }
   }
 
+  Path construct(String stringForm) {
+    if (stringForm.isEmpty()) {
+      return Path.EMPTY;
+    } else if (stringForm.equals("/")) {
+      return Path.ROOT;
+    } else {
+      return new PathValue(stringForm);
+    }
+  }
+
   private static final boolean[] charactersToLeaveAsIs = include('/');
 
   static final boolean[] pathCharSet = combine(pcharCharSet, charactersToLeaveAsIs);

--- a/wiremock-url/wiremock-url/src/main/java/org/wiremock/url/PathValue.java
+++ b/wiremock-url/wiremock-url/src/main/java/org/wiremock/url/PathValue.java
@@ -182,7 +182,8 @@ final class PathValue implements Path {
       if (lastIndexOfSlash == -1) {
         result = other;
       } else {
-        result = PathParser.INSTANCE.parse(this.path.substring(0, lastIndexOfSlash + 1) + other);
+        result =
+            PathParser.INSTANCE.construct(this.path.substring(0, lastIndexOfSlash + 1) + other);
       }
     }
     return result.normalise();


### PR DESCRIPTION
* Skip building path segments just to check if it ends with a `/`
* Stop validating path strings that must already be valid as they were taken from a valid path
