### PR TITLE
refactor: Make buildSchema.gradle work in an included build

### DIFF
--- a/wiremock-core/buildSchema.gradle
+++ b/wiremock-core/buildSchema.gradle
@@ -15,6 +15,8 @@ buildscript {
   }
 }
 
+def schemasDir = new File(sourceSets.main.resources.sourceDirectories.singleFile, 'swagger/schemas')
+
 /**
  * Replaces refs as follows:
  * <ul>
@@ -22,7 +24,8 @@ buildscript {
  *   <li>{@code "$ref": "date-time-elements.yaml#/format"} -> {@code "$ref": "#/definitions/format"}</li>
  * </ul>
  */
-private def replaceFileRefs(JsonNode node) {
+def replaceFileRefs
+replaceFileRefs = { JsonNode node ->
   if (node instanceof ObjectNode) {
     def nodeAsObject = (ObjectNode) node
     final def ref = nodeAsObject["\$ref"]?.asText()
@@ -32,7 +35,7 @@ private def replaceFileRefs(JsonNode node) {
       }
       //date-time-elements.yaml is handled explicitly because it contains multiple standalone schemas
       else if (ref.startsWith("date-time-elements.yaml#/")) {
-        nodeAsObject.put("\$ref", "#/definitions/${removePrefix(ref, "date-time-elements.yaml#/")}")
+        nodeAsObject.put("\$ref", "#/definitions/${ref.substring("date-time-elements.yaml#/".length())}")
       }
     } else {
       for (child in nodeAsObject) {
@@ -47,11 +50,7 @@ private def replaceFileRefs(JsonNode node) {
   }
 }
 
-private static String removePrefix(String input, String prefix) {
-  return input.substring(prefix.length())
-}
-
-private JsonNode readSchema(ObjectMapper objectMapper, File file) {
+def readSchema = { ObjectMapper objectMapper, File file ->
   def node = objectMapper.readTree(file)
   replaceFileRefs(node)
   return node
@@ -86,7 +85,7 @@ private JsonNode readSchema(ObjectMapper objectMapper, File file) {
  * }
  * </pre>
  */
-private String doBuildStubMappingSchema() {
+def doBuildStubMappingSchema = {
   def jsonMapper = new ObjectMapper()
   def document = jsonMapper.createObjectNode()
   document.put("title", "WireMock stub mapping")
@@ -98,7 +97,7 @@ private String doBuildStubMappingSchema() {
   def yamlMapper = new ObjectMapper(YAMLFactory.builder().build())
 
   def schemas = new ArrayList<Tuple>()
-  file('src/main/resources/swagger/schemas').listFiles().toList().sort { it.name }.each { file ->
+  schemasDir.listFiles().toList().sort { it.name }.each { file ->
     def name = file.name - ".yaml"
     def schema = readSchema(yamlMapper, file)
 
@@ -126,7 +125,7 @@ private String doBuildStubMappingSchema() {
       .writeValueAsString(document)
 }
 
-private String doBuildMessageStubMappingSchema() {
+def doBuildMessageStubMappingSchema = {
   def jsonMapper = new ObjectMapper()
   def document = jsonMapper.createObjectNode()
   document.put("title", "WireMock message stub mapping")
@@ -137,7 +136,7 @@ private String doBuildMessageStubMappingSchema() {
   def yamlMapper = new ObjectMapper(YAMLFactory.builder().build())
 
   def schemas = new ArrayList<Tuple>()
-  file('src/main/resources/swagger/schemas').listFiles().toList().sort { it.name }.each { file ->
+  schemasDir.listFiles().toList().sort { it.name }.each { file ->
     def name = file.name - ".yaml"
     def schema = readSchema(yamlMapper, file)
 
@@ -165,24 +164,24 @@ private String doBuildMessageStubMappingSchema() {
 def buildStubMappingSchema = tasks.register("buildStubMappingSchema") {
   group = "build"
   outputs.dir(temporaryDir)
-  inputs.dir('src/main/resources/swagger/schemas')
+  inputs.dir(schemasDir)
 
   doLast {
-    def schemasDir = new File(temporaryDir, "schemas")
-    schemasDir.mkdir()
-    new File(schemasDir, "wiremock-stub-mapping.json").write(doBuildStubMappingSchema())
+    def outDir = new File(temporaryDir, "schemas")
+    outDir.mkdir()
+    new File(outDir, "wiremock-stub-mapping.json").write(doBuildStubMappingSchema())
   }
 }
 
 def buildMessageStubMappingSchema = tasks.register("buildMessageStubMappingSchema") {
   group = "build"
   outputs.dir(temporaryDir)
-  inputs.dir('src/main/resources/swagger/schemas')
+  inputs.dir(schemasDir)
 
   doLast {
-    def schemasDir = new File(temporaryDir, "schemas")
-    schemasDir.mkdir()
-    new File(schemasDir, "wiremock-message-stub-mapping.json").write(doBuildMessageStubMappingSchema())
+    def outDir = new File(temporaryDir, "schemas")
+    outDir.mkdir()
+    new File(outDir, "wiremock-message-stub-mapping.json").write(doBuildMessageStubMappingSchema())
   }
 }
 


### PR DESCRIPTION
It only worked when run directly previously.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
