### PR TITLE
Fix the jsonPath helper to write extracted arrays in JSON format

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,9 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 public class HandlebarsJsonPathHelperTest extends HandlebarsHelperTestBase {
 
@@ -59,6 +62,91 @@ public class HandlebarsJsonPathHelperTest extends HandlebarsHelperTestBase {
             aResponse().withBody("{\"test\": \"{{jsonPath request.body '$.a.test'}}\"}"));
 
     assertThat(responseDefinition.getBody(), is("{\"test\": \"success\"}"));
+  }
+
+  @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
+  public void mergesAnObjectValueFromRequestIntoResponseBody() {
+    final ResponseDefinition responseDefinition =
+        transform(
+            transformer,
+            mockRequest().url("/json").body("{\"a\": {\"test\": \"success\"}}"),
+            aResponse().withBody("{\"check\": {{jsonPath request.body '$.a'}} }"));
+
+    assertThat(responseDefinition.getBody(), is("{\"check\": {\n  \"test\" : \"success\"\n} }"));
+  }
+
+  @Test
+  @EnabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
+  public void mergesAnObjectValueFromRequestIntoResponseBodyWindows() {
+    final ResponseDefinition responseDefinition =
+        transform(
+            transformer,
+            mockRequest().url("/json").body("{\"a\": {\"test\": \"success\"}}"),
+            aResponse().withBody("{\"check\": {{jsonPath request.body '$.a'}} }"));
+
+    assertThat(
+        responseDefinition.getBody(), is("{\"check\": {\r\n  \"test\" : \"success\"\r\n} }"));
+  }
+
+  @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
+  public void mergesAnArrayValueFromRequestIntoResponseBody() {
+    final ResponseDefinition responseDefinition =
+        transform(
+            transformer,
+            mockRequest()
+                .url("/json")
+                .body(
+                    "{\n"
+                        + "    \"items\": [\n"
+                        + "        {\n"
+                        + "            \"name\": \"One\"\n"
+                        + "        },\n"
+                        + "        {\n"
+                        + "            \"name\": \"Two\"\n"
+                        + "        },\n"
+                        + "        {\n"
+                        + "            \"name\": \"Three\"\n"
+                        + "        }\n"
+                        + "    ]\n"
+                        + "}"),
+            aResponse().withBody("{\"test\": {{jsonPath request.body '$.items'}} }"));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is(
+            "{\"test\": [ {\n  \"name\" : \"One\"\n}, {\n  \"name\" : \"Two\"\n}, {\n  \"name\" : \"Three\"\n} ] }"));
+  }
+
+  @Test
+  @EnabledOnOs(value = OS.WINDOWS, disabledReason = "Wrap differs per OS")
+  public void mergesAnArrayValueFromRequestIntoResponseBodyWindows() {
+    final ResponseDefinition responseDefinition =
+        transform(
+            transformer,
+            mockRequest()
+                .url("/json")
+                .body(
+                    "{\n"
+                        + "    \"items\": [\n"
+                        + "        {\n"
+                        + "            \"name\": \"One\"\n"
+                        + "        },\n"
+                        + "        {\n"
+                        + "            \"name\": \"Two\"\n"
+                        + "        },\n"
+                        + "        {\n"
+                        + "            \"name\": \"Three\"\n"
+                        + "        }\n"
+                        + "    ]\n"
+                        + "}"),
+            aResponse().withBody("{\"test\": {{jsonPath request.body '$.items'}} }"));
+
+    assertThat(
+        responseDefinition.getBody(),
+        is(
+            "{\"test\": [ {\r\n  \"name\" : \"One\"\r\n}, {\r\n  \"name\" : \"Two\"\r\n}, {\r\n  \"name\" : \"Three\"\r\n} ] }"));
   }
 
   @Test

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonData.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/JsonData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 Thomas Akehurst
+ * Copyright (C) 2018-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -229,7 +229,7 @@ public abstract class JsonData<T> {
 
     @Override
     protected String toJsonString() {
-      return String.valueOf(data);
+      return Json.write(data);
     }
   }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Previously, when the `jsonPath` helper was used to extract an array, the resulting array was written as e.g.
```
[{name=One}, {name=Two}, {name=Three}]
```
intead of in JSON format:
```json
[{"name" : "One"}, {"name" : "Two"}, {"name" : "Three"}]
```

which made it inconsistent with object extraction since it produces the actual JSON object.

This behaviour of array extraction also made it necessary to apply the `toJson` helper too to receive the array in the actual JSON format.

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
