### PR TITLE
fix: Bugs in new saving mechanism

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/core/MappingsSaverTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/core/MappingsSaverTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.core;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class MappingsSaverTest {
+
+  private final MappingsSaver saver = mock();
+
+  {
+    doCallRealMethod().when(saver).mutate(any(), any());
+    doCallRealMethod().when(saver).remove(any(List.class));
+  }
+
+  @Test
+  void defaultMutateDoesNotCallSaveWhenSaveListIsEmpty() {
+    saver.mutate(List.of(), List.of(UUID.randomUUID()));
+
+    verify(saver, never()).save(any(List.class));
+  }
+
+  @Test
+  void defaultMutateDoesNotCallRemoveWhenRemoveListIsEmpty() {
+    StubMapping stub = get("/test").willReturn(ok()).build();
+
+    saver.mutate(List.of(stub), List.of());
+
+    verify(saver, never()).remove(any(UUID.class));
+  }
+
+  @Test
+  void defaultMutateCallsSaveAndRemoveWhenBothListsAreNonEmpty() {
+    StubMapping stub = get("/test").willReturn(ok()).build();
+    UUID id = UUID.randomUUID();
+
+    saver.mutate(List.of(stub), List.of(id));
+
+    verify(saver).save(List.of(stub));
+    verify(saver).remove(id);
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/SaveMappingsAtomicityTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/SaveMappingsAtomicityTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.stubbing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.standalone.MappingsSource;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+
+class SaveMappingsAtomicityTest {
+
+  private final MappingsSource mappingsSource = mock();
+
+  @RegisterExtension
+  WireMockExtension wm =
+      WireMockExtension.newInstance()
+          .options(wireMockConfig().mappingSource(mappingsSource).dynamicPort())
+          .build();
+
+  @Test
+  void saveMappingsSavesAllStubsInSingleMutateCall() {
+    wm.stubFor(get("/one").willReturn(ok("one")));
+    wm.stubFor(get("/two").willReturn(ok("two")));
+    wm.stubFor(get("/three").willReturn(ok("three")));
+
+    wm.saveMappings();
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<StubMapping>> saveCaptor = ArgumentCaptor.forClass(List.class);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<java.util.UUID>> removeCaptor = ArgumentCaptor.forClass(List.class);
+
+    verify(mappingsSource).mutate(saveCaptor.capture(), removeCaptor.capture());
+    verify(mappingsSource, never()).save(any(StubMapping.class));
+
+    List<StubMapping> savedStubs = saveCaptor.getValue();
+    assertEquals(3, savedStubs.size());
+    assertTrue(savedStubs.stream().allMatch(StubMapping::shouldBePersisted));
+    assertTrue(removeCaptor.getValue().isEmpty());
+  }
+
+  @Test
+  void saveMappingsMarksAllStubsAsPersistent() {
+    wm.stubFor(get("/not-persistent").willReturn(ok()));
+
+    wm.saveMappings();
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<StubMapping>> saveCaptor = ArgumentCaptor.forClass(List.class);
+
+    verify(mappingsSource).mutate(saveCaptor.capture(), any());
+
+    List<StubMapping> savedStubs = saveCaptor.getValue();
+    assertEquals(1, savedStubs.size());
+    assertTrue(savedStubs.get(0).shouldBePersisted());
+  }
+}

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/MappingsSaver.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/MappingsSaver.java
@@ -55,7 +55,11 @@ public interface MappingsSaver {
   }
 
   default void mutate(List<StubMapping> toSave, List<UUID> toRemove) {
-    save(toSave);
-    remove(toRemove);
+    if (!toSave.isEmpty()) {
+      save(toSave);
+    }
+    if (!toRemove.isEmpty()) {
+      remove(toRemove);
+    }
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -376,9 +376,11 @@ public class WireMockApp implements StubServer, Admin {
 
   @Override
   public void saveMappings() {
+    List<StubMapping> allPersistent = new ArrayList<>();
     for (StubMapping stubMapping : stubMappings.getAll()) {
-      stubMappings.editMapping(stubMapping.transform(b -> b.setPersistent(true)));
+      allPersistent.add(stubMapping.transform(b -> b.setPersistent(true)));
     }
+    stubMappings.updateMappings(allPersistent, List.of());
   }
 
   @Override


### PR DESCRIPTION
* [WireMockApp.saveMappings saves all mappings atomically](https://github.com/wiremock/wiremock/commit/75e80aafcb7067b564bb3c2c119958bc1125f5e7)
* [MappingsSaver default mutate does not make unnecessary calls](https://github.com/wiremock/wiremock/commit/eb1ebd1d983bf54d190b5302553fdbc5e39aac4d)

## References

Fixes bugs introduced by
https://github.com/wiremock/wiremock/pull/3379

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
