### PR TITLE
Recorder serve event transformer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -244,7 +244,8 @@ tasks.register("release") {
 }
 
 tasks.register("localRelease") {
-  dependsOn(tasks.clean, tasks.assemble, ":wiremock-standalone:publishToMavenLocal", tasks.publishToMavenLocal)
+  dependsOn(tasks.clean, tasks.assemble, tasks.publishToMavenLocal)
+  dependsOn(subprojects.filter { it.plugins.hasPlugin("maven-publish") }.map { "${it.path}:publishToMavenLocal" })
 }
 
 fun updateFiles(currentVersion: String, nextVersion: String) {

--- a/buildSrc/src/main/kotlin/wiremock.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/wiremock.common-conventions.gradle.kts
@@ -190,8 +190,8 @@ signing {
   val signingPassphrase = providers.environmentVariable("OSSRH_GPG_SECRET_KEY_PASSWORD").orElse("").get()
   if (signingKey.isNotEmpty() && signingPassphrase.isNotEmpty()) {
     useInMemoryPgpKeys(signingKey, signingPassphrase)
+    sign(publishing.publications)
   }
-  sign(publishing.publications)
 }
 
 publishing {

--- a/src/test/java/com/github/tomakehurst/wiremock/RecorderServeEventTransformerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecorderServeEventTransformerAcceptanceTest.java
@@ -20,13 +20,16 @@ import static com.github.tomakehurst.wiremock.common.Metadata.metadata;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.recording.SnapshotRecordResult;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import com.github.tomakehurst.wiremock.testsupport.FilteringRecorderServeEventTransformer;
 import com.github.tomakehurst.wiremock.testsupport.HeaderModifyingRecorderServeEventTransformer;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -94,7 +97,13 @@ public class RecorderServeEventTransformerAcceptanceTest extends AcceptanceTestB
     proxyingTestClient.postJson("/foo/bar", "{\"key\": \"value\"}");
 
     SnapshotRecordResult recordResult =
-        proxyingService.snapshotRecord(recordSpec().captureHeader("Content-Type"));
+        proxyingService.snapshotRecord(
+            recordSpec()
+                    .makeStubsPersistent(false)
+                    .extractBinaryBodiesOver(Long.MAX_VALUE)
+                    .extractTextBodiesOver(Long.MAX_VALUE)
+                    .captureHeader("Content-Type")
+        );
     assertThat(recordResult.getErrors(), empty());
 
     StubMapping recordedStub =
@@ -114,5 +123,39 @@ public class RecorderServeEventTransformerAcceptanceTest extends AcceptanceTestB
         recordedStub.getResponse().getHeaders().getHeader("Content-Type").firstValue(),
         is("text/plain"));
     assertThat(recordedStub.getResponse().getBody(), is("transformed response body"));
+  }
+
+  @Test
+  public void filtersOutServeEventsWhenTransformerReturnsEmpty() {
+    wireMockServer.stubFor(any(anyUrl()).willReturn(ok("response")));
+
+    proxyServerStart(
+        wireMockConfig()
+            .withRootDirectory("src/test/resources/empty")
+            .extensions(FilteringRecorderServeEventTransformer.class));
+
+    proxyingTestClient.get("/include/this");
+    proxyingTestClient.get("/exclude/this");
+    proxyingTestClient.get("/include/also");
+
+    SnapshotRecordResult recordResult =
+        proxyingService.snapshotRecord(recordSpec()
+                .makeStubsPersistent(false)
+                .extractBinaryBodiesOver(Long.MAX_VALUE)
+                .extractTextBodiesOver(Long.MAX_VALUE)
+        );
+
+    List<StubMapping> recordedStubs = recordResult.getStubMappings();
+    assertThat(recordedStubs, hasSize(2));
+
+    List<StubMapping> allStubs = proxyingService.listAllStubMappings().getMappings();
+    boolean hasExcludedStub =
+        allStubs.stream()
+            .anyMatch(
+                stub -> {
+                  String url = stub.getRequest().getUrl();
+                  return url != null && url.startsWith("/exclude");
+                });
+    assertThat(hasExcludedStub, is(false));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/RecorderServeEventTransformerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecorderServeEventTransformerAcceptanceTest.java
@@ -99,11 +99,10 @@ public class RecorderServeEventTransformerAcceptanceTest extends AcceptanceTestB
     SnapshotRecordResult recordResult =
         proxyingService.snapshotRecord(
             recordSpec()
-                    .makeStubsPersistent(false)
-                    .extractBinaryBodiesOver(Long.MAX_VALUE)
-                    .extractTextBodiesOver(Long.MAX_VALUE)
-                    .captureHeader("Content-Type")
-        );
+                .makeStubsPersistent(false)
+                .extractBinaryBodiesOver(Long.MAX_VALUE)
+                .extractTextBodiesOver(Long.MAX_VALUE)
+                .captureHeader("Content-Type"));
     assertThat(recordResult.getErrors(), empty());
 
     StubMapping recordedStub =
@@ -139,11 +138,11 @@ public class RecorderServeEventTransformerAcceptanceTest extends AcceptanceTestB
     proxyingTestClient.get("/include/also");
 
     SnapshotRecordResult recordResult =
-        proxyingService.snapshotRecord(recordSpec()
+        proxyingService.snapshotRecord(
+            recordSpec()
                 .makeStubsPersistent(false)
                 .extractBinaryBodiesOver(Long.MAX_VALUE)
-                .extractTextBodiesOver(Long.MAX_VALUE)
-        );
+                .extractTextBodiesOver(Long.MAX_VALUE));
 
     List<StubMapping> recordedStubs = recordResult.getStubMappings();
     assertThat(recordedStubs, hasSize(2));

--- a/src/test/java/com/github/tomakehurst/wiremock/RecorderServeEventTransformerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecorderServeEventTransformerAcceptanceTest.java
@@ -18,8 +18,6 @@ package com.github.tomakehurst.wiremock;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.common.Metadata.metadata;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -29,10 +27,6 @@ import com.github.tomakehurst.wiremock.recording.SnapshotRecordResult;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.HeaderModifyingRecorderServeEventTransformer;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
-import java.util.List;
-import java.util.Optional;
-
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -90,10 +84,7 @@ public class RecorderServeEventTransformerAcceptanceTest extends AcceptanceTestB
   @SuppressWarnings("unchecked")
   @Test
   public void appliesGlobalRecorderServeEventTransformerToRecordedStubs() {
-    wireMockServer.stubFor(
-        any(anyUrl())
-            .willReturn(
-                okJson("{\"original\": true}")));
+    wireMockServer.stubFor(any(anyUrl()).willReturn(okJson("{\"original\": true}")));
 
     proxyServerStart(
         wireMockConfig()
@@ -102,17 +93,26 @@ public class RecorderServeEventTransformerAcceptanceTest extends AcceptanceTestB
 
     proxyingTestClient.postJson("/foo/bar", "{\"key\": \"value\"}");
 
-    SnapshotRecordResult recordResult = proxyingService.snapshotRecord(recordSpec().captureHeader("Content-Type"));
+    SnapshotRecordResult recordResult =
+        proxyingService.snapshotRecord(recordSpec().captureHeader("Content-Type"));
     assertThat(recordResult.getErrors(), empty());
 
-    StubMapping recordedStub = proxyingService.listAllStubMappings().getMappings().stream()
+    StubMapping recordedStub =
+        proxyingService.listAllStubMappings().getMappings().stream()
             .filter(stub -> "/foo/bar".equals(stub.getRequest().getUrl()))
             .findFirst()
-            .orElseThrow(() -> new AssertionError("Expected a recorded stub to be present with URL /foo/bar"));
+            .orElseThrow(
+                () ->
+                    new AssertionError("Expected a recorded stub to be present with URL /foo/bar"));
 
-    assertThat(recordedStub.getRequest().getHeaders().get("Content-Type").getExpected(), is("text/plain"));
-    assertThat(recordedStub.getRequest().getBodyPatterns().get(0).getExpected(), is("transformed request body"));
-    assertThat(recordedStub.getResponse().getHeaders().getHeader("Content-Type").firstValue(), is("text/plain"));
+    assertThat(
+        recordedStub.getRequest().getHeaders().get("Content-Type").getExpected(), is("text/plain"));
+    assertThat(
+        recordedStub.getRequest().getBodyPatterns().get(0).getExpected(),
+        is("transformed request body"));
+    assertThat(
+        recordedStub.getResponse().getHeaders().getHeader("Content-Type").firstValue(),
+        is("text/plain"));
     assertThat(recordedStub.getResponse().getBody(), is("transformed response body"));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/RecorderServeEventTransformerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecorderServeEventTransformerAcceptanceTest.java
@@ -15,20 +15,24 @@
  */
 package com.github.tomakehurst.wiremock;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.any;
-import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.proxyAllTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.common.Metadata.metadata;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.recording.SnapshotRecordResult;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.HeaderModifyingRecorderServeEventTransformer;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import java.util.List;
+import java.util.Optional;
+
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,7 +50,6 @@ public class RecorderServeEventTransformerAcceptanceTest extends AcceptanceTestB
         proxyAllTo(proxyTargetUrl).withMetadata(metadata().attr("proxy", true)));
 
     proxyingTestClient = new WireMockTestClient(proxyingService.port());
-    wireMockServer.stubFor(any(anyUrl()).willReturn(ok()));
   }
 
   @BeforeEach
@@ -60,7 +63,7 @@ public class RecorderServeEventTransformerAcceptanceTest extends AcceptanceTestB
     proxyingService.stop();
   }
 
-  private static final String STUB_WITH_ADDED_HEADER =
+  private static final String EXPECTED_STUB =
       // language=json
       """
       {
@@ -68,12 +71,16 @@ public class RecorderServeEventTransformerAcceptanceTest extends AcceptanceTestB
               {
                   "request" : {
                       "url" : "/foo/bar",
-                      "method" : "GET"
+                      "method" : "POST",
+                      "bodyPatterns" : [
+                          { "equalTo" : "transformed request body" }
+                      ]
                   },
                   "response" : {
                       "status" : 200,
+                      "body" : "transformed response body",
                       "headers" : {
-                          "X-Custom-Header" : "transformed"
+                          "Content-Type" : "text/plain"
                       }
                   }
               }
@@ -83,24 +90,29 @@ public class RecorderServeEventTransformerAcceptanceTest extends AcceptanceTestB
   @SuppressWarnings("unchecked")
   @Test
   public void appliesGlobalRecorderServeEventTransformerToRecordedStubs() {
+    wireMockServer.stubFor(
+        any(anyUrl())
+            .willReturn(
+                okJson("{\"original\": true}")));
+
     proxyServerStart(
         wireMockConfig()
             .withRootDirectory("src/test/resources/empty")
             .extensions(HeaderModifyingRecorderServeEventTransformer.class));
 
-    proxyingTestClient.get("/foo/bar");
+    proxyingTestClient.postJson("/foo/bar", "{\"key\": \"value\"}");
 
-    String recordedStubJson =
-        proxyingTestClient.snapshot(
-            // language=json
-            """
-            {
-                "outputFormat": "full",
-                "persist": "false"
-            }""");
+    SnapshotRecordResult recordResult = proxyingService.snapshotRecord(recordSpec().captureHeader("Content-Type"));
+    assertThat(recordResult.getErrors(), empty());
 
-    assertThat(
-        recordedStubJson,
-        jsonEquals(STUB_WITH_ADDED_HEADER).withOptions(List.of(IGNORING_EXTRA_FIELDS)));
+    StubMapping recordedStub = proxyingService.listAllStubMappings().getMappings().stream()
+            .filter(stub -> "/foo/bar".equals(stub.getRequest().getUrl()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Expected a recorded stub to be present with URL /foo/bar"));
+
+    assertThat(recordedStub.getRequest().getHeaders().get("Content-Type").getExpected(), is("text/plain"));
+    assertThat(recordedStub.getRequest().getBodyPatterns().get(0).getExpected(), is("transformed request body"));
+    assertThat(recordedStub.getResponse().getHeaders().getHeader("Content-Type").firstValue(), is("text/plain"));
+    assertThat(recordedStub.getResponse().getBody(), is("transformed response body"));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/RecorderServeEventTransformerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecorderServeEventTransformerAcceptanceTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.proxyAllTo;
+import static com.github.tomakehurst.wiremock.common.Metadata.metadata;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.testsupport.HeaderModifyingRecorderServeEventTransformer;
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RecorderServeEventTransformerAcceptanceTest extends AcceptanceTestBase {
+
+  private WireMockServer proxyingService;
+  private WireMockTestClient proxyingTestClient;
+
+  private void proxyServerStart(WireMockConfiguration config) {
+    proxyingService = new WireMockServer(config.dynamicPort());
+    proxyingService.start();
+    String proxyTargetUrl = wireMockServer.getBaseUrl().toString();
+    proxyingService.stubFor(
+        proxyAllTo(proxyTargetUrl).withMetadata(metadata().attr("proxy", true)));
+
+    proxyingTestClient = new WireMockTestClient(proxyingService.port());
+    wireMockServer.stubFor(any(anyUrl()).willReturn(ok()));
+  }
+
+  @BeforeEach
+  public void clearTargetServerMappings() {
+    wireMockServer.resetMappings();
+  }
+
+  @AfterEach
+  public void proxyServerShutdown() {
+    proxyingService.resetMappings();
+    proxyingService.stop();
+  }
+
+  private static final String STUB_WITH_ADDED_HEADER =
+      // language=json
+      """
+      {
+          "mappings": [
+              {
+                  "request" : {
+                      "url" : "/foo/bar",
+                      "method" : "GET"
+                  },
+                  "response" : {
+                      "status" : 200,
+                      "headers" : {
+                          "X-Custom-Header" : "transformed"
+                      }
+                  }
+              }
+          ]
+      }""";
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void appliesGlobalRecorderServeEventTransformerToRecordedStubs() {
+    proxyServerStart(
+        wireMockConfig()
+            .withRootDirectory("src/test/resources/empty")
+            .extensions(HeaderModifyingRecorderServeEventTransformer.class));
+
+    proxyingTestClient.get("/foo/bar");
+
+    String recordedStubJson =
+        proxyingTestClient.snapshot(
+            // language=json
+            """
+            {
+                "outputFormat": "full",
+                "persist": "false"
+            }""");
+
+    assertThat(
+        recordedStubJson,
+        jsonEquals(STUB_WITH_ADDED_HEADER).withOptions(List.of(IGNORING_EXTRA_FIELDS)));
+  }
+}

--- a/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/FilteringRecorderServeEventTransformer.java
+++ b/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/FilteringRecorderServeEventTransformer.java
@@ -13,11 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.tomakehurst.wiremock.extension;
+package com.github.tomakehurst.wiremock.testsupport;
 
+import com.github.tomakehurst.wiremock.extension.RecorderServeEventTransformer;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import java.util.Optional;
 
-public interface RecorderServeEventTransformer extends Extension {
-  Optional<ServeEvent> transform(ServeEvent serveEvent);
+public class FilteringRecorderServeEventTransformer implements RecorderServeEventTransformer {
+
+  @Override
+  public Optional<ServeEvent> transform(ServeEvent serveEvent) {
+    if (serveEvent.getRequest().getUrl().startsWith("/exclude")) {
+      return Optional.empty();
+    }
+    return Optional.of(serveEvent);
+  }
+
+  @Override
+  public String getName() {
+    return "filtering-recorder-serve-event-transformer";
+  }
 }

--- a/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/HeaderModifyingRecorderServeEventTransformer.java
+++ b/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/HeaderModifyingRecorderServeEventTransformer.java
@@ -21,32 +21,34 @@ import com.github.tomakehurst.wiremock.extension.RecorderServeEventTransformer;
 import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import java.util.Optional;
 
 public class HeaderModifyingRecorderServeEventTransformer implements RecorderServeEventTransformer {
 
   @Override
-  public ServeEvent transform(ServeEvent serveEvent) {
-    return serveEvent
-        .withRequest(
-            serveEvent
-                .getRequest()
-                .transform(
-                    builder ->
-                        builder
-                            .withBody("transformed request body")
-                            .withHeaders(
-                                replaceContentType(
-                                    serveEvent.getRequest().getHeaders(), "text/plain"))))
-        .withResponse(
-            serveEvent
-                .getResponse()
-                .transform(
-                    builder ->
-                        builder
-                            .withBody("transformed response body".getBytes())
-                            .withHeaders(
-                                replaceContentType(
-                                    serveEvent.getResponse().getHeaders(), "text/plain"))));
+  public Optional<ServeEvent> transform(ServeEvent serveEvent) {
+    return Optional.of(
+        serveEvent
+            .withRequest(
+                serveEvent
+                    .getRequest()
+                    .transform(
+                        builder ->
+                            builder
+                                .withBody("transformed request body")
+                                .withHeaders(
+                                    replaceContentType(
+                                        serveEvent.getRequest().getHeaders(), "text/plain"))))
+            .withResponse(
+                serveEvent
+                    .getResponse()
+                    .transform(
+                        builder ->
+                            builder
+                                .withBody("transformed response body".getBytes())
+                                .withHeaders(
+                                    replaceContentType(
+                                        serveEvent.getResponse().getHeaders(), "text/plain")))));
   }
 
   private static HttpHeaders replaceContentType(HttpHeaders headers, String contentType) {

--- a/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/HeaderModifyingRecorderServeEventTransformer.java
+++ b/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/HeaderModifyingRecorderServeEventTransformer.java
@@ -16,27 +16,49 @@
 package com.github.tomakehurst.wiremock.testsupport;
 
 import com.github.tomakehurst.wiremock.extension.RecorderServeEventTransformer;
+import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+
+import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 
 public class HeaderModifyingRecorderServeEventTransformer implements RecorderServeEventTransformer {
 
   @Override
   public ServeEvent transform(ServeEvent serveEvent) {
-    return serveEvent.withResponse(
-        serveEvent
-            .getResponse()
-            .transform(
-                builder ->
-                    builder.withHeaders(
-                        serveEvent
-                            .getResponse()
-                            .getHeaders()
-                            .plus(new HttpHeader("X-Custom-Header", "transformed")))));
+    return serveEvent
+        .withRequest(
+            serveEvent
+                .getRequest()
+                .transform(
+                    builder ->
+                        builder
+                            .withBody("transformed request body")
+                            .withHeaders(
+                                replaceContentType(
+                                    serveEvent.getRequest().getHeaders(), "text/plain"))))
+        .withResponse(
+            serveEvent
+                .getResponse()
+                .transform(
+                    builder ->
+                        builder
+                            .withBody("transformed response body".getBytes())
+                            .withHeaders(
+                                replaceContentType(
+                                    serveEvent.getResponse().getHeaders(), "text/plain"))));
+  }
+
+  private static HttpHeaders replaceContentType(HttpHeaders headers, String contentType) {
+    return getFirstNonNull(headers, HttpHeaders.noHeaders()).transform(it -> it
+                    .remove(ContentTypeHeader.KEY)
+                    .add(ContentTypeHeader.KEY, contentType)
+    );
   }
 
   @Override
   public String getName() {
-    return "global-recorder-serve-event-transformer";
+    return "header-modifying-recorder-serve-event-transformer";
   }
 }

--- a/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/HeaderModifyingRecorderServeEventTransformer.java
+++ b/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/HeaderModifyingRecorderServeEventTransformer.java
@@ -15,13 +15,12 @@
  */
 package com.github.tomakehurst.wiremock.testsupport;
 
+import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
+
 import com.github.tomakehurst.wiremock.extension.RecorderServeEventTransformer;
 import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
-import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-
-import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 
 public class HeaderModifyingRecorderServeEventTransformer implements RecorderServeEventTransformer {
 
@@ -51,10 +50,8 @@ public class HeaderModifyingRecorderServeEventTransformer implements RecorderSer
   }
 
   private static HttpHeaders replaceContentType(HttpHeaders headers, String contentType) {
-    return getFirstNonNull(headers, HttpHeaders.noHeaders()).transform(it -> it
-                    .remove(ContentTypeHeader.KEY)
-                    .add(ContentTypeHeader.KEY, contentType)
-    );
+    return getFirstNonNull(headers, HttpHeaders.noHeaders())
+        .transform(it -> it.remove(ContentTypeHeader.KEY).add(ContentTypeHeader.KEY, contentType));
   }
 
   @Override

--- a/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/HeaderModifyingRecorderServeEventTransformer.java
+++ b/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/HeaderModifyingRecorderServeEventTransformer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.testsupport;
+
+import com.github.tomakehurst.wiremock.extension.RecorderServeEventTransformer;
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+
+public class HeaderModifyingRecorderServeEventTransformer implements RecorderServeEventTransformer {
+
+  @Override
+  public ServeEvent transform(ServeEvent serveEvent) {
+    return serveEvent.withResponse(
+        serveEvent
+            .getResponse()
+            .transform(
+                builder ->
+                    builder.withHeaders(
+                        serveEvent
+                            .getResponse()
+                            .getHeaders()
+                            .plus(new HttpHeader("X-Custom-Header", "transformed")))));
+  }
+
+  @Override
+  public String getName() {
+    return "global-recorder-serve-event-transformer";
+  }
+}

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/RecorderServeEventTransformer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/RecorderServeEventTransformer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension;
+
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+
+public interface RecorderServeEventTransformer extends Extension {
+  ServeEvent transform(ServeEvent serveEvent);
+}

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
@@ -167,6 +167,26 @@ public class LoggedResponse {
       return this;
     }
 
+    public int getStatus() {
+      return status;
+    }
+
+    public HttpHeaders getHeaders() {
+      return headers;
+    }
+
+    public byte[] getBody() {
+      return body;
+    }
+
+    public Fault getFault() {
+      return fault;
+    }
+
+    public boolean isFromProxy() {
+      return fromProxy;
+    }
+
     public LoggedResponse build() {
       return new LoggedResponse(status, headers, body, fault, fromProxy);
     }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.common.Encoding;
 import com.github.tomakehurst.wiremock.common.Limit;
 import com.github.tomakehurst.wiremock.common.Strings;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.function.Consumer;
 
 public class LoggedResponse {
@@ -137,7 +138,7 @@ public class LoggedResponse {
     public Builder(LoggedResponse original) {
       this.status = original.status;
       this.headers = original.headers;
-      this.body = original.body;
+      this.body = original.body != null ? Arrays.copyOf(original.body, original.body.length) : null;
       this.fault = original.fault;
       this.fromProxy = original.fromProxy;
     }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.common.Encoding;
 import com.github.tomakehurst.wiremock.common.Limit;
 import com.github.tomakehurst.wiremock.common.Strings;
 import java.nio.charset.Charset;
+import java.util.function.Consumer;
 
 public class LoggedResponse {
 
@@ -114,5 +115,60 @@ public class LoggedResponse {
 
   public boolean isFromProxy() {
     return fromProxy;
+  }
+
+  public LoggedResponse transform(Consumer<Builder> transformer) {
+    Builder builder = toBuilder();
+    transformer.accept(builder);
+    return builder.build();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  public static class Builder {
+    private int status;
+    private HttpHeaders headers;
+    private byte[] body;
+    private Fault fault;
+    private boolean fromProxy;
+
+    public Builder(LoggedResponse original) {
+      this.status = original.status;
+      this.headers = original.headers;
+      this.body = original.body;
+      this.fault = original.fault;
+      this.fromProxy = original.fromProxy;
+    }
+
+    public Builder withStatus(int status) {
+      this.status = status;
+      return this;
+    }
+
+    public Builder withHeaders(HttpHeaders headers) {
+      this.headers = headers;
+      return this;
+    }
+
+    public Builder withBody(byte[] body) {
+      this.body = body;
+      return this;
+    }
+
+    public Builder withFault(Fault fault) {
+      this.fault = fault;
+      return this;
+    }
+
+    public Builder withFromProxy(boolean fromProxy) {
+      this.fromProxy = fromProxy;
+      return this;
+    }
+
+    public LoggedResponse build() {
+      return new LoggedResponse(status, headers, body, fault, fromProxy);
+    }
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
@@ -31,6 +31,7 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubImport;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -135,18 +136,21 @@ public class Recorder {
         serveEventsResult.stream()
             .filter(serveEventFilters)
             .map(serveEvent -> applyServeEventTransformers(serveEvent, serveEventTransformers))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
             .map((serveEvent) -> new Pair<>(serveEvent, stubMappingGenerator.apply(serveEvent)))
             .collect(Collectors.toList());
 
     return stubMappingPostProcessor.process(stubMappings);
   }
 
-  private static ServeEvent applyServeEventTransformers(
+  private static Optional<ServeEvent> applyServeEventTransformers(
       ServeEvent serveEvent, List<RecorderServeEventTransformer> transformers) {
+    Optional<ServeEvent> result = Optional.of(serveEvent);
     for (RecorderServeEventTransformer transformer : transformers) {
-      serveEvent = transformer.transform(serveEvent);
+      result = result.flatMap(transformer::transform);
     }
-    return serveEvent;
+    return result;
   }
 
   private SnapshotStubMappingPostProcessor getStubMappingPostProcessor(RecordSpec recordSpec) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Pair;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.Extensions;
+import com.github.tomakehurst.wiremock.extension.RecorderServeEventTransformer;
 import com.github.tomakehurst.wiremock.extension.StubMappingTransformer;
 import com.github.tomakehurst.wiremock.store.BlobStore;
 import com.github.tomakehurst.wiremock.store.RecorderStateStore;
@@ -127,13 +128,25 @@ public class Recorder {
       ProxiedServeEventFilters serveEventFilters,
       SnapshotStubMappingGenerator stubMappingGenerator,
       SnapshotStubMappingPostProcessor stubMappingPostProcessor) {
+    final List<RecorderServeEventTransformer> serveEventTransformers =
+        List.copyOf(extensions.ofType(RecorderServeEventTransformer.class).values());
+
     final List<Pair<ServeEvent, StubMapping>> stubMappings =
         serveEventsResult.stream()
             .filter(serveEventFilters)
+            .map(serveEvent -> applyServeEventTransformers(serveEvent, serveEventTransformers))
             .map((serveEvent) -> new Pair<>(serveEvent, stubMappingGenerator.apply(serveEvent)))
             .collect(Collectors.toList());
 
     return stubMappingPostProcessor.process(stubMappings);
+  }
+
+  private static ServeEvent applyServeEventTransformers(
+      ServeEvent serveEvent, List<RecorderServeEventTransformer> transformers) {
+    for (RecorderServeEventTransformer transformer : transformers) {
+      serveEvent = transformer.transform(serveEvent);
+    }
+    return serveEvent;
   }
 
   private SnapshotStubMappingPostProcessor getStubMappingPostProcessor(RecordSpec recordSpec) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
@@ -118,6 +118,11 @@ public class ServeEvent {
         id, request, stubMapping, responseDefinition, response, false, timing, subEvents);
   }
 
+  public ServeEvent withRequest(LoggedRequest request) {
+    return new ServeEvent(
+        id, request, stubMapping, responseDefinition, response, false, timing, subEvents);
+  }
+
   public ServeEvent withResponse(LoggedResponse response) {
     return new ServeEvent(
         id, request, stubMapping, responseDefinition, response, false, timing, subEvents);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,11 @@ public class ServeEvent {
   }
 
   public ServeEvent withStubMapping(StubMapping stubMapping) {
+    return new ServeEvent(
+        id, request, stubMapping, responseDefinition, response, false, timing, subEvents);
+  }
+
+  public ServeEvent withResponse(LoggedResponse response) {
     return new ServeEvent(
         id, request, stubMapping, responseDefinition, response, false, timing, subEvents);
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -418,9 +418,125 @@ public class LoggedRequest implements Request {
       this.formParameters = original.formParameters;
     }
 
+    public UUID getId() {
+      return id;
+    }
+
+    public Builder withId(UUID id) {
+      this.id = id;
+      return this;
+    }
+
+    public String getScheme() {
+      return scheme;
+    }
+
+    public Builder withScheme(String scheme) {
+      this.scheme = scheme;
+      return this;
+    }
+
+    public String getHost() {
+      return host;
+    }
+
+    public Builder withHost(String host) {
+      this.host = host;
+      return this;
+    }
+
+    public Integer getPort() {
+      return port;
+    }
+
+    public Builder withPort(Integer port) {
+      this.port = port;
+      return this;
+    }
+
+    public PathAndQuery getPathAndQuery() {
+      return pathAndQuery;
+    }
+
+    public Builder withPathAndQuery(PathAndQuery pathAndQuery) {
+      this.pathAndQuery = pathAndQuery;
+      return this;
+    }
+
+    public AbsoluteUrl getAbsoluteUrl() {
+      return absoluteUrl;
+    }
+
+    public Builder withAbsoluteUrl(AbsoluteUrl absoluteUrl) {
+      this.absoluteUrl = absoluteUrl;
+      return this;
+    }
+
+    public RequestMethod getMethod() {
+      return method;
+    }
+
+    public Builder withMethod(RequestMethod method) {
+      this.method = method;
+      return this;
+    }
+
+    public String getClientIp() {
+      return clientIp;
+    }
+
+    public Builder withClientIp(String clientIp) {
+      this.clientIp = clientIp;
+      return this;
+    }
+
+    public HttpHeaders getHeaders() {
+      return headers;
+    }
+
     public Builder withHeaders(HttpHeaders headers) {
       this.headers = headers;
       return this;
+    }
+
+    public PathParams getPathParams() {
+      return pathParams;
+    }
+
+    public Builder withPathParams(PathParams pathParams) {
+      this.pathParams = pathParams;
+      return this;
+    }
+
+    public Map<String, Cookie> getCookies() {
+      return cookies;
+    }
+
+    public Builder withCookies(Map<String, Cookie> cookies) {
+      this.cookies = cookies;
+      return this;
+    }
+
+    public boolean isBrowserProxyRequest() {
+      return isBrowserProxyRequest;
+    }
+
+    public Builder withBrowserProxyRequest(boolean isBrowserProxyRequest) {
+      this.isBrowserProxyRequest = isBrowserProxyRequest;
+      return this;
+    }
+
+    public Date getLoggedDate() {
+      return loggedDate;
+    }
+
+    public Builder withLoggedDate(Date loggedDate) {
+      this.loggedDate = loggedDate;
+      return this;
+    }
+
+    public byte[] getBody() {
+      return body;
     }
 
     public Builder withBody(byte[] body) {
@@ -433,8 +549,30 @@ public class LoggedRequest implements Request {
       return this;
     }
 
-    public Builder withMethod(RequestMethod method) {
-      this.method = method;
+    public Collection<Part> getMultiparts() {
+      return multiparts;
+    }
+
+    public Builder withMultiparts(Collection<Part> multiparts) {
+      this.multiparts = multiparts;
+      return this;
+    }
+
+    public String getProtocol() {
+      return protocol;
+    }
+
+    public Builder withProtocol(String protocol) {
+      this.protocol = protocol;
+      return this;
+    }
+
+    public Map<String, FormParameter> getFormParameters() {
+      return formParameters;
+    }
+
+    public Builder withFormParameters(Map<String, FormParameter> formParameters) {
+      this.formParameters = formParameters;
       return this;
     }
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -31,6 +31,8 @@ import com.github.tomakehurst.wiremock.common.url.PathParams;
 import com.github.tomakehurst.wiremock.http.*;
 import java.nio.charset.Charset;
 import java.util.*;
+import java.util.function.Consumer;
+
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.wiremock.url.AbsoluteUrl;
@@ -369,7 +371,7 @@ public class LoggedRequest implements Request {
         : null;
   }
 
-  public LoggedRequest transform(java.util.function.Consumer<Builder> transformer) {
+  public LoggedRequest transform(Consumer<Builder> transformer) {
     Builder builder = toBuilder();
     transformer.accept(builder);
     return builder.build();

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -32,7 +32,6 @@ import com.github.tomakehurst.wiremock.http.*;
 import java.nio.charset.Charset;
 import java.util.*;
 import java.util.function.Consumer;
-
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.wiremock.url.AbsoluteUrl;
@@ -414,7 +413,7 @@ public class LoggedRequest implements Request {
       this.cookies = original.cookies;
       this.isBrowserProxyRequest = original.isBrowserProxyRequest;
       this.loggedDate = original.loggedDate;
-      this.body = original.body;
+      this.body = original.body != null ? Arrays.copyOf(original.body, original.body.length) : null;
       this.multiparts = original.multiparts;
       this.protocol = original.protocol;
       this.formParameters = original.formParameters;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -440,10 +440,23 @@ public class LoggedRequest implements Request {
 
     public LoggedRequest build() {
       return new LoggedRequest(
-          id, scheme, host, port, pathAndQuery, absoluteUrl,
-          method, clientIp, headers, pathParams, cookies,
-          isBrowserProxyRequest, loggedDate, body, multiparts,
-          protocol, formParameters);
+          id,
+          scheme,
+          host,
+          port,
+          pathAndQuery,
+          absoluteUrl,
+          method,
+          clientIp,
+          headers,
+          pathParams,
+          cookies,
+          isBrowserProxyRequest,
+          loggedDate,
+          body,
+          multiparts,
+          protocol,
+          formParameters);
     }
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -368,4 +368,82 @@ public class LoggedRequest implements Request {
             .orElse(null)
         : null;
   }
+
+  public LoggedRequest transform(java.util.function.Consumer<Builder> transformer) {
+    Builder builder = toBuilder();
+    transformer.accept(builder);
+    return builder.build();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  public static class Builder {
+    private UUID id;
+    private String scheme;
+    private String host;
+    private Integer port;
+    private PathAndQuery pathAndQuery;
+    private AbsoluteUrl absoluteUrl;
+    private RequestMethod method;
+    private String clientIp;
+    private HttpHeaders headers;
+    private PathParams pathParams;
+    private Map<String, Cookie> cookies;
+    private boolean isBrowserProxyRequest;
+    private Date loggedDate;
+    private byte[] body;
+    private Collection<Part> multiparts;
+    private String protocol;
+    private Map<String, FormParameter> formParameters;
+
+    public Builder(LoggedRequest original) {
+      this.id = original.id;
+      this.scheme = original.scheme;
+      this.host = original.host;
+      this.port = original.port;
+      this.pathAndQuery = original.pathAndQuery;
+      this.absoluteUrl = original.absoluteUrl;
+      this.method = original.method;
+      this.clientIp = original.clientIp;
+      this.headers = original.headers;
+      this.pathParams = original.pathParams;
+      this.cookies = original.cookies;
+      this.isBrowserProxyRequest = original.isBrowserProxyRequest;
+      this.loggedDate = original.loggedDate;
+      this.body = original.body;
+      this.multiparts = original.multiparts;
+      this.protocol = original.protocol;
+      this.formParameters = original.formParameters;
+    }
+
+    public Builder withHeaders(HttpHeaders headers) {
+      this.headers = headers;
+      return this;
+    }
+
+    public Builder withBody(byte[] body) {
+      this.body = body;
+      return this;
+    }
+
+    public Builder withBody(String body) {
+      this.body = body != null ? body.getBytes(UTF_8) : null;
+      return this;
+    }
+
+    public Builder withMethod(RequestMethod method) {
+      this.method = method;
+      return this;
+    }
+
+    public LoggedRequest build() {
+      return new LoggedRequest(
+          id, scheme, host, port, pathAndQuery, absoluteUrl,
+          method, clientIp, headers, pathParams, cookies,
+          isBrowserProxyRequest, loggedDate, body, multiparts,
+          protocol, formParameters);
+    }
+  }
 }


### PR DESCRIPTION
Supports transformation of serve events before they are processed by the recorder, providing another way to customise recorded output.

Intended for situations like where the the request and response body are in a format like protobuf and must be converted to JSON for use within WireMock.