### PR TITLE
Breaking change reporting

### DIFF
--- a/.claude/skills/breaking-change-report/SKILL.md
+++ b/.claude/skills/breaking-change-report/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: breaking-change-report
+description: Run the japicmp binary-compatibility report for wiremock-core and produce a filtered summary covering only @PublishedAPI-annotated classes. Use this when asked to generate, refresh, or summarise the breaking-changes report.
+allowed-tools: Bash, Read, Write
+---
+
+Generate a filtered breaking-change summary for `@PublishedAPI`-annotated classes by following these steps in order.
+
+## 1 — Run the report
+
+```bash
+./gradlew :wiremock-core:japicmp --no-daemon -q
+```
+
+If the build fails, diagnose and fix before continuing.
+
+## 2 — Collect the published API surface
+
+Run this to get the fully-qualified class names of every `@PublishedAPI`-annotated type:
+
+```bash
+grep -rl "@PublishedAPI" wiremock-core/src/main/java --include="*.java" \
+  | sed 's|.*/java/||; s|\.java$||; s|/|.|g' | sort
+```
+
+Keep this list in mind — it is the filter for the next step.
+
+## 3 — Read the raw report
+
+Read the full text report at:
+
+```
+wiremock-core/build/reports/japicmp/breaking-changes.txt
+```
+
+## 4 — Produce the filtered summary
+
+Cross-reference the raw report against the `@PublishedAPI` class list. Include an entry if:
+- The class name matches a `@PublishedAPI` class exactly, **or**
+- The class is a public inner class of a `@PublishedAPI` class (indicated by `$` in the name).
+
+Exclude entries where the only change is the class-file format version bump
+(Java version upgrade) — note this once at the top of the output instead.
+
+Write the filtered summary as Markdown to:
+
+```
+wiremock-core/build/reports/japicmp/breaking-changes-published-api.md
+```
+
+Use the following structure:
+
+```
+# Breaking changes in published API — WireMock <old-version> → <new-version>
+
+> Java class-file version bump (X → Y) affects every class; Java N is now
+> the minimum runtime.
+
+---
+
+## <Logical group (e.g. Core server & configuration)>
+
+### `ClassName`
+- **Removed method** `methodSignature()`
+- **Return type changed** `method()`: `OldType` → `NewType`
+- ...
+
+(repeat per class, grouped sensibly)
+```
+
+Group classes by area rather than listing them alphabetically:
+- Core server & configuration (`WireMockServer`, `WireMockConfiguration`, `Options`, `MappingsSaver`)
+- Client DSL (`WireMock`, `WireMockBuilder`, etc.)
+- Stub mapping model (`StubMapping`, `StubMappings`, etc.)
+- HTTP model (`ResponseDefinition`, `Request`, `RequestMethod`, etc.)
+- Extension SPI (`StubLifecycleListener`, `HttpServerFactory`, etc.)
+- Common / shared types (`Metadata`, `Parameters`, etc.)
+- Recording API (`SnapshotRecordResult`, `SnapshotOutputFormatter`, etc.)
+- Any other areas that have changes
+
+Omit groups that have no breaking changes in `@PublishedAPI` classes.
+
+Once the file is written, print the path and a one-line count of how many
+`@PublishedAPI` classes had breaking changes.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,33 @@ On the other hand if you're pretty certain you've found a bug please open an iss
 WireMock only uses log4j in its test dependencies. Neither the thin nor standalone JAR depends on or embeds log4j, so
 you can continue to use WireMock 2.32.0 and above without any risk of exposure to the recently discovered vulnerability.
 
+## Breaking-change report
+
+A [japicmp](https://github.com/melix/japicmp-gradle-plugin)-based report compares the
+current build against the last 3.x release and lists binary-incompatible changes to
+classes annotated `@PublishedAPI`.
+
+If you have [Claude Code](https://claude.ai/code) installed, run the report and produce
+a filtered summary in one step:
+
+```
+/breaking-change-report
+```
+
+To generate the raw report without Claude Code (which will included classes not intended to be part of the published DSL/API):
+
+```bash
+./gradlew :wiremock-core:japicmp
+```
+
+Reports are written to `wiremock-core/build/reports/japicmp/`:
+
+| File | Contents |
+|------|----------|
+| `breaking-changes.html` | Full report (all public classes) |
+| `breaking-changes.txt` | Same, plain text |
+| `breaking-changes-published-api.md` | Filtered to `@PublishedAPI` classes only (produced by the skill) |
+
 ## Contributing
 
 WireMock exists and continues to thrive due to the efforts of contributors.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -139,4 +139,5 @@ nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0
 spotless = { id = "com.diffplug.spotless", version = "8.5.1" }
 sonarqube = { id = "org.sonarqube", version = "7.3.0.8198" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
+japicmp = { id = "me.champeau.gradle.japicmp", version = "0.4.4" }
 task-tree = { id = "com.dorongold.task-tree", version = "4.0.1" }

--- a/wiremock-core/build.gradle.kts
+++ b/wiremock-core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("wiremock.common-conventions")
+    alias(libs.plugins.japicmp)
 }
 
 apply(from = "buildSchema.gradle")
@@ -93,4 +94,53 @@ publishing {
             }
         }
     }
+}
+
+// Full transitive classpath of the 3.x baseline, used for type resolution
+val japicmpBaseline by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
+// Just the baseline JAR itself, used to tell japicmp what to compare (not its deps)
+val japicmpBaselineJar by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
+dependencies {
+    japicmpBaseline("org.wiremock:wiremock:3.13.2")
+    japicmpBaselineJar("org.wiremock:wiremock:3.13.2") {
+        isTransitive = false
+    }
+}
+
+tasks.register<me.champeau.gradle.japicmp.JapicmpTask>("japicmp") {
+    dependsOn(tasks.jar)
+    // Full classpaths for resolving referenced types (Jackson, Guava, etc.)
+    oldClasspath.from(configurations["japicmpBaseline"])
+    newClasspath.from(tasks.jar.map { it.archiveFile }, configurations.runtimeClasspath)
+    // Specific JARs to compare — keeps the diff to WireMock classes only
+    oldArchives.from(configurations["japicmpBaselineJar"])
+    newArchives.from(tasks.jar.map { it.archiveFile })
+    onlyBinaryIncompatibleModified.set(true)
+    // annotationIncludes only works when the annotation exists in both the old and new JARs.
+    // For the 3.x→4.x comparison the annotation didn't exist in 3.x, so we scope by package
+    // instead. Switch back to annotationIncludes for future 4.x→4.x+1 comparisons.
+    packageIncludes.set(listOf(
+        "com.github.tomakehurst.wiremock",
+        "com.github.tomakehurst.wiremock.client",
+        "com.github.tomakehurst.wiremock.common",
+        "com.github.tomakehurst.wiremock.core",
+        "com.github.tomakehurst.wiremock.extension",
+        "com.github.tomakehurst.wiremock.http",
+        "com.github.tomakehurst.wiremock.recording",
+        "com.github.tomakehurst.wiremock.security",
+        "com.github.tomakehurst.wiremock.stubbing",
+        "com.github.tomakehurst.wiremock.verification",
+        "org.wiremock"
+    ))
+    htmlOutputFile.set(layout.buildDirectory.file("reports/japicmp/breaking-changes.html"))
+    xmlOutputFile.set(layout.buildDirectory.file("reports/japicmp/breaking-changes.xml"))
+    txtOutputFile.set(layout.buildDirectory.file("reports/japicmp/breaking-changes.txt"))
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -56,6 +56,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+
+import org.wiremock.annotations.PublishedAPI;
 import org.wiremock.url.AbsoluteUrl;
 import org.wiremock.url.BaseUrl;
 import org.wiremock.url.HostAndPort;
@@ -65,6 +67,7 @@ import org.wiremock.url.RelativeUrl;
 import org.wiremock.url.Scheme;
 import org.wiremock.url.SchemeRegistry;
 
+@PublishedAPI
 public class WireMockServer implements Container, Stubbing, Admin {
 
   private final WireMockApp wireMockApp;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/BasicCredentials.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/BasicCredentials.java
@@ -21,7 +21,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.matching.EqualToPatternWithCaseInsensitivePrefix;
 import com.github.tomakehurst.wiremock.matching.MultiValuePattern;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public class BasicCredentials {
 
   public final String username;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/CountMatchingMode.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/CountMatchingMode.java
@@ -16,8 +16,10 @@
 package com.github.tomakehurst.wiremock.client;
 
 import com.github.tomakehurst.wiremock.common.BiPredicate;
+import org.wiremock.annotations.PublishedAPI;
 
 /** */
+@PublishedAPI
 public interface CountMatchingMode extends BiPredicate<Integer, Integer> {
 
   String getFriendlyName();

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/CountMatchingStrategy.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/CountMatchingStrategy.java
@@ -15,7 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.client;
 
+import org.wiremock.annotations.PublishedAPI;
+
 /** Matches the number of requests made using relational predicates. */
+@PublishedAPI
 public class CountMatchingStrategy {
 
   public static final CountMatchingMode LESS_THAN =

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
@@ -21,10 +21,13 @@ import com.github.tomakehurst.wiremock.extension.ServeEventListener;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.matching.*;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+@PublishedAPI
 public interface MappingBuilder {
 
   MappingBuilder withScheme(String scheme);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/MessageStubMappingBuilder.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/MessageStubMappingBuilder.java
@@ -19,10 +19,13 @@ import com.github.tomakehurst.wiremock.common.Metadata;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.message.MessageAction;
 import com.github.tomakehurst.wiremock.message.MessageStubMapping;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.Map;
 import java.util.UUID;
 
 /** Builder interface for creating message stub mappings using a fluent DSL. */
+@PublishedAPI
 public interface MessageStubMappingBuilder {
 
   /**

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -25,9 +25,11 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.*;
 import java.util.*;
 import org.jspecify.annotations.Nullable;
+import org.wiremock.annotations.PublishedAPI;
 import org.wiremock.url.Path;
 
 @SuppressWarnings("UnusedReturnValue")
+@PublishedAPI
 public class ResponseDefinitionBuilder {
 
   protected final ResponseDefinition.Builder builder;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/ScenarioMappingBuilder.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/ScenarioMappingBuilder.java
@@ -23,10 +23,13 @@ import com.github.tomakehurst.wiremock.matching.MultiValuePattern;
 import com.github.tomakehurst.wiremock.matching.MultipartValuePatternBuilder;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.matching.ValueMatcher;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+@PublishedAPI
 public interface ScenarioMappingBuilder extends MappingBuilder {
 
   ScenarioMappingBuilder whenScenarioStateIs(String stateName);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
@@ -20,9 +20,12 @@ import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.github.tomakehurst.wiremock.verification.NearMiss;
 import com.github.tomakehurst.wiremock.verification.diff.Diff;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
+@PublishedAPI
 public class VerificationException extends AssertionError {
 
   private static final long serialVersionUID = 5116216532516117538L;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -67,10 +67,13 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.wiremock.annotations.PublishedAPI;
 import org.wiremock.url.Path;
 import org.wiremock.url.PathAndQuery;
 
 @SuppressWarnings("unused")
+@PublishedAPI
 public class WireMock {
 
   private static final int DEFAULT_PORT = 8080;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/WireMockBuilder.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/WireMockBuilder.java
@@ -29,8 +29,11 @@ import com.github.tomakehurst.wiremock.http.client.HttpClientFactory;
 import com.github.tomakehurst.wiremock.security.ClientAuthenticator;
 import com.github.tomakehurst.wiremock.security.ClientBasicAuthenticator;
 import com.github.tomakehurst.wiremock.security.NoClientAuthenticator;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.Collections;
 
+@PublishedAPI
 public class WireMockBuilder {
 
   private static final String DEFAULT_HOST = "localhost";

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/Errors.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/Errors.java
@@ -18,9 +18,12 @@ package com.github.tomakehurst.wiremock.common;
 import static java.util.Collections.singletonList;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 import java.util.Objects;
 
+@PublishedAPI
 public class Errors {
 
   private final List<Error> errors;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/Metadata.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/Metadata.java
@@ -19,12 +19,15 @@ import static com.github.tomakehurst.wiremock.common.ParameterUtils.checkParamet
 import static java.util.Collections.emptyMap;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+@PublishedAPI
 public class Metadata implements Map<String, Object> {
 
   private final Map<String, Object> data;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/Timing.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/Timing.java
@@ -19,7 +19,9 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Stopwatch;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public class Timing {
 
   public static final Timing UNTIMED = create();

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinition.java
@@ -17,7 +17,9 @@ package com.github.tomakehurst.wiremock.common.entity;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 @JsonDeserialize(using = EntityDefinitionDeserializer.class)
 @JsonSubTypes(
     value = {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
@@ -30,11 +30,14 @@ import com.github.tomakehurst.wiremock.recording.SnapshotRecordResult;
 import com.github.tomakehurst.wiremock.stubbing.StubImport;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.verification.*;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+@PublishedAPI
 public interface Admin {
 
   void addStubMapping(StubMapping stubMapping);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/MappingsSaver.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/MappingsSaver.java
@@ -16,9 +16,12 @@
 package com.github.tomakehurst.wiremock.core;
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 import java.util.UUID;
 
+@PublishedAPI
 public interface MappingsSaver {
 
   MappingsSaver NOOP =

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -28,11 +28,14 @@ import com.github.tomakehurst.wiremock.standalone.MappingsLoader;
 import com.github.tomakehurst.wiremock.store.Stores;
 import com.github.tomakehurst.wiremock.verification.notmatched.NotMatchedRenderer;
 import com.github.tomakehurst.wiremock.verification.notmatched.PlainTextStubNotMatchedRenderer;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+@PublishedAPI
 public interface Options {
 
   enum ChunkedEncodingPolicy {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -49,6 +49,8 @@ import com.github.tomakehurst.wiremock.store.DefaultStores;
 import com.github.tomakehurst.wiremock.store.Stores;
 import com.github.tomakehurst.wiremock.verification.notmatched.NotMatchedRenderer;
 import com.github.tomakehurst.wiremock.verification.notmatched.PlainTextStubNotMatchedRenderer;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -56,6 +58,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@PublishedAPI
 public class WireMockConfiguration implements Options {
 
   private long asyncResponseTimeout = DEFAULT_TIMEOUT;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/direct/DirectCallHttpServer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/direct/DirectCallHttpServer.java
@@ -17,6 +17,8 @@ package com.github.tomakehurst.wiremock.direct;
 
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.http.*;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -28,6 +30,7 @@ import java.util.concurrent.TimeoutException;
  * <p>This is to allow the use of Wiremock through direct method calls, which is then suitable for
  * i.e. running in Serverless applications.
  */
+@PublishedAPI
 public class DirectCallHttpServer implements HttpServer {
   private final AdminRequestHandler adminRequestHandler;
   private final StubRequestHandler stubRequestHandler;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/AbstractTransformer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/AbstractTransformer.java
@@ -17,7 +17,9 @@ package com.github.tomakehurst.wiremock.extension;
 
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.http.Request;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public abstract class AbstractTransformer<T> implements Extension {
 
   public abstract T transform(Request request, T response, FileSource files, Parameters parameters);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/AdminApiExtension.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/AdminApiExtension.java
@@ -16,7 +16,9 @@
 package com.github.tomakehurst.wiremock.extension;
 
 import com.github.tomakehurst.wiremock.admin.Router;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public interface AdminApiExtension extends Extension {
 
   /**

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/Extension.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/Extension.java
@@ -15,6 +15,9 @@
  */
 package com.github.tomakehurst.wiremock.extension;
 
+import org.wiremock.annotations.PublishedAPI;
+
+@PublishedAPI
 public interface Extension {
 
   String getName();

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ExtensionFactory.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ExtensionFactory.java
@@ -15,8 +15,11 @@
  */
 package com.github.tomakehurst.wiremock.extension;
 
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 
+@PublishedAPI
 public interface ExtensionFactory {
 
   /**

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/GlobalSettingsListener.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/GlobalSettingsListener.java
@@ -16,7 +16,9 @@
 package com.github.tomakehurst.wiremock.extension;
 
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public interface GlobalSettingsListener extends Extension {
 
   default void beforeGlobalSettingsUpdated(

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/MappingsLoaderExtension.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/MappingsLoaderExtension.java
@@ -16,5 +16,7 @@
 package com.github.tomakehurst.wiremock.extension;
 
 import com.github.tomakehurst.wiremock.standalone.MappingsLoader;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public interface MappingsLoaderExtension extends MappingsLoader, Extension {}

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/MessageActionTransformer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/MessageActionTransformer.java
@@ -17,7 +17,9 @@ package com.github.tomakehurst.wiremock.extension;
 
 import com.github.tomakehurst.wiremock.message.MessageAction;
 import com.github.tomakehurst.wiremock.message.MessageActionContext;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public interface MessageActionTransformer extends Extension {
 
   MessageAction transform(MessageAction action, MessageActionContext context);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/Parameters.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/Parameters.java
@@ -20,10 +20,13 @@ import static com.github.tomakehurst.wiremock.common.ParameterUtils.checkParamet
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Metadata;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
+@PublishedAPI
 public class Parameters extends Metadata {
 
   public Parameters() {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/PostServeAction.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/PostServeAction.java
@@ -17,11 +17,13 @@ package com.github.tomakehurst.wiremock.extension;
 
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import org.wiremock.annotations.PublishedAPI;
 
 /**
  * @deprecated Use {@link ServeEventListener} instead.
  */
 @Deprecated
+@PublishedAPI
 public abstract class PostServeAction implements Extension {
 
   /**

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/PostServeActionDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/PostServeActionDefinition.java
@@ -16,7 +16,9 @@
 package com.github.tomakehurst.wiremock.extension;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public class PostServeActionDefinition {
 
   private final String name;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/RecorderServeEventTransformer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/RecorderServeEventTransformer.java
@@ -16,8 +16,11 @@
 package com.github.tomakehurst.wiremock.extension;
 
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.Optional;
 
+@PublishedAPI
 public interface RecorderServeEventTransformer extends Extension {
   Optional<ServeEvent> transform(ServeEvent serveEvent);
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ResponseDefinitionTransformer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ResponseDefinitionTransformer.java
@@ -18,7 +18,9 @@ package com.github.tomakehurst.wiremock.extension;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 @Deprecated
 /**
  * @deprecated Use {@link ResponseDefinitionTransformerV2} instead

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ResponseDefinitionTransformerV2.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ResponseDefinitionTransformerV2.java
@@ -17,7 +17,9 @@ package com.github.tomakehurst.wiremock.extension;
 
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public interface ResponseDefinitionTransformerV2 extends Extension {
 
   ResponseDefinition transform(ServeEvent serveEvent);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ResponseTransformer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ResponseTransformer.java
@@ -18,7 +18,9 @@ package com.github.tomakehurst.wiremock.extension;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.Response;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 @Deprecated
 /**
  * @deprecated Use {@link ResponseTransformerV2} instead

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ResponseTransformerV2.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ResponseTransformerV2.java
@@ -17,7 +17,9 @@ package com.github.tomakehurst.wiremock.extension;
 
 import com.github.tomakehurst.wiremock.http.Response;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public interface ResponseTransformerV2 extends Extension {
 
   Response transform(Response response, ServeEvent serveEvent);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ServeEventListener.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ServeEventListener.java
@@ -16,7 +16,9 @@
 package com.github.tomakehurst.wiremock.extension;
 
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public interface ServeEventListener extends Extension {
 
   enum RequestPhase {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ServeEventListenerDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/ServeEventListenerDefinition.java
@@ -16,8 +16,11 @@
 package com.github.tomakehurst.wiremock.extension;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.Set;
 
+@PublishedAPI
 public class ServeEventListenerDefinition {
 
   private final String name;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/StubLifecycleListener.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/StubLifecycleListener.java
@@ -18,7 +18,9 @@ package com.github.tomakehurst.wiremock.extension;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import java.util.List;
 import org.jspecify.annotations.NullMarked;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 @NullMarked
 public interface StubLifecycleListener extends Extension {
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/StubMappingTransformer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/StubMappingTransformer.java
@@ -19,11 +19,13 @@ import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.recording.StubGenerationResult;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import org.wiremock.annotations.PublishedAPI;
 
 /**
  * Base class for stub mapping transformer extensions. This allows transforming stub mappings
  * recorded via the snapshot and recording API endpoints.
  */
+@PublishedAPI
 public abstract class StubMappingTransformer implements Extension {
   public StubMapping transform(StubMapping stubMapping, FileSource files, Parameters parameters) {
     throw new UnsupportedOperationException();

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/TemplateHelperProviderExtension.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/TemplateHelperProviderExtension.java
@@ -16,8 +16,11 @@
 package com.github.tomakehurst.wiremock.extension;
 
 import com.github.jknack.handlebars.Helper;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.Map;
 
+@PublishedAPI
 public interface TemplateHelperProviderExtension extends Extension {
   Map<String, Helper<?>> provideTemplateHelpers();
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/TemplateModelDataProviderExtension.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/TemplateModelDataProviderExtension.java
@@ -16,8 +16,11 @@
 package com.github.tomakehurst.wiremock.extension;
 
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.Map;
 
+@PublishedAPI
 public interface TemplateModelDataProviderExtension extends Extension {
   Map<String, Object> provideTemplateModelData(ServeEvent serveEvent);
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/WireMockServices.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/WireMockServices.java
@@ -22,7 +22,9 @@ import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngi
 import com.github.tomakehurst.wiremock.http.client.HttpClient;
 import com.github.tomakehurst.wiremock.http.client.HttpClientFactory;
 import com.github.tomakehurst.wiremock.store.Stores;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public interface WireMockServices {
 
   Admin getAdmin();

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/CaseInsensitiveKey.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/CaseInsensitiveKey.java
@@ -15,8 +15,11 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.function.Function;
 
+@PublishedAPI
 public class CaseInsensitiveKey {
 
   private final String key;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ChunkedDribbleDelay.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ChunkedDribbleDelay.java
@@ -17,7 +17,9 @@ package com.github.tomakehurst.wiremock.http;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public class ChunkedDribbleDelay {
 
   private final Integer numberOfChunks;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
@@ -15,12 +15,15 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import org.wiremock.annotations.PublishedAPI;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Optional;
 
+@PublishedAPI
 public class ContentTypeHeader extends HttpHeader {
 
   public static final String KEY = "Content-Type";

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Cookie.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Cookie.java
@@ -22,9 +22,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.Collections;
 import java.util.List;
 
+@PublishedAPI
 public class Cookie extends MultiValue {
 
   @JsonCreator

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/DelayDistribution.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/DelayDistribution.java
@@ -17,12 +17,14 @@ package com.github.tomakehurst.wiremock.http;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.wiremock.annotations.PublishedAPI;
 
 /**
  * Distribution that models delays.
  *
  * <p>Implementations should be thread safe.
  */
+@PublishedAPI
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = LogNormal.class, name = "lognormal"),

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Fault.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Fault.java
@@ -16,7 +16,9 @@
 package com.github.tomakehurst.wiremock.http;
 
 import com.github.tomakehurst.wiremock.core.FaultInjector;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public enum Fault {
   CONNECTION_RESET_BY_PEER {
     @Override

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/FixedDelayDistribution.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/FixedDelayDistribution.java
@@ -16,7 +16,9 @@
 package com.github.tomakehurst.wiremock.http;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public class FixedDelayDistribution implements DelayDistribution {
 
   private final long milliseconds;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/FormParameter.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/FormParameter.java
@@ -16,9 +16,12 @@
 package com.github.tomakehurst.wiremock.http;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.Collections;
 import java.util.List;
 
+@PublishedAPI
 public class FormParameter extends MultiValue {
 
   public FormParameter(

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeader.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeader.java
@@ -15,6 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import org.wiremock.annotations.PublishedAPI;
+
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 import static java.util.Arrays.asList;
 
@@ -22,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+@PublishedAPI
 public class HttpHeader extends MultiValue {
 
   public HttpHeader(String key, String... values) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
@@ -24,10 +24,13 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+@PublishedAPI
 @JsonSerialize(using = HttpHeadersJsonSerializer.class)
 @JsonDeserialize(using = HttpHeadersJsonDeserializer.class)
 public class HttpHeaders {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/HttpServer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/HttpServer.java
@@ -15,6 +15,9 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import org.wiremock.annotations.PublishedAPI;
+
+@PublishedAPI
 public interface HttpServer {
   void start();
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactory.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/HttpServerFactory.java
@@ -18,7 +18,9 @@ package com.github.tomakehurst.wiremock.http;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.message.MessageStubRequestHandler;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 @FunctionalInterface
 public interface HttpServerFactory extends Extension {
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
@@ -27,10 +27,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.jspecify.annotations.NonNull;
+import org.wiremock.annotations.PublishedAPI;
 import org.wiremock.url.AbsoluteUrl;
 import org.wiremock.url.PathAndQuery;
 import org.wiremock.url.Port;
 
+@PublishedAPI
 public class ImmutableRequest implements Request {
 
   private final @NonNull AbsoluteUrl absoluteUrl;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/JvmProxyConfigurer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/JvmProxyConfigurer.java
@@ -18,10 +18,13 @@ package com.github.tomakehurst.wiremock.http;
 import static java.util.Arrays.asList;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@PublishedAPI
 public class JvmProxyConfigurer {
 
   private static final String HTTP_PROXY_HOST = "http.proxyHost";

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/LogNormal.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/LogNormal.java
@@ -17,6 +17,8 @@ package com.github.tomakehurst.wiremock.http;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -30,6 +32,7 @@ import java.util.concurrent.ThreadLocalRandom;
  *     href="https://www.wolframalpha.com/input/?i=lognormaldistribution%28log%2890%29%2C+0.1%29">lognormal
  *     example</a>
  */
+@PublishedAPI
 public final class LogNormal implements DelayDistribution {
 
   @JsonProperty("median")

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
@@ -23,10 +23,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.Encoding;
 import com.github.tomakehurst.wiremock.common.Limit;
 import com.github.tomakehurst.wiremock.common.Strings;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.function.Consumer;
 
+@PublishedAPI
 public class LoggedResponse {
 
   private final int status;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/MimeType.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/MimeType.java
@@ -15,6 +15,9 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import org.wiremock.annotations.PublishedAPI;
+
+@PublishedAPI
 public enum MimeType {
   JSON("application/json"),
   XML("text/xml"),

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/MultiValue.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/MultiValue.java
@@ -19,9 +19,12 @@ import static com.github.tomakehurst.wiremock.common.ParameterUtils.checkState;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
+@PublishedAPI
 public class MultiValue {
 
   protected final String key;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/QueryParameter.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/QueryParameter.java
@@ -18,9 +18,12 @@ package com.github.tomakehurst.wiremock.http;
 import static java.util.Arrays.asList;
 
 import com.fasterxml.jackson.annotation.*;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.Collections;
 import java.util.List;
 
+@PublishedAPI
 public class QueryParameter extends MultiValue {
 
   @JsonCreator

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -24,10 +24,12 @@ import java.util.Set;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.wiremock.annotations.PublishedAPI;
 import org.wiremock.url.AbsoluteUrl;
 import org.wiremock.url.PathAndQuery;
 import org.wiremock.url.Query;
 
+@PublishedAPI
 public interface Request {
 
   // This is populated by the serve event.

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/RequestEventSource.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/RequestEventSource.java
@@ -15,6 +15,9 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import org.wiremock.annotations.PublishedAPI;
+
+@PublishedAPI
 public interface RequestEventSource {
 
   void addRequestListener(RequestListener requestListener);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/RequestListener.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/RequestListener.java
@@ -15,6 +15,9 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import org.wiremock.annotations.PublishedAPI;
+
+@PublishedAPI
 public interface RequestListener {
 
   void requestReceived(Request request, Response response);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/RequestMethod.java
@@ -20,10 +20,12 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.MultiRequestMethodPattern;
 import com.github.tomakehurst.wiremock.matching.NamedValueMatcher;
+import org.wiremock.annotations.PublishedAPI;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
+@PublishedAPI
 @JsonDeserialize(using = RequestMethodJsonDeserializer.class)
 public class RequestMethod implements NamedValueMatcher<RequestMethod> {
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
@@ -21,10 +21,13 @@ import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 import com.github.tomakehurst.wiremock.common.*;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 
+@PublishedAPI
 public class Response {
 
   private final int status;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -37,9 +37,11 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.wiremock.annotations.PublishedAPI;
 import org.wiremock.url.AbsoluteUrl;
 import org.wiremock.url.Path;
 
+@PublishedAPI
 @JsonInclude(Include.NON_NULL)
 public class ResponseDefinition {
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/UniformDistribution.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/UniformDistribution.java
@@ -16,6 +16,8 @@
 package com.github.tomakehurst.wiremock.http;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -25,6 +27,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * between 50 and 60. This would useful for representing an average delay of 55ms with a +/- 5ms
  * jitter.
  */
+@PublishedAPI
 public final class UniformDistribution implements DelayDistribution {
 
   @JsonProperty("lower")

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/CaptureHeadersSpec.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/CaptureHeadersSpec.java
@@ -16,7 +16,9 @@
 package com.github.tomakehurst.wiremock.recording;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public class CaptureHeadersSpec {
 
   private final Boolean caseInsensitive;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/NotRecordingException.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/NotRecordingException.java
@@ -17,7 +17,9 @@ package com.github.tomakehurst.wiremock.recording;
 
 import com.github.tomakehurst.wiremock.common.ClientError;
 import com.github.tomakehurst.wiremock.common.Errors;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public class NotRecordingException extends ClientError {
 
   public NotRecordingException() {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordError.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordError.java
@@ -18,7 +18,9 @@ package com.github.tomakehurst.wiremock.recording;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.PROPERTY,

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpec.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpec.java
@@ -19,9 +19,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.extension.Parameters;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 import java.util.Map;
 
+@PublishedAPI
 /** Encapsulates options for generating and outputting StubMappings */
 public class RecordSpec {
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpecBuilder.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpecBuilder.java
@@ -20,11 +20,14 @@ import static java.util.Arrays.asList;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+@PublishedAPI
 public class RecordSpecBuilder {
 
   private String targetBaseUrl;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecorderState.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecorderState.java
@@ -17,8 +17,11 @@ package com.github.tomakehurst.wiremock.recording;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.UUID;
 
+@PublishedAPI
 public class RecorderState {
 
   private final RecordingStatus status;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordingStatus.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordingStatus.java
@@ -15,6 +15,9 @@
  */
 package com.github.tomakehurst.wiremock.recording;
 
+import org.wiremock.annotations.PublishedAPI;
+
+@PublishedAPI
 public enum RecordingStatus {
   NeverStarted,
   Recording,

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordingStatusResult.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/RecordingStatusResult.java
@@ -17,7 +17,9 @@ package com.github.tomakehurst.wiremock.recording;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public class RecordingStatusResult {
 
   private final RecordingStatus status;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/Authenticator.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/Authenticator.java
@@ -16,7 +16,9 @@
 package com.github.tomakehurst.wiremock.security;
 
 import com.github.tomakehurst.wiremock.http.Request;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public interface Authenticator {
 
   boolean authenticate(Request request);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/BasicAuthenticator.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/BasicAuthenticator.java
@@ -20,9 +20,12 @@ import static java.util.Arrays.asList;
 
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.github.tomakehurst.wiremock.http.Request;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
+@PublishedAPI
 public class BasicAuthenticator implements Authenticator {
 
   private final List<BasicCredentials> credentials;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/ClientAuthenticator.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/ClientAuthenticator.java
@@ -16,8 +16,11 @@
 package com.github.tomakehurst.wiremock.security;
 
 import com.github.tomakehurst.wiremock.http.HttpHeader;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 
+@PublishedAPI
 public interface ClientAuthenticator {
 
   List<HttpHeader> generateAuthHeaders();

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/ClientBasicAuthenticator.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/ClientBasicAuthenticator.java
@@ -21,8 +21,11 @@ import static java.util.Collections.singletonList;
 
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 
+@PublishedAPI
 public class ClientBasicAuthenticator implements ClientAuthenticator {
 
   private final String username;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/ClientTokenAuthenticator.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/ClientTokenAuthenticator.java
@@ -15,8 +15,11 @@
  */
 package com.github.tomakehurst.wiremock.security;
 
+import org.wiremock.annotations.PublishedAPI;
+
 import static com.github.tomakehurst.wiremock.common.ContentTypes.AUTHORIZATION;
 
+@PublishedAPI
 public class ClientTokenAuthenticator extends SingleHeaderClientAuthenticator {
 
   public ClientTokenAuthenticator(String token) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/NoAuthenticator.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/NoAuthenticator.java
@@ -16,7 +16,9 @@
 package com.github.tomakehurst.wiremock.security;
 
 import com.github.tomakehurst.wiremock.http.Request;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public class NoAuthenticator implements Authenticator {
 
   @Override

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/NoClientAuthenticator.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/NoClientAuthenticator.java
@@ -18,8 +18,11 @@ package com.github.tomakehurst.wiremock.security;
 import static java.util.Collections.emptyList;
 
 import com.github.tomakehurst.wiremock.http.HttpHeader;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 
+@PublishedAPI
 public class NoClientAuthenticator implements ClientAuthenticator {
 
   public static NoClientAuthenticator noClientAuthenticator() {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/NotAuthorisedException.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/NotAuthorisedException.java
@@ -15,6 +15,9 @@
  */
 package com.github.tomakehurst.wiremock.security;
 
+import org.wiremock.annotations.PublishedAPI;
+
+@PublishedAPI
 public class NotAuthorisedException extends RuntimeException {
 
   public NotAuthorisedException() {}

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/SingleHeaderAuthenticator.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/SingleHeaderAuthenticator.java
@@ -19,8 +19,11 @@ import static com.github.tomakehurst.wiremock.common.ContentTypes.AUTHORIZATION;
 
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.Request;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 
+@PublishedAPI
 public class SingleHeaderAuthenticator implements Authenticator {
 
   private final String key;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/SingleHeaderClientAuthenticator.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/SingleHeaderClientAuthenticator.java
@@ -16,9 +16,12 @@
 package com.github.tomakehurst.wiremock.security;
 
 import com.github.tomakehurst.wiremock.http.HttpHeader;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.Collections;
 import java.util.List;
 
+@PublishedAPI
 public class SingleHeaderClientAuthenticator implements ClientAuthenticator {
 
   private final String key;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/TokenAuthenticator.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/security/TokenAuthenticator.java
@@ -15,8 +15,11 @@
  */
 package com.github.tomakehurst.wiremock.security;
 
+import org.wiremock.annotations.PublishedAPI;
+
 import static com.github.tomakehurst.wiremock.common.ContentTypes.AUTHORIZATION;
 
+@PublishedAPI
 public class TokenAuthenticator extends SingleHeaderAuthenticator {
 
   public TokenAuthenticator(String token) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/Scenario.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/Scenario.java
@@ -22,10 +22,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.common.Json;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+@PublishedAPI
 public class Scenario {
 
   public static final String STARTED = "Started";

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/ServeEvent.java
@@ -29,9 +29,12 @@ import com.github.tomakehurst.wiremock.extension.ServeEventListenerDefinition;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.common.base.Stopwatch;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+@PublishedAPI
 public class ServeEvent {
 
   public static final String ORIGINAL_SERVE_EVENT_KEY = "wiremock.ORIGINAL_SERVE_EVENT";

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubImport.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubImport.java
@@ -17,8 +17,11 @@ package com.github.tomakehurst.wiremock.stubbing;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 
+@PublishedAPI
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StubImport {
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubImportBuilder.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubImportBuilder.java
@@ -16,9 +16,12 @@
 package com.github.tomakehurst.wiremock.stubbing;
 
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.ArrayList;
 import java.util.List;
 
+@PublishedAPI
 public class StubImportBuilder {
 
   private List<StubMapping> mappings = new ArrayList<>();

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
@@ -34,7 +34,9 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
 import org.jspecify.annotations.NonNull;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 @JsonPropertyOrder({"id", "name", "request", "newRequest", "response"})
 @JsonIgnoreProperties({
   "$schema", "uuid"

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingCollection.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingCollection.java
@@ -17,8 +17,11 @@ package com.github.tomakehurst.wiremock.stubbing;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 
+@PublishedAPI
 @JsonIgnoreProperties({"$schema", "meta", "uuid"})
 @JsonDeserialize() // stops infinite recursion when deserializing as StubMappingOrMappings
 public class StubMappingCollection implements StubMappingOrMappings {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingOrMappings.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingOrMappings.java
@@ -21,9 +21,12 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.io.IOException;
 import java.util.List;
 
+@PublishedAPI
 @JsonDeserialize(using = StubMappingOrMappingsJsonDeserializer.class)
 public interface StubMappingOrMappings {
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappings.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappings.java
@@ -16,10 +16,13 @@
 package com.github.tomakehurst.wiremock.stubbing;
 
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+@PublishedAPI
 public interface StubMappings {
 
   ServeEvent serveFor(ServeEvent request);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/SubEvent.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/SubEvent.java
@@ -18,10 +18,13 @@ package com.github.tomakehurst.wiremock.stubbing;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Message;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+@PublishedAPI
 public class SubEvent {
 
   public static final String NON_MATCH_TYPE = "REQUEST_NOT_MATCHED";

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -35,9 +35,11 @@ import java.util.*;
 import java.util.function.Consumer;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.wiremock.annotations.PublishedAPI;
 import org.wiremock.url.AbsoluteUrl;
 import org.wiremock.url.PathAndQuery;
 
+@PublishedAPI
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class LoggedRequest implements Request {
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/MessageVerificationResult.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/MessageVerificationResult.java
@@ -18,7 +18,9 @@ package com.github.tomakehurst.wiremock.verification;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.Json;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public class MessageVerificationResult {
 
   private final int count;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/NearMiss.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/NearMiss.java
@@ -22,7 +22,9 @@ import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.verification.diff.Diff;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public class NearMiss implements Comparable<NearMiss> {
 
   private final LoggedRequest request;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/VerificationResult.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/VerificationResult.java
@@ -18,7 +18,9 @@ package com.github.tomakehurst.wiremock.verification;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.Json;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public class VerificationResult extends JournalBasedResult {
 
   private final Integer count;

--- a/wiremock-core/src/main/java/org/wiremock/annotations/PublishedAPI.java
+++ b/wiremock-core/src/main/java/org/wiremock/annotations/PublishedAPI.java
@@ -13,14 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.tomakehurst.wiremock.recording;
+package org.wiremock.annotations;
 
-import com.github.tomakehurst.wiremock.stubbing.StubMapping;
-import org.wiremock.annotations.PublishedAPI;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-@PublishedAPI
-public sealed interface StubGenerationResult {
-  record Success(StubMapping stubMapping) implements StubGenerationResult {}
-
-  record Failure(String reason) implements StubGenerationResult {}
-}
+/**
+ * Marks a type as part of WireMock's published API. Only types carrying this annotation are
+ * included in breaking-change compatibility reports. Types without it are considered internal and
+ * may change without notice between any releases.
+ *
+ * @since 4.0.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface PublishedAPI {}

--- a/wiremock-core/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
+++ b/wiremock-core/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.tomakehurst.wiremock.common.Metadata;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.*;
+import org.wiremock.annotations.PublishedAPI;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -32,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@PublishedAPI
 public class WebhookDefinition {
 
   private String method;

--- a/wiremock-core/src/main/java/org/wiremock/webhooks/WebhookTransformer.java
+++ b/wiremock-core/src/main/java/org/wiremock/webhooks/WebhookTransformer.java
@@ -17,7 +17,9 @@ package org.wiremock.webhooks;
 
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import org.wiremock.annotations.PublishedAPI;
 
+@PublishedAPI
 public interface WebhookTransformer extends Extension {
 
   WebhookDefinition transform(ServeEvent serveEvent, WebhookDefinition webhookDefinition);


### PR DESCRIPTION
Add reporting of breaking changes to classes annotated with `@PublishedAPI`. Uses a combination of `japicmp` and an agent skill.

Currently set to compare the current version with 3.13.2.

Includes an agent skill called `breaking-change-report` as the entry point.
