### PR TITLE
fix: include all operands in AbstractLogicalMatcher equals/hashCode

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/matching/LogicalAndTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/LogicalAndTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Thomas Akehurst
+ * Copyright (C) 2021-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/LogicalAndTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/LogicalAndTest.java
@@ -104,6 +104,15 @@ public class LogicalAndTest {
   }
 
   @Test
+  public void objectsWithSameFirstOperandButDifferentLaterOperandsShouldNotBeEqual() {
+    LogicalAnd matcher1 = new LogicalAnd(WireMock.equalTo("A"), WireMock.equalTo("B"));
+    LogicalAnd matcher2 = new LogicalAnd(WireMock.equalTo("A"), WireMock.equalTo("C"));
+
+    assertNotEquals(matcher1, matcher2);
+    assertNotEquals(matcher1.hashCode(), matcher2.hashCode());
+  }
+
+  @Test
   void canSuccessfullyConstructWithAbsentAsFirstMatcher() {
     assertDoesNotThrow(
         () ->

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/LogicalOrTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/LogicalOrTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Thomas Akehurst
+ * Copyright (C) 2021-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/LogicalOrTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/LogicalOrTest.java
@@ -119,6 +119,15 @@ public class LogicalOrTest {
   }
 
   @Test
+  public void objectsWithSameFirstOperandButDifferentLaterOperandsShouldNotBeEqual() {
+    LogicalOr matcher1 = new LogicalOr(WireMock.equalTo("A"), WireMock.equalTo("B"));
+    LogicalOr matcher2 = new LogicalOr(WireMock.equalTo("A"), WireMock.equalTo("C"));
+
+    assertNotEquals(matcher1, matcher2);
+    assertNotEquals(matcher1.hashCode(), matcher2.hashCode());
+  }
+
+  @Test
   void correctlyEvaluatesAbsentOrDoesNotMatch() {
     LogicalOr matcher =
         new LogicalOr(

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractLogicalMatcher.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/AbstractLogicalMatcher.java
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.matching;
 import static java.util.Arrays.asList;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public abstract class AbstractLogicalMatcher extends StringValuePattern {
@@ -53,4 +54,18 @@ public abstract class AbstractLogicalMatcher extends StringValuePattern {
   }
 
   protected abstract String getOperationName();
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    AbstractLogicalMatcher that = (AbstractLogicalMatcher) o;
+    return Objects.equals(operands, that.operands);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), operands);
+  }
 }


### PR DESCRIPTION
## What

Overrides `equals()` and `hashCode()` in `AbstractLogicalMatcher` to compare the full operands list, not just the inherited `expectedValue`.

## Why

`AbstractLogicalMatcher` inherits `equals()`/`hashCode()` from `StringValuePattern`, which only compares the `expectedValue` field. The constructor passes only the **first operand's** expected value to the parent via `checkAtLeast2OperandsAndReturnFirstExpected()`.

This means two `LogicalAnd`/`LogicalOr` instances with the same first operand but different subsequent operands are incorrectly treated as equal:

```java
LogicalAnd matcher1 = new LogicalAnd(WireMock.equalTo("A"), WireMock.equalTo("B"));
LogicalAnd matcher2 = new LogicalAnd(WireMock.equalTo("A"), WireMock.equalTo("C"));

matcher1.equals(matcher2); // true — should be false
```

This causes incorrect stub deduplication when `ignoreRepeatRequests` is used with a `StubMappingTransformer` that produces logical AND/OR body patterns.

## Changes

- `AbstractLogicalMatcher.java` — override `equals()` to also compare `operands` list; override `hashCode()` to include `operands`
- `LogicalAndTest.java` — added test: same first operand, different later operands → not equal
- `LogicalOrTest.java` — added same test for `LogicalOr`

Fixes #3353

Made with [Cursor](https://cursor.com)