### PR TITLE
Remove need for breaking change MappingsSaver.mutate

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/StubImportAlternativeAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubImportAlternativeAcceptanceTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2026 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.common.ListFunctions.indexBy;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.*;
+
+import com.github.tomakehurst.wiremock.extension.StubLifecycleListener;
+import com.github.tomakehurst.wiremock.extension.StubLifecycleListener.AlteredStubMapping;
+import com.github.tomakehurst.wiremock.extension.StubLifecycleListener.StubMappingToAlter;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.standalone.MappingsSource;
+import com.github.tomakehurst.wiremock.stubbing.StubImport;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+
+class StubImportAlternativeAcceptanceTest {
+
+  private final MappingsSource mappingsSource = mock();
+  private final StubLifecycleListener lifecycleListener =
+      mock(StubLifecycleListener.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+
+  @RegisterExtension
+  WireMockExtension wmExt =
+      WireMockExtension.newInstance()
+          .options(
+              wireMockConfig()
+                  .mappingSource(mappingsSource)
+                  .extensions(lifecycleListener)
+                  .dynamicPort())
+          .configureStaticDsl(false)
+          .build();
+
+  static Stream<Arguments> duplicatePolicyAndDeleteCombinations() {
+    return Stream.of(
+        Arguments.of(
+            StubImport.Options.DuplicatePolicy.OVERWRITE,
+            true,
+            List.of(
+                "Created Persistent 7",
+                "Created Transient 8",
+                "Created Persistent 9",
+                "Created Transient 10",
+                "Edited Transient 5",
+                "Edited Persistent 4",
+                "Edited Transient 2",
+                "Edited Persistent 1"),
+            List.of(
+                "Created Persistent 7",
+                "Created Persistent 9",
+                "Edited Persistent 4",
+                "Edited Persistent 1"),
+            List.of(
+                "edit:Persistent 1->Edited Persistent 1",
+                "edit:Persistent 2->Edited Transient 2",
+                "edit:Transient 4->Edited Persistent 4",
+                "edit:Transient 5->Edited Transient 5",
+                "create:Created Persistent 7",
+                "create:Created Transient 8",
+                "create:Created Persistent 9",
+                "create:Created Transient 10",
+                "remove:Persistent 3",
+                "remove:Transient 6")),
+        Arguments.of(
+            StubImport.Options.DuplicatePolicy.OVERWRITE,
+            false,
+            List.of(
+                "Created Persistent 7",
+                "Created Transient 8",
+                "Created Persistent 9",
+                "Created Transient 10",
+                "Transient 6",
+                "Edited Transient 5",
+                "Edited Persistent 4",
+                "Persistent 3",
+                "Edited Transient 2",
+                "Edited Persistent 1"),
+            List.of(
+                "Created Persistent 7",
+                "Created Persistent 9",
+                "Edited Persistent 4",
+                "Edited Persistent 1"),
+            List.of(
+                "edit:Persistent 1->Edited Persistent 1",
+                "edit:Persistent 2->Edited Transient 2",
+                "edit:Transient 4->Edited Persistent 4",
+                "edit:Transient 5->Edited Transient 5",
+                "create:Created Persistent 7",
+                "create:Created Transient 8",
+                "create:Created Persistent 9",
+                "create:Created Transient 10")),
+        Arguments.of(
+            StubImport.Options.DuplicatePolicy.IGNORE,
+            true,
+            List.of(
+                "Created Persistent 7",
+                "Created Transient 8",
+                "Created Persistent 9",
+                "Created Transient 10",
+                "Transient 5",
+                "Transient 4",
+                "Persistent 2",
+                "Persistent 1"),
+            List.of("Created Persistent 7", "Created Persistent 9", "Persistent 2", "Persistent 1"),
+            List.of(
+                "create:Created Persistent 7",
+                "create:Created Transient 8",
+                "create:Created Persistent 9",
+                "create:Created Transient 10",
+                "remove:Persistent 3",
+                "remove:Transient 6")),
+        Arguments.of(
+            StubImport.Options.DuplicatePolicy.IGNORE,
+            false,
+            List.of(
+                "Created Persistent 7",
+                "Created Transient 8",
+                "Created Persistent 9",
+                "Created Transient 10",
+                "Transient 6",
+                "Transient 5",
+                "Transient 4",
+                "Persistent 3",
+                "Persistent 2",
+                "Persistent 1"),
+            List.of("Created Persistent 7", "Created Persistent 9"),
+            List.of(
+                "create:Created Persistent 7",
+                "create:Created Transient 8",
+                "create:Created Persistent 9",
+                "create:Created Transient 10")));
+  }
+
+  @ParameterizedTest
+  @MethodSource("duplicatePolicyAndDeleteCombinations")
+  void importWithPersistentAndTransientStubs(
+      StubImport.Options.DuplicatePolicy duplicatePolicy,
+      boolean deleteAllNotInImport,
+      List<String> expectedStubNames,
+      List<String> expectedSavedNames,
+      List<String> expectedAlterations) {
+
+    // given
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
+    UUID id3 = UUID.randomUUID();
+    UUID id4 = UUID.randomUUID();
+    UUID id5 = UUID.randomUUID();
+    UUID id6 = UUID.randomUUID();
+    UUID id7 = UUID.randomUUID();
+    UUID id8 = UUID.randomUUID();
+
+    wmExt.addStubMapping(getStubMapping("/1", id1, true, "Persistent 1"));
+    wmExt.addStubMapping(getStubMapping("/2", id2, true, "Persistent 2"));
+    wmExt.addStubMapping(getStubMapping("/3", id3, true, "Persistent 3"));
+    wmExt.addStubMapping(getStubMapping("/4", id4, false, "Transient 4"));
+    wmExt.addStubMapping(getStubMapping("/5", id5, false, "Transient 5"));
+    wmExt.addStubMapping(getStubMapping("/6", id6, false, "Transient 6"));
+
+    // expect
+    assertSameNames(
+        wmExt.listAllStubMappings().getMappings(),
+        List.of(
+            "Transient 6",
+            "Transient 5",
+            "Transient 4",
+            "Persistent 3",
+            "Persistent 2",
+            "Persistent 1"));
+
+    clearInvocations(mappingsSource);
+    clearInvocations(lifecycleListener);
+
+    // when
+    List<StubMapping> importStubs =
+        new ArrayList<>(
+            List.of(
+                getStubMapping("/1-import", id1, true, "Edited Persistent 1"),
+                getStubMapping("/2-import", id2, false, "Edited Transient 2"),
+                getStubMapping("/4-import", id4, true, "Edited Persistent 4"),
+                getStubMapping("/5-import", id5, false, "Edited Transient 5")));
+    Collections.shuffle(importStubs);
+    importStubs.addAll(
+        List.of(
+            getStubMapping("/7-import", id7, true, "Created Persistent 7"),
+            getStubMapping("/8-import", id8, false, "Created Transient 8"),
+            getStubMapping("/9-import", id7, true, "Created Persistent 9"),
+            getStubMapping("/10-import", id8, false, "Created Transient 10")));
+
+    wmExt.importStubs(
+        new StubImport(importStubs, new StubImport.Options(duplicatePolicy, deleteAllNotInImport)));
+
+    // then
+    List<StubMapping> stubsAfterImport = wmExt.listAllStubMappings().getMappings();
+    assertSameNames(stubsAfterImport, expectedStubNames);
+
+    Map<String, StubMapping> stubsAfterImportByName =
+        indexBy(stubsAfterImport, StubMapping::getName);
+    List<StubMapping> expectedSavedStubs =
+        expectedSavedNames.stream().map(stubsAfterImportByName::get).toList();
+
+    // and
+    if (deleteAllNotInImport) {
+      verify(mappingsSource).setAll(expectedSavedStubs);
+    } else {
+      verify(mappingsSource).save(expectedSavedStubs);
+    }
+    verifyNoMoreInteractions(mappingsSource);
+
+    // and the lifecycle listener was called with the same alterations before and after
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<StubMappingToAlter>> beforeCaptor = ArgumentCaptor.forClass(List.class);
+    verify(lifecycleListener).beforeStubsAltered(beforeCaptor.capture());
+    assertThat(
+        describeAlterations(beforeCaptor.getValue()),
+        containsInAnyOrder(expectedAlterations.toArray()));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<AlteredStubMapping>> afterCaptor = ArgumentCaptor.forClass(List.class);
+    verify(lifecycleListener).afterStubsAltered(afterCaptor.capture());
+    assertThat(
+        describeAlterations(afterCaptor.getValue()),
+        containsInAnyOrder(expectedAlterations.toArray()));
+  }
+
+  private static StubMapping getStubMapping(String url, UUID id1, boolean persistent, String name) {
+    return get(url).withId(id1).persistent(persistent).withName(name).willReturn(ok()).build();
+  }
+
+  private static void assertSameNames(
+      List<StubMapping> resultStubs, List<String> expectedStubNames) {
+    List<String> resultNames = resultStubs.stream().map(StubMapping::getName).toList();
+
+    assertThat(resultNames, is(expectedStubNames));
+  }
+
+  private static List<String> describeAlterations(List<?> alterations) {
+    return alterations.stream()
+        .map(
+            alteration -> {
+              if (alteration instanceof StubLifecycleListener.CreatedStubMapping created) {
+                return "create:" + created.getStub().getName();
+              } else if (alteration instanceof StubLifecycleListener.EditedStubMapping edited) {
+                return "edit:"
+                    + edited.getOldStub().getName()
+                    + "->"
+                    + edited.getNewStub().getName();
+              } else if (alteration instanceof StubLifecycleListener.RemovedStubMapping removed) {
+                return "remove:" + removed.getStub().getName();
+              }
+              throw new IllegalArgumentException("Unknown alteration type: " + alteration);
+            })
+        .toList();
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/MappingsSaveRollbackTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/MappingsSaveRollbackTest.java
@@ -90,9 +90,7 @@ class MappingsSaveRollbackTest {
     wm.addStubMapping(stub1);
     wm.addStubMapping(stub2);
 
-    doThrow(new RuntimeException("delete failed"))
-        .when(mappingsSource)
-        .mutate(any(List.class), any(List.class));
+    doThrow(new RuntimeException("delete failed")).when(mappingsSource).remove(any(List.class));
 
     assertThrows(RuntimeException.class, () -> wm.removeStubMappings(List.of(stub1, stub2)));
 
@@ -102,9 +100,7 @@ class MappingsSaveRollbackTest {
 
   @Test
   void rollsBackImportWhenSaveFails() {
-    doThrow(new RuntimeException("save failed"))
-        .when(mappingsSource)
-        .mutate(any(List.class), any(List.class));
+    doThrow(new RuntimeException("save failed")).when(mappingsSource).save(any(List.class));
 
     StubMapping stub = get("/imported").persistent(true).willReturn(ok()).build();
 
@@ -120,9 +116,7 @@ class MappingsSaveRollbackTest {
     StubMapping existing = get("/existing").persistent(true).willReturn(ok()).build();
     wm.addStubMapping(existing);
 
-    doThrow(new RuntimeException("save failed"))
-        .when(mappingsSource)
-        .mutate(any(List.class), any(List.class));
+    doThrow(new RuntimeException("save failed")).when(mappingsSource).setAll(any(List.class));
 
     StubMapping imported = post("/imported").persistent(true).willReturn(ok()).build();
 

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/RemoveStubMappingsByMetadataPersistenceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/RemoveStubMappingsByMetadataPersistenceTest.java
@@ -23,7 +23,6 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -91,7 +90,7 @@ class RemoveStubMappingsByMetadataPersistenceTest {
     clearInvocations(mappingsSource);
 
     wm.removeStubMappingsByMetadata(equalToJson("{ \"key1\": \"value1\" }"));
-    verify(mappingsSource, times(1)).mutate(eq(List.of()), removedCaptor.capture());
+    verify(mappingsSource, times(1)).remove(removedCaptor.capture());
     verifyNoMoreInteractions(mappingsSource);
 
     List<UUID> removedStubIds = removedCaptor.getValue();
@@ -137,7 +136,7 @@ class RemoveStubMappingsByMetadataPersistenceTest {
     wm.removeStubMappingsByMetadata(equalToJson("{ \"key1\": \"value1\" }"));
 
     assertThat(wm.listAllStubMappings().getMappings(), containsInAnyOrder(stub2, stub3, stub4));
-    verify(mappingsSource, times(1)).mutate(List.of(), List.of(stub1.getId()));
+    verify(mappingsSource, times(1)).remove(List.of(stub1.getId()));
 
     clearInvocations(mappingsSource);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/RemoveStubMappingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/RemoveStubMappingsTest.java
@@ -143,8 +143,7 @@ class RemoveStubMappingsTest {
               get("/whatever").withId(existingStub1.getId()).build(),
               get("/whatever").withId(existingStub2.getId()).build()));
 
-      verify(mappingsSource)
-          .mutate(List.of(), List.of(existingStub1.getId(), existingStub2.getId()));
+      verify(mappingsSource).remove(List.of(existingStub1.getId(), existingStub2.getId()));
       verifyNoMoreInteractions(mappingsSource);
       clearInvocations(mappingsSource);
 
@@ -176,8 +175,7 @@ class RemoveStubMappingsTest {
 
       wireMockServer.removeStubMappings(List.of(get("/").build(), post("/create").build()));
 
-      verify(mappingsSource)
-          .mutate(List.of(), List.of(existingStub1.getId(), existingStub2.getId()));
+      verify(mappingsSource).remove(List.of(existingStub1.getId(), existingStub2.getId()));
       verifyNoMoreInteractions(mappingsSource);
       clearInvocations(mappingsSource);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/RemoveStubsPersistenceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/RemoveStubsPersistenceTest.java
@@ -86,7 +86,7 @@ class RemoveStubsPersistenceTest {
             get("/stub-4").withId(UUID.randomUUID()).build(),
             get("/whatever").withId(stub2.getId()).build());
     wm.removeStubMappings(stubsToRemove);
-    verify(mappingsSource, times(1)).mutate(List.of(), List.of(stub1.getId(), stub4.getId()));
+    verify(mappingsSource, times(1)).remove(List.of(stub1.getId(), stub4.getId()));
     verifyNoMoreInteractions(mappingsSource);
   }
 
@@ -125,7 +125,7 @@ class RemoveStubsPersistenceTest {
     wm.removeStubMappings(List.of(stub1));
 
     assertThat(wm.listAllStubMappings().getMappings(), containsInAnyOrder(stub2, stub3, stub4));
-    verify(mappingsSource, times(1)).mutate(List.of(), List.of(stub1.getId()));
+    verify(mappingsSource, times(1)).remove(List.of(stub1.getId()));
 
     clearInvocations(mappingsSource);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/SaveMappingsAtomicityTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/SaveMappingsAtomicityTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.stubbing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.standalone.MappingsSource;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+
+class SaveMappingsAtomicityTest {
+
+  private final MappingsSource mappingsSource = mock();
+
+  @RegisterExtension
+  WireMockExtension wm =
+      WireMockExtension.newInstance()
+          .options(wireMockConfig().mappingSource(mappingsSource).dynamicPort())
+          .build();
+
+  @Test
+  void saveMappingsSavesAllStubsInSingleMutateCall() {
+    wm.stubFor(get("/one").willReturn(ok("one")));
+    wm.stubFor(get("/two").willReturn(ok("two")));
+    wm.stubFor(get("/three").willReturn(ok("three")));
+
+    wm.saveMappings();
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<StubMapping>> saveCaptor = ArgumentCaptor.forClass(List.class);
+    verify(mappingsSource).setAll(saveCaptor.capture());
+    verify(mappingsSource, never()).save(any(StubMapping.class));
+
+    List<StubMapping> savedStubs = saveCaptor.getValue();
+    assertEquals(3, savedStubs.size());
+    assertTrue(savedStubs.stream().allMatch(StubMapping::shouldBePersisted));
+  }
+
+  @Test
+  void saveMappingsMarksAllStubsAsPersistent() {
+    wm.stubFor(get("/not-persistent").willReturn(ok()));
+
+    wm.saveMappings();
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<StubMapping>> saveCaptor = ArgumentCaptor.forClass(List.class);
+
+    verify(mappingsSource).setAll(saveCaptor.capture());
+
+    List<StubMapping> savedStubs = saveCaptor.getValue();
+    assertEquals(1, savedStubs.size());
+    assertTrue(savedStubs.get(0).shouldBePersisted());
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubImportPersistenceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubImportPersistenceTest.java
@@ -69,7 +69,7 @@ class StubImportPersistenceTest {
     wm.importStubs(
         new StubImport(newStubs, new StubImport.Options(DuplicatePolicy.OVERWRITE, false)));
     verify(mappingsSource, times(1))
-        .mutate(List.of(newStubs.get(3), newStubs.get(2), newStubs.get(0)), List.of());
+        .save(List.of(newStubs.get(0), newStubs.get(2), newStubs.get(3)));
     verifyNoMoreInteractions(mappingsSource);
   }
 
@@ -93,17 +93,15 @@ class StubImportPersistenceTest {
                 .persistent(true)
                 .build());
     wm.importStubs(new StubImport(newStubs, new StubImport.Options(DuplicatePolicy.IGNORE, false)));
-    verify(mappingsSource, times(1)).mutate(List.of(newStubs.get(2), newStubs.get(0)), List.of());
+    verify(mappingsSource, times(1)).save(List.of(newStubs.get(0), newStubs.get(2)));
     verifyNoMoreInteractions(mappingsSource);
   }
 
   @Test
-  void savesAndRemovesStubsWhenImportingMultipleStubsAndRemovingNonImportedStubs() {
-    StubMapping existingStub1 = get("/existing/stub").persistent(true).willReturn(ok()).build();
-    StubMapping existingStub2 =
-        put("/another/existing/stub").persistent(true).willReturn(noContent()).build();
-    wm.addStubMapping(existingStub1);
-    wm.addStubMapping(existingStub2);
+  void setsAllStubsTogetherWhenImportingMultipleStubsAndRemovingNonImportedStubs() {
+    wm.addStubMapping(get("/existing/stub").persistent(true).willReturn(ok()).build());
+    wm.addStubMapping(
+        put("/another/existing/stub").persistent(true).willReturn(noContent()).build());
 
     clearInvocations(mappingsSource);
 
@@ -116,19 +114,15 @@ class StubImportPersistenceTest {
     wm.importStubs(
         new StubImport(newStubs, new StubImport.Options(DuplicatePolicy.OVERWRITE, true)));
     verify(mappingsSource, times(1))
-        .mutate(
-            List.of(newStubs.get(3), newStubs.get(2), newStubs.get(0)),
-            List.of(existingStub2.getId(), existingStub1.getId()));
+        .setAll(List.of(newStubs.get(0), newStubs.get(2), newStubs.get(3)));
     verifyNoMoreInteractions(mappingsSource);
   }
 
   @Test
   void removesAllPersistedStubsWhenNoImportedStubsAreSetToPersistAndNonImportedStubsAreDeleted() {
-    StubMapping existingStub1 = get("/existing/stub").persistent(true).willReturn(ok()).build();
-    StubMapping existingStub2 =
-        put("/another/existing/stub").persistent(true).willReturn(noContent()).build();
-    wm.addStubMapping(existingStub1);
-    wm.addStubMapping(existingStub2);
+    wm.addStubMapping(get("/existing/stub").persistent(true).willReturn(ok()).build());
+    wm.addStubMapping(
+        put("/another/existing/stub").persistent(true).willReturn(noContent()).build());
 
     clearInvocations(mappingsSource);
 
@@ -138,8 +132,7 @@ class StubImportPersistenceTest {
             get("/do/not/persist").willReturn(ok()).persistent(false).build());
     wm.importStubs(
         new StubImport(newStubs, new StubImport.Options(DuplicatePolicy.OVERWRITE, true)));
-    verify(mappingsSource, times(1))
-        .mutate(List.of(), List.of(existingStub2.getId(), existingStub1.getId()));
+    verify(mappingsSource, times(1)).setAll(List.of());
     verifyNoMoreInteractions(mappingsSource);
   }
 
@@ -147,7 +140,7 @@ class StubImportPersistenceTest {
   void savesNothingWhenNoStubsAreSetToPersist() {
     StubMapping existingStub = get("/existing/stub").persistent(true).willReturn(ok()).build();
     wm.importStubs(new StubImport(List.of(existingStub), StubImport.Options.DEFAULTS));
-    verify(mappingsSource, times(1)).mutate(List.of(existingStub), List.of());
+    verify(mappingsSource, times(1)).save(List.of(existingStub));
 
     clearInvocations(mappingsSource);
 
@@ -162,7 +155,7 @@ class StubImportPersistenceTest {
   @Test
   void keepsIgnoredStubsWhenAllOtherNonImportedStubsAreDeleted() {
     StubMapping existingStub1 = wm.stubFor(get("/1").persistent().willReturn(ok()));
-    StubMapping existingStub2 = wm.stubFor(get("/2").persistent().willReturn(ok()));
+    wm.stubFor(get("/2").persistent().willReturn(ok()));
 
     clearInvocations(mappingsSource);
     var newStub2 = post("/three").persistent().willReturn(ok()).build();
@@ -173,7 +166,7 @@ class StubImportPersistenceTest {
             .ignoreExisting()
             .deleteAllExistingStubsNotInImport()
             .build());
-    verify(mappingsSource, times(1)).mutate(List.of(newStub2), List.of(existingStub2.getId()));
+    verify(mappingsSource, times(1)).setAll(List.of(newStub2, existingStub1));
     verifyNoMoreInteractions(mappingsSource);
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/ListFunctions.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/ListFunctions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 Thomas Akehurst
+ * Copyright (C) 2020-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,12 @@
 package com.github.tomakehurst.wiremock.common;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jspecify.annotations.NonNull;
 
 public final class ListFunctions {
 
@@ -38,6 +41,13 @@ public final class ListFunctions {
   @SafeVarargs
   public static <T> List<T> concatenate(List<T>... lists) {
     return Stream.of(lists).flatMap(List::stream).collect(Collectors.toList());
+  }
+
+  public static <K, V> @NonNull LinkedHashMap<K, V> indexBy(
+      @NonNull List<V> items, @NonNull Function<V, K> keyFunction) {
+    return items.stream()
+        .collect(
+            Collectors.toMap(keyFunction, Function.identity(), (a, b) -> a, LinkedHashMap::new));
   }
 
   private ListFunctions() {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/MappingsSaver.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/MappingsSaver.java
@@ -53,9 +53,4 @@ public interface MappingsSaver {
     removeAll();
     save(stubMappings);
   }
-
-  default void mutate(List<StubMapping> toSave, List<UUID> toRemove) {
-    save(toSave);
-    remove(toRemove);
-  }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -15,7 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.core;
 
+import static com.github.tomakehurst.wiremock.common.ListFunctions.indexBy;
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
+import static com.github.tomakehurst.wiremock.stubbing.StubImport.Options.DuplicatePolicy.OVERWRITE;
+import static java.util.stream.Collectors.toSet;
 
 import com.github.tomakehurst.wiremock.admin.AdminRoutes;
 import com.github.tomakehurst.wiremock.admin.LimitAndOffsetPaginator;
@@ -376,9 +379,11 @@ public class WireMockApp implements StubServer, Admin {
 
   @Override
   public void saveMappings() {
-    for (StubMapping stubMapping : stubMappings.getAll()) {
-      stubMappings.editMapping(stubMapping.transform(b -> b.setPersistent(true)));
-    }
+    List<StubMapping> allPersistent =
+        stubMappings.getAll().stream()
+            .map(stubMapping -> stubMapping.transform(b -> b.setPersistent(true)))
+            .toList();
+    stubMappings.setAllMappings(allPersistent);
   }
 
   @Override
@@ -599,7 +604,7 @@ public class WireMockApp implements StubServer, Admin {
     return requestJournal.getAllServeEvents().stream()
         .filter(event -> event.getStubMapping() != null)
         .map(event -> event.getStubMapping().getId())
-        .collect(Collectors.toSet());
+        .collect(toSet());
   }
 
   @Override
@@ -629,33 +634,34 @@ public class WireMockApp implements StubServer, Admin {
 
   @Override
   public void importStubs(StubImport stubImport) {
-    List<StubMapping> mappings = stubImport.getMappings();
+    List<StubMapping> mappingsToImport = stubImport.getMappings();
     StubImport.Options importOptions =
         getFirstNonNull(stubImport.getImportOptions(), StubImport.Options.DEFAULTS);
 
-    List<StubMapping> mappingsToInsert = new ArrayList<>();
-    for (int i = mappings.size() - 1; i >= 0; i--) {
-      StubMapping mapping = mappings.get(i);
-      if (getStubMapping(mapping.getId()).isPresent()) {
-        if (importOptions.getDuplicatePolicy() == StubImport.Options.DuplicatePolicy.OVERWRITE) {
-          mappingsToInsert.add(mapping);
+    Map<UUID, StubMapping> existing = indexBy(stubMappings.getAll(), StubMapping::getId);
+
+    boolean settingAllMappings = importOptions.getDeleteAllNotInImport() == true;
+
+    List<StubMapping> inputToStubMappings = new ArrayList<>(mappingsToImport.size());
+    if (importOptions.getDuplicatePolicy() == OVERWRITE) {
+      inputToStubMappings.addAll(mappingsToImport);
+    } else {
+      for (StubMapping mapping : mappingsToImport) {
+        var existingMapping = existing.get(mapping.getId());
+        if (existingMapping == null) {
+          inputToStubMappings.add(mapping);
+        } else if (settingAllMappings) {
+          inputToStubMappings.add(existingMapping);
         }
-      } else {
-        mappingsToInsert.add(mapping);
       }
     }
 
-    if (importOptions.getDeleteAllNotInImport()) {
-      Set<UUID> ids = mappings.stream().map(StubMapping::getId).collect(Collectors.toSet());
-      List<StubMapping> mappingsToRemove = new ArrayList<>();
-      for (StubMapping mapping : listAllStubMappings().getMappings()) {
-        if (!ids.contains(mapping.getId())) {
-          mappingsToRemove.add(mapping);
-        }
-      }
-      stubMappings.updateMappings(mappingsToInsert, mappingsToRemove);
+    Collections.reverse(inputToStubMappings);
+
+    if (settingAllMappings) {
+      stubMappings.setAllMappings(inputToStubMappings);
     } else {
-      stubMappings.updateMappings(mappingsToInsert, List.of());
+      stubMappings.updateMappings(inputToStubMappings);
     }
   }
 
@@ -670,7 +676,7 @@ public class WireMockApp implements StubServer, Admin {
                 })
             .toList();
     if (!toRemove.isEmpty()) {
-      this.stubMappings.updateMappings(List.of(), toRemove);
+      this.stubMappings.removeMappings(toRemove);
     }
   }
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StoreBackedStubMappings.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StoreBackedStubMappings.java
@@ -248,7 +248,7 @@ public class StoreBackedStubMappings implements StubMappings {
 
     afterStubsAltered(toAlterStubs);
 
-    return List.of();
+    return toRemove;
   }
 
   @Override

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StoreBackedStubMappings.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StoreBackedStubMappings.java
@@ -20,6 +20,7 @@ import static com.github.tomakehurst.wiremock.common.Pair.pair;
 import static com.github.tomakehurst.wiremock.extension.ServeEventListener.RequestPhase.AFTER_MATCH;
 import static com.github.tomakehurst.wiremock.extension.ServeEventListenerUtils.triggerListeners;
 import static com.github.tomakehurst.wiremock.http.ResponseDefinition.copyOf;
+import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toList;
 
 import com.github.tomakehurst.wiremock.admin.NotFoundException;
@@ -44,7 +45,10 @@ import com.github.tomakehurst.wiremock.store.StubMappingStore;
 import com.github.tomakehurst.wiremock.store.files.BlobStoreFileSource;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 
 public class StoreBackedStubMappings implements StubMappings {
@@ -229,6 +233,25 @@ public class StoreBackedStubMappings implements StubMappings {
   }
 
   @Override
+  public List<StubMapping> removeMappings(List<StubMapping> toRemove) {
+    List<StubMappingToAlter> toAlterStubs =
+        toRemove.stream().<StubMappingToAlter>map(RemoveStubMapping::new).toList();
+
+    beforeStubsAltered(toAlterStubs);
+
+    remove(toRemove.stream().filter(StubMapping::shouldBePersisted).toList());
+
+    for (StubMapping remove : toRemove) {
+      store.remove(remove.getId());
+      scenarios.onStubMappingRemoved(remove);
+    }
+
+    afterStubsAltered(toAlterStubs);
+
+    return List.of();
+  }
+
+  @Override
   public StubMapping editMapping(StubMapping stubMapping) {
     final Optional<StubMapping> optionalExistingMapping = store.get(stubMapping.getId());
 
@@ -263,6 +286,16 @@ public class StoreBackedStubMappings implements StubMappings {
     mappingsSaver.save(stubMapping);
   }
 
+  private void save(List<StubMapping> toSave) {
+    if (!toSave.isEmpty()) {
+      mappingsSaver.save(toSave);
+    }
+  }
+
+  private void setAll(List<StubMapping> toSave) {
+    mappingsSaver.setAll(toSave);
+  }
+
   private void remove(UUID stubMappingId) {
     mappingsSaver.remove(stubMappingId);
   }
@@ -271,16 +304,28 @@ public class StoreBackedStubMappings implements StubMappings {
     mappingsSaver.removeAll();
   }
 
-  private void mutate(List<StubMapping> toSave, List<StubMapping> toRemove) {
-    List<UUID> ids =
-        toRemove.stream().filter(StubMapping::shouldBePersisted).map(StubMapping::getId).toList();
-    if (!toSave.isEmpty() || !ids.isEmpty()) {
-      mappingsSaver.mutate(toSave, ids);
+  private void remove(List<StubMapping> toRemove) {
+    if (!toRemove.isEmpty()) {
+      mappingsSaver.remove(toRemove.stream().map(StubMapping::getId).toList());
     }
   }
 
   @Override
-  public List<StubMapping> updateMappings(List<StubMapping> toInsert, List<StubMapping> toRemove) {
+  public List<StubMapping> updateMappings(List<StubMapping> toInsert) {
+    return updateMappings(toInsert, List.of(), this::save);
+  }
+
+  public List<StubMapping> setAllMappings(List<StubMapping> stubMappings) {
+    Set<UUID> ids = stubMappings.stream().map(StubMapping::getId).collect(Collectors.toSet());
+    List<StubMapping> toRemove =
+        getAll().stream().filter(mapping -> !ids.contains(mapping.getId())).toList();
+    return updateMappings(stubMappings, toRemove, this::setAll);
+  }
+
+  private @NonNull List<StubMapping> updateMappings(
+      List<StubMapping> toInsert,
+      List<StubMapping> toRemove,
+      Consumer<List<StubMapping>> persister) {
     List<StubMappingToAlter> toAlterStubs =
         Stream.concat(
                 toInsert.stream()
@@ -294,9 +339,10 @@ public class StoreBackedStubMappings implements StubMappings {
                 toRemove.stream().<StubMappingToAlter>map(RemoveStubMapping::new))
             .toList();
 
-    for (StubLifecycleListener listener : stubLifecycleListeners) {
-      listener.beforeStubsAltered(toAlterStubs);
-    }
+    List<StubMappingToAlter> toNotify =
+        toAlterStubs.stream().filter(not(StoreBackedStubMappings::isUnchanged)).toList();
+
+    beforeStubsAltered(toNotify);
 
     List<StubMapping> toSave = new ArrayList<>();
     List<StubMapping> newPersisted = new ArrayList<>();
@@ -322,8 +368,9 @@ public class StoreBackedStubMappings implements StubMappings {
 
     // The call to `store.add` returns a changed stub (adds an insertion index), so we have to
     // undo if the add fails
+    toSave.sort(Comparator.comparingLong(StubMapping::getInsertionIndex).reversed());
     try {
-      mutate(toSave, toRemove);
+      persister.accept(toSave);
     } catch (Exception e) {
       for (StubMapping add : newPersisted) {
         store.remove(add.getId());
@@ -346,12 +393,30 @@ public class StoreBackedStubMappings implements StubMappings {
       }
     }
 
-    for (StubLifecycleListener listener : stubLifecycleListeners) {
-      listener.afterStubsAltered(
-          toAlterStubs.stream().map(toAlter -> (AlteredStubMapping) toAlter).toList());
-    }
+    afterStubsAltered(toNotify);
 
     return result;
+  }
+
+  private static boolean isUnchanged(StubMappingToAlter stubMappingToAlter) {
+    return stubMappingToAlter instanceof EditStubMapping editStubMapping
+        && Objects.equals(editStubMapping.newStub, editStubMapping.oldStub)
+        && Objects.equals(editStubMapping.newStub.getName(), editStubMapping.oldStub.getName());
+  }
+
+  private void beforeStubsAltered(List<StubMappingToAlter> toAlterStubs) {
+    for (StubLifecycleListener listener : stubLifecycleListeners) {
+      listener.beforeStubsAltered(toAlterStubs);
+    }
+  }
+
+  private void afterStubsAltered(List<StubMappingToAlter> toAlterStubs) {
+    List<AlteredStubMapping> toNotifyAsAltered =
+        toAlterStubs.stream().map(toAlter -> (AlteredStubMapping) toAlter).toList();
+
+    for (StubLifecycleListener listener : stubLifecycleListeners) {
+      listener.afterStubsAltered(toNotifyAsAltered);
+    }
   }
 
   @Override

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappings.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappings.java
@@ -28,9 +28,13 @@ public interface StubMappings {
 
   StubMapping removeMapping(StubMapping mapping);
 
+  List<StubMapping> removeMappings(List<StubMapping> toRemove);
+
   StubMapping editMapping(StubMapping stubMapping);
 
-  List<StubMapping> updateMappings(List<StubMapping> toInsert, List<StubMapping> toRemove);
+  List<StubMapping> updateMappings(List<StubMapping> stubMappings);
+
+  List<StubMapping> setAllMappings(List<StubMapping> stubMappings);
 
   void reset();
 


### PR DESCRIPTION
It wasn't necessary.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
