### PR TITLE
Add captureAllHeaders option for recording request headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ scripts/client-cert.*
 notes.txt
 
 .kotlin/
+.java-version

--- a/README.md
+++ b/README.md
@@ -71,6 +71,84 @@ Key features include:
 
 Full documentation can be found at [wiremock.org/docs](https://wiremock.org/docs).
 
+## Recording with Capture All Headers
+
+When recording API traffic, WireMock can capture all request headers using the `captureAllHeaders` option.
+By default, only headers explicitly specified in `captureHeaders` are recorded.
+
+### JSON API
+
+```json
+{
+  "targetBaseUrl": "http://example.com",
+  "captureAllHeaders": true,
+  "persist": true
+}
+```
+
+**Example:**
+
+```bash
+# Start recording with all headers captured
+curl -X POST http://localhost:8080/__admin/recordings/start \
+  -H "Content-Type: application/json" \
+  -d '{
+    "targetBaseUrl": "http://example.com",
+    "captureAllHeaders": true
+  }'
+
+# Make requests through WireMock proxy...
+
+# Stop recording
+curl -X POST http://localhost:8080/__admin/recordings/stop
+```
+
+### Java DSL
+
+```java
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+// Capture all headers
+WireMock.startRecording(
+    recordSpec()
+        .forTarget("http://example.com")
+        .captureAllHeaders()
+        .build()
+);
+
+// Capture all headers with specific header settings (e.g., case-insensitive)
+WireMock.startRecording(
+    recordSpec()
+        .forTarget("http://example.com")
+        .captureAllHeaders()
+        .captureHeader("Authorization", true)  // case-insensitive matching
+        .build()
+);
+```
+
+### Result
+
+When `captureAllHeaders` is `true`, the generated stub mapping includes all request headers:
+
+```json
+{
+  "request": {
+    "url": "/api/users",
+    "method": "GET",
+    "headers": {
+      "Accept": { "equalTo": "application/json" },
+      "Authorization": { "equalTo": "Bearer token123" },
+      "X-Request-Id": { "equalTo": "abc-123" },
+      "User-Agent": { "equalTo": "curl/8.0" }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "..."
+  }
+}
+```
+
 ## Questions and Issues
 
 If you have a question about WireMock, or are experiencing a problem you're not sure is a bug please post a message to the

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/RequestPatternTransformerTest.java
@@ -78,4 +78,66 @@ public class RequestPatternTransformerTest {
     assertEquals(
         expected.build(), new RequestPatternTransformer(headers, null).apply(request).build());
   }
+
+  @Test
+  public void applyWithCaptureAllHeaders() {
+    Request request =
+        mockRequest()
+            .url("/")
+            .method(RequestMethod.POST)
+            .header("Content-Type", "application/json")
+            .header("Accept", "text/plain")
+            .header("X-Custom", "value");
+
+    RequestPatternBuilder expected =
+        new RequestPatternBuilder(RequestMethod.POST, urlEqualTo("/"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withHeader("Accept", equalTo("text/plain"))
+            .withHeader("X-Custom", equalTo("value"));
+
+    assertEquals(
+        expected.build(),
+        new RequestPatternTransformer(null, true, null).apply(request).build());
+  }
+
+  @Test
+  public void applyWithCaptureAllHeadersAndSpecificHeaderSettings() {
+    Request request =
+        mockRequest()
+            .url("/")
+            .method(RequestMethod.POST)
+            .header("Content-Type", "application/json")
+            .header("Accept", "TEXT/PLAIN")
+            .header("X-Custom", "Value");
+
+    Map<String, CaptureHeadersSpec> headers =
+        Map.of("Accept", new CaptureHeadersSpec(true));
+
+    RequestPatternBuilder expected =
+        new RequestPatternBuilder(RequestMethod.POST, urlEqualTo("/"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withHeader("Accept", equalToIgnoreCase("TEXT/PLAIN"))
+            .withHeader("X-Custom", equalTo("Value"));
+
+    assertEquals(
+        expected.build(),
+        new RequestPatternTransformer(headers, true, null).apply(request).build());
+  }
+
+  @Test
+  public void applyWithCaptureAllHeadersFalse() {
+    Request request =
+        mockRequest()
+            .url("/")
+            .method(RequestMethod.GET)
+            .header("Content-Type", "application/json")
+            .header("Accept", "text/plain");
+
+    RequestPatternBuilder expected =
+        new RequestPatternBuilder(RequestMethod.GET, urlEqualTo("/"));
+
+    assertEquals(
+        expected.build(),
+        new RequestPatternTransformer(null, false, null).apply(request).build());
+  }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpec.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpec.java
@@ -35,6 +35,9 @@ public class RecordSpec {
   // matcher
   private final Map<String, CaptureHeadersSpec> captureHeaders;
 
+  // Whether to capture all headers from the request
+  private final Boolean captureAllHeaders;
+
   // Factory for the StringValuePattern that will be used to match request bodies
   private final RequestBodyPatternFactory requestBodyPatternFactory;
 
@@ -61,6 +64,7 @@ public class RecordSpec {
       @JsonProperty("targetBaseUrl") String targetBaseUrl,
       @JsonProperty("filters") ProxiedServeEventFilters filters,
       @JsonProperty("captureHeaders") Map<String, CaptureHeadersSpec> captureHeaders,
+      @JsonProperty("captureAllHeaders") Boolean captureAllHeaders,
       @JsonProperty("requestBodyPattern") RequestBodyPatternFactory requestBodyPatternFactory,
       @JsonProperty("extractBodyCriteria") ResponseDefinitionBodyMatcher extractBodyCriteria,
       @JsonProperty("outputFormat") SnapshotOutputFormatter outputFormat,
@@ -71,6 +75,7 @@ public class RecordSpec {
     this.targetBaseUrl = targetBaseUrl;
     this.filters = filters == null ? ProxiedServeEventFilters.ALLOW_ALL : filters;
     this.captureHeaders = captureHeaders;
+    this.captureAllHeaders = captureAllHeaders;
     this.requestBodyPatternFactory =
         requestBodyPatternFactory == null
             ? RequestBodyAutomaticPatternFactory.DEFAULTS
@@ -84,13 +89,14 @@ public class RecordSpec {
   }
 
   private RecordSpec() {
-    this(null, null, null, null, null, null, null, null, null, null);
+    this(null, null, null, null, null, null, null, null, null, null, null);
   }
 
   public static final RecordSpec DEFAULTS = new RecordSpec();
 
   public static RecordSpec forBaseUrl(String targetBaseUrl) {
-    return new RecordSpec(targetBaseUrl, null, null, null, null, null, null, true, null, null);
+    return new RecordSpec(
+        targetBaseUrl, null, null, null, null, null, null, null, true, null, null);
   }
 
   public String getTargetBaseUrl() {
@@ -103,6 +109,15 @@ public class RecordSpec {
 
   public Map<String, CaptureHeadersSpec> getCaptureHeaders() {
     return captureHeaders;
+  }
+
+  public Boolean getCaptureAllHeaders() {
+    return captureAllHeaders;
+  }
+
+  @JsonIgnore
+  public boolean shouldCaptureAllHeaders() {
+    return captureAllHeaders != null && captureAllHeaders;
   }
 
   public SnapshotOutputFormatter getOutputFormat() {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpecBuilder.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpecBuilder.java
@@ -31,6 +31,7 @@ public class RecordSpecBuilder {
   private RequestPatternBuilder filterRequestPatternBuilder;
   private List<UUID> filterIds;
   private final Map<String, CaptureHeadersSpec> headers = new LinkedHashMap<>();
+  private boolean captureAllHeaders = false;
   private RequestBodyPatternFactory requestBodyPatternFactory;
   private long maxTextBodySize = ResponseDefinitionBodyMatcher.DEFAULT_MAX_TEXT_SIZE;
   private long maxBinaryBodySize = ResponseDefinitionBodyMatcher.DEFAULT_MAX_BINARY_SIZE;
@@ -98,6 +99,16 @@ public class RecordSpecBuilder {
     return this;
   }
 
+  public RecordSpecBuilder captureAllHeaders() {
+    this.captureAllHeaders = true;
+    return this;
+  }
+
+  public RecordSpecBuilder captureAllHeaders(boolean captureAllHeaders) {
+    this.captureAllHeaders = captureAllHeaders;
+    return this;
+  }
+
   public RecordSpecBuilder chooseBodyMatchTypeAutomatically() {
     return chooseBodyMatchTypeAutomatically(null, null, null);
   }
@@ -157,6 +168,7 @@ public class RecordSpecBuilder {
         targetBaseUrl,
         filters,
         headers.isEmpty() ? null : headers,
+        captureAllHeaders ? true : null,
         requestBodyPatternFactory,
         responseDefinitionBodyMatcher,
         SnapshotOutputFormatter.FULL,

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
@@ -114,6 +114,7 @@ public class Recorder {
             recordSpec.getFilters(),
             new SnapshotStubMappingGenerator(
                 recordSpec.getCaptureHeaders(),
+                recordSpec.shouldCaptureAllHeaders(),
                 recordSpec.getRequestBodyPatternFactory(),
                 recordSpec.shouldPersist()),
             getStubMappingPostProcessor(recordSpec));

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGenerator.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGenerator.java
@@ -44,10 +44,11 @@ class SnapshotStubMappingGenerator implements Function<ServeEvent, StubMapping> 
 
   SnapshotStubMappingGenerator(
       Map<String, CaptureHeadersSpec> captureHeaders,
+      boolean captureAllHeaders,
       RequestBodyPatternFactory requestBodyPatternFactory,
       boolean markStubsPersistent) {
     this(
-        new RequestPatternTransformer(captureHeaders, requestBodyPatternFactory),
+        new RequestPatternTransformer(captureHeaders, captureAllHeaders, requestBodyPatternFactory),
         new LoggedResponseDefinitionTransformer(),
         markStubsPersistent);
   }

--- a/wiremock-core/src/main/resources/swagger/examples/record-spec.yaml
+++ b/wiremock-core/src/main/resources/swagger/examples/record-spec.yaml
@@ -6,6 +6,7 @@ captureHeaders:
   Accept: {}
   Content-Type:
     caseInsensitive: true
+captureAllHeaders: false
 requestBodyPattern:
   matcher: equalToJson
   ignoreArrayOrder: false

--- a/wiremock-core/src/main/resources/swagger/examples/snapshot-spec.yaml
+++ b/wiremock-core/src/main/resources/swagger/examples/snapshot-spec.yaml
@@ -7,6 +7,7 @@ captureHeaders:
   Accept: {}
   Content-Type:
     caseInsensitive: true
+captureAllHeaders: false
 requestBodyPattern:
   matcher: equalToJson
   ignoreArrayOrder: false

--- a/wiremock-core/src/main/resources/swagger/schemas/record-spec.yaml
+++ b/wiremock-core/src/main/resources/swagger/schemas/record-spec.yaml
@@ -13,6 +13,10 @@ properties:
       Accept: {}
       Content-Type:
         caseInsensitive: true
+  captureAllHeaders:
+    type: boolean
+    default: false
+    description: When true, all headers from the request will be captured in the generated stub mappings. When false (default), only headers specified in captureHeaders will be captured
   extractBodyCriteria:
     type: object
     description: Criteria for extracting response bodies to a separate file instead of including it in the stub mapping


### PR DESCRIPTION
- Add captureAllHeaders field to RecordSpec (default: false)
- Add captureAllHeaders() method to RecordSpecBuilder for Java DSL
- Update RequestPatternTransformer to capture all headers when enabled
- Update Swagger/YAML schema files
- Add unit tests for captureAllHeaders functionality
- Update README with usage examples for JSON API and Java DSL