### PR TITLE
Allow string array headers in the response definition schema

### DIFF
--- a/schemas/wiremock-message-stub-mapping-or-mappings.json
+++ b/schemas/wiremock-message-stub-mapping-or-mappings.json
@@ -1475,7 +1475,14 @@
             "type" : "object",
             "description" : "Map of response headers to send",
             "additionalProperties" : {
-              "type" : "string"
+              "oneOf" : [ {
+                "type" : "string"
+              }, {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              } ]
             }
           },
           "additionalProxyRequestHeaders" : {

--- a/schemas/wiremock-stub-mapping-or-mappings.json
+++ b/schemas/wiremock-stub-mapping-or-mappings.json
@@ -1475,7 +1475,14 @@
             "type" : "object",
             "description" : "Map of response headers to send",
             "additionalProperties" : {
-              "type" : "string"
+              "oneOf" : [ {
+                "type" : "string"
+              }, {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              } ]
             }
           },
           "additionalProxyRequestHeaders" : {

--- a/wiremock-core/src/main/resources/swagger/schemas/response-definition.yaml
+++ b/wiremock-core/src/main/resources/swagger/schemas/response-definition.yaml
@@ -12,7 +12,11 @@ allOf:
         type: object
         description: Map of response headers to send
         additionalProperties:
-          type: string
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
       additionalProxyRequestHeaders:
         type: object
         description: Extra request headers to send when proxying to another host.


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

The PR adds the ability to match agains string arrays in `response.headers.*` JSON properties, so that both arrays and strings are accepted.

`com.github.tomakehurst.wiremock.http.HttpHeadersTest` has already had tests covering this case.

## References

- https://github.com/wiremock/wiremock/issues/3185

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
