### PR TITLE
Switch webhooks to use EntityDefinition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,7 @@ The following packages contain messaging/websocket functionality:
 
 3. **Always import** - Do not use fully-qualified class names. Always use `import` statements.
 
+## Testing
+
+1. **Use JsonUnit for JSON assertions** - Use `net.javacrumbs.jsonunit.JsonMatchers` (e.g. `jsonEquals`, `jsonPartEquals`) rather than `JSONAssert` for JSON assertions in tests.
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -139,5 +139,5 @@ nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0
 spotless = { id = "com.diffplug.spotless", version = "8.5.1" }
 sonarqube = { id = "org.sonarqube", version = "7.3.0.8198" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
-japicmp = { id = "me.champeau.gradle.japicmp", version = "0.4.6" }
+japicmp = { id = "me.champeau.gradle.japicmp", version = "0.4.4" }
 task-tree = { id = "com.dorongold.task-tree", version = "4.0.1" }

--- a/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2025 Thomas Akehurst
+ * Copyright (C) 2011-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,6 +107,8 @@ public class AcceptanceTestBase {
     } else if (options.portNumber() == Options.DEFAULT_PORT) {
       options.dynamicPort();
     }
+
+    options.bindAddress("127.0.0.1");
 
     wireMockServer = new WireMockServer(options);
     wireMockServer.start();

--- a/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WebhooksAcceptanceViaServeEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 Thomas Akehurst
+ * Copyright (C) 2021-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@ package com.github.tomakehurst.wiremock;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.common.Strings.bytesFromString;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
+import static com.github.tomakehurst.wiremock.testsupport.TestFiles.defaultTestFilesRoot;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.waitAtMost;
@@ -240,39 +242,39 @@ public class WebhooksAcceptanceViaServeEventTest extends WebhooksAcceptanceTest 
 
     client.postJson(
         "/__admin/mappings",
-        "{\n"
-            + "  \"request\": {\n"
-            + "    \"urlPath\": \"/hook\",\n"
-            + "    \"method\": \"POST\"\n"
-            + "  },\n"
-            + "  \"response\": {\n"
-            + "    \"status\": 204\n"
-            + "  },\n"
-            + "  \"serveEventListeners\": [\n"
-            + "    {\n"
-            + "      \"name\": \"webhook\",\n"
-            + "      \"parameters\": {\n"
-            + "        \"headers\": {\n"
-            + "          \"Content-Type\": \"application/json\"\n"
-            + "        },\n"
-            + "        \"method\": \"POST\",\n"
-            + "        \"body\": \"{ \\\"result\\\": \\\"SUCCESS\\\" }\",\n"
-            + "        \"url\" : \""
-            + targetServer.baseUrl()
-            + "/callback1\"\n"
-            + "      }\n"
-            + "    },\n"
-            + "    {\n"
-            + "      \"name\": \"webhook\",\n"
-            + "      \"parameters\": {\n"
-            + "        \"method\": \"POST\",\n"
-            + "        \"url\" : \""
-            + targetServer.baseUrl()
-            + "/callback2\"\n"
-            + "      }\n"
-            + "    }\n"
-            + "  ]\n"
-            + "}");
+        // language=json
+        """
+        {
+          "request": {
+            "urlPath": "/hook",
+            "method": "POST"
+          },
+          "response": {
+            "status": 204
+          },
+          "serveEventListeners": [
+            {
+              "name": "webhook",
+              "parameters": {
+                "headers": {
+                  "Content-Type": "application/json"
+                },
+                "method": "POST",
+                "body": "{ \\"result\\": \\"SUCCESS\\" }",
+                "url": "%s/callback1"
+              }
+            },
+            {
+              "name": "webhook",
+              "parameters": {
+                "method": "POST",
+                "url": "%s/callback2"
+              }
+            }
+          ]
+        }
+        """
+            .formatted(targetServer.baseUrl(), targetServer.baseUrl()));
 
     verify(0, postRequestedFor(anyUrl()));
 
@@ -329,32 +331,34 @@ public class WebhooksAcceptanceViaServeEventTest extends WebhooksAcceptanceTest 
   public void appliesTemplatingToUrlMethodHeadersAndBodyViaJSON() throws Exception {
     client.postJson(
         "/__admin/mappings",
-        "{\n"
-            + "  \"id\" : \"8a58e190-4a83-4244-a064-265fcca46884\",\n"
-            + "  \"request\" : {\n"
-            + "    \"urlPath\" : \"/templating\",\n"
-            + "    \"method\" : \"POST\"\n"
-            + "  },\n"
-            + "  \"response\" : {\n"
-            + "    \"status\" : 200\n"
-            + "  },\n"
-            + "  \"uuid\" : \"8a58e190-4a83-4244-a064-265fcca46884\",\n"
-            + "  \"serveEventListeners\" : [{\n"
-            + "    \"name\" : \"webhook\",\n"
-            + "    \"parameters\" : {\n"
-            + "      \"method\" : \"{{jsonPath originalRequest.body '$.method'}}\",\n"
-            + "      \"url\" : \""
-            + targetServer.baseUrl()
-            + "{{{jsonPath originalRequest.body '$.callbackPath'}}}\",\n"
-            + "      \"headers\" : {\n"
-            + "        \"X-Single\" : \"{{math 1 '+' 2}}\",\n"
-            + "        \"X-Multi\" : [ \"{{math 3 'x' 2}}\", \"{{parameters.one}}\" ]\n"
-            + "      },\n"
-            + "      \"body\" : \"{{jsonPath originalRequest.body '$.name'}}\",\n"
-            + "      \"one\" : \"param-one-value\"\n"
-            + "    }\n"
-            + "  }]\n"
-            + "}\n");
+        // language=json
+        """
+        {
+          "id": "8a58e190-4a83-4244-a064-265fcca46884",
+          "request": {
+            "urlPath": "/templating",
+            "method": "POST"
+          },
+          "response": {
+            "status": 200
+          },
+          "uuid": "8a58e190-4a83-4244-a064-265fcca46884",
+          "serveEventListeners": [{
+            "name": "webhook",
+            "parameters": {
+              "method": "{{jsonPath originalRequest.body '$.method'}}",
+              "url": "%s{{{jsonPath originalRequest.body '$.callbackPath'}}}",
+              "headers": {
+                "X-Single": "{{math 1 '+' 2}}",
+                "X-Multi": ["{{math 3 'x' 2}}", "{{parameters.one}}"]
+              },
+              "body": "{{jsonPath originalRequest.body '$.name'}}",
+              "one": "param-one-value"
+            }
+          }]
+        }
+        """
+            .formatted(targetServer.baseUrl()));
 
     verify(0, postRequestedFor(anyUrl()));
 
@@ -415,26 +419,28 @@ public class WebhooksAcceptanceViaServeEventTest extends WebhooksAcceptanceTest 
   public void addsRandomDelayViaJSON() throws Exception {
     client.postJson(
         "/__admin/mappings",
-        "{\n"
-            + "  \"request\" : {\n"
-            + "    \"urlPath\" : \"/delayed\",\n"
-            + "    \"method\" : \"POST\"\n"
-            + "  },\n"
-            + "  \"serveEventListeners\" : [{\n"
-            + "    \"name\" : \"webhook\",\n"
-            + "    \"parameters\" : {\n"
-            + "      \"method\" : \"GET\",\n"
-            + "      \"url\" : \""
-            + targetServer.baseUrl()
-            + "/callback\",\n"
-            + "      \"delay\" : {\n"
-            + "        \"type\" : \"uniform\",\n"
-            + "        \"lower\": 500,\n"
-            + "        \"upper\": 1000\n"
-            + "      }\n"
-            + "    }\n"
-            + "  }]\n"
-            + "}");
+        // language=json
+        """
+        {
+          "request": {
+            "urlPath": "/delayed",
+            "method": "POST"
+          },
+          "serveEventListeners": [{
+            "name": "webhook",
+            "parameters": {
+              "method": "GET",
+              "url": "%s/callback",
+              "delay": {
+                "type": "uniform",
+                "lower": 500,
+                "upper": 1000
+              }
+            }
+          }]
+        }
+        """
+            .formatted(targetServer.baseUrl()));
 
     verify(0, postRequestedFor(anyUrl()));
 
@@ -516,6 +522,166 @@ public class WebhooksAcceptanceViaServeEventTest extends WebhooksAcceptanceTest 
     if (method.hasEntity()) {
       assertThat(requests.get(0).getBodyAsString(), is(body));
     }
+  }
+
+  @Test
+  public void webhookBodyCanBeLoadedFromFile() throws Exception {
+    // This test needs a separate rule with file root configured
+    WireMockServer fileServer =
+        new WireMockServer(
+            options().dynamicPort().withRootDirectory(defaultTestFilesRoot()).notifier(notifier));
+
+    try {
+      fileServer.start();
+      latch = new CountDownLatch(1);
+
+      // Set up target server to receive the webhook
+      targetServer.stubFor(any(urlPathMatching("/callback.*")).willReturn(ok()));
+
+      // Stub with webhook that uses bodyFileName via JSON API
+      new WireMockTestClient(fileServer.port())
+          .postJson(
+              "/__admin/mappings",
+              // language=json
+              """
+              {
+                "request": {
+                  "urlPath": "/trigger-file-webhook",
+                  "method": "POST"
+                },
+                "response": {
+                  "status": 200
+                },
+                "serveEventListeners": [
+                  {
+                    "name": "webhook",
+                    "parameters": {
+                      "method": "POST",
+                      "url": "%s/callback-file",
+                      "headers": {
+                        "Content-Type": "application/json"
+                      },
+                      "body": {
+                        "filePath": "webhook-body.json"
+                      }
+                    }
+                  }
+                ]
+              }
+              """
+                  .formatted(targetServer.baseUrl()));
+
+      new WireMockTestClient(fileServer.port()).post("/trigger-file-webhook");
+
+      waitForRequestToTargetServer();
+
+      targetServer.verify(
+          1,
+          postRequestedFor(urlEqualTo("/callback-file"))
+              .withHeader("Content-Type", equalTo("application/json"))
+              .withRequestBody(
+                  equalToJson("{ \"source\": \"file\", \"message\": \"Hello from file\" }")));
+    } finally {
+      fileServer.stop();
+    }
+  }
+
+  @Test
+  public void webhookBodyCanBeLoadedFromFileViaDSL() throws Exception {
+    // This test needs a separate rule with file root configured
+    WireMockServer fileServer =
+        new WireMockServer(
+            options().dynamicPort().withRootDirectory(defaultTestFilesRoot()).notifier(notifier));
+
+    try {
+      fileServer.start();
+      latch = new CountDownLatch(1);
+
+      // Set up target server to receive the webhook
+      targetServer.stubFor(any(urlPathMatching("/callback.*")).willReturn(ok()));
+
+      // Create stub using DSL
+      fileServer.stubFor(
+          post(urlPathEqualTo("/trigger-file-dsl-webhook"))
+              .willReturn(ok())
+              .withServeEventListener(
+                  "webhook",
+                  webhook()
+                      .withMethod(POST)
+                      .withUrl(targetServer.url("/callback-file-dsl"))
+                      .withHeader("Content-Type", "application/json")
+                      .withBodyFileName("webhook-body.json")));
+
+      new WireMockTestClient(fileServer.port()).post("/trigger-file-dsl-webhook");
+
+      waitForRequestToTargetServer();
+
+      targetServer.verify(
+          1,
+          postRequestedFor(urlEqualTo("/callback-file-dsl"))
+              .withHeader("Content-Type", equalTo("application/json"))
+              .withRequestBody(
+                  equalToJson("{ \"source\": \"file\", \"message\": \"Hello from file\" }")));
+    } finally {
+      fileServer.stop();
+    }
+  }
+
+  @Test
+  public void webhookBodyCanBeLoadedFromDataStore() throws Exception {
+    // This test uses the rule server and puts data in its store
+    String webhookBody = "{ \"source\": \"dataStore\", \"message\": \"Hello from store\" }";
+    rule.getOptions()
+        .getStores()
+        .getBlobStore("webhookStore")
+        .put("webhookData", bytesFromString(webhookBody));
+
+    latch = new CountDownLatch(1);
+
+    // Set up target server to receive the webhook
+    targetServer.stubFor(any(urlPathMatching("/callback.*")).willReturn(ok()));
+
+    // Stub with webhook that uses data store ref via JSON API
+    client.postJson(
+        "/__admin/mappings",
+        // language=json
+        """
+        {
+          "request": {
+            "urlPath": "/trigger-store-webhook",
+            "method": "POST"
+          },
+          "response": {
+            "status": 200
+          },
+          "serveEventListeners": [{
+            "name": "webhook",
+            "parameters": {
+              "method": "POST",
+              "url": "%s/callback-store",
+              "headers": {
+                "Content-Type": "application/json"
+              },
+              "body": {
+                "dataStore": "webhookStore",
+                "dataRef": "webhookData"
+              }
+            }
+          }]
+        }
+        """
+            .formatted(targetServer.baseUrl()));
+
+    client.post("/trigger-store-webhook");
+
+    waitForRequestToTargetServer();
+
+    targetServer.verify(
+        1,
+        postRequestedFor(urlEqualTo("/callback-store"))
+            .withHeader("Content-Type", equalTo("application/json"))
+            .withRequestBody(
+                equalToJson("{ \"source\": \"dataStore\", \"message\": \"Hello from store\" }")));
   }
 
   private static Stream<RequestMethod> allHttpMethodsForWebhooks() {

--- a/src/test/java/org/wiremock/webhooks/WebhookDefinitionTest.java
+++ b/src/test/java/org/wiremock/webhooks/WebhookDefinitionTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2026 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.webhooks;
+
+import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.github.tomakehurst.wiremock.common.Encoding;
+import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.common.entity.EntityDefinition;
+import com.github.tomakehurst.wiremock.common.entity.Format;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.http.UniformDistribution;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class WebhookDefinitionTest {
+
+  @Test
+  void serialisesCorrectlyWhenStringBodyUsed() {
+    WebhookDefinition webhookDefinition =
+        new WebhookDefinition()
+            .withUrl("https://example.com/post-me")
+            .withMethod(RequestMethod.POST)
+            .withBody("body text")
+            .withDelay(new UniformDistribution(10, 20))
+            .withHeaders(List.of(httpHeader("Content-Type", "text/plain")));
+
+    var json = Json.write(webhookDefinition);
+
+    assertThat(
+        json,
+        jsonEquals(
+            // language=json
+            """
+                {
+                   "url": "https://example.com/post-me",
+                   "method": "POST",
+                   "headers": {
+                     "Content-Type": "text/plain"
+                   },
+                   "body": "body text",
+                   "delay": {
+                     "type": "uniform",
+                     "lower": 10,
+                     "upper": 20
+                   }
+                 }
+                """));
+  }
+
+  @Test
+  void serialisesCorrectlyWhenBodyFileNameUsed() {
+    WebhookDefinition webhookDefinition =
+        new WebhookDefinition()
+            .withUrl("https://example.com/post-me")
+            .withMethod(RequestMethod.POST)
+            .withBody("body text")
+            .withBodyFileName("webhooks/body.json");
+
+    var json = Json.write(webhookDefinition);
+
+    assertThat(
+        json,
+        jsonEquals(
+            // language=json
+            """
+                {
+                   "url": "https://example.com/post-me",
+                   "method": "POST",
+                   "bodyFileName": "webhooks/body.json"
+                 }
+                """));
+  }
+
+  @Test
+  void deserialisesCorrectlyWhenStringBodyUsed() {
+    var json = // language=json
+        """
+                {
+                   "url": "https://example.com/post-me",
+                   "method": "POST",
+                   "body": "<stuff />",
+                   "headers": {
+                      "Content-Type": "application/xml"
+                   }
+                 }
+                """;
+
+    WebhookDefinition webhookDefinition = Json.read(json, WebhookDefinition.class);
+
+    assertThat(webhookDefinition.getBody(), is("<stuff />"));
+
+    EntityDefinition entity = webhookDefinition.getBodyEntityDefinition();
+    assertThat(entity.getFilePath(), nullValue());
+    assertThat(entity.getDataAsString(), is("<stuff />"));
+    assertThat(entity.getFormat(), is(Format.XML));
+  }
+
+  @Test
+  void deserialisesCorrectlyWhenBodyFileNameUsed() {
+    var json = // language=json
+        """
+                {
+                   "url": "https://example.com/post-me",
+                   "method": "POST",
+                   "bodyFileName": "webhooks/body.json",
+                   "headers": {
+                      "Content-Type": "text/json"
+                   }
+                 }
+                """;
+
+    WebhookDefinition webhookDefinition = Json.read(json, WebhookDefinition.class);
+
+    assertThat(webhookDefinition.getBodyFileName(), is("webhooks/body.json"));
+
+    EntityDefinition entity = webhookDefinition.getBodyEntityDefinition();
+    assertThat(entity.getFilePath(), is("webhooks/body.json"));
+    assertThat(entity.getFormat(), is(Format.JSON));
+    assertThat(entity.getData(), nullValue());
+  }
+
+  @Test
+  void deserialisesCorrectlyWhenBase64BodyUsed() {
+    String base64Body = "e30K";
+    var json = // language=json
+        """
+                {
+                   "url": "https://example.com/post-me",
+                   "method": "POST",
+                   "base64Body": "%s",
+                   "headers": {
+                      "Content-Type": "application/octet-stream"
+                   }
+                 }
+                """
+            .formatted(base64Body);
+
+    WebhookDefinition webhookDefinition = Json.read(json, WebhookDefinition.class);
+
+    assertThat(webhookDefinition.getBase64Body(), is(base64Body));
+
+    EntityDefinition entity = webhookDefinition.getBodyEntityDefinition();
+    assertThat(entity.getDataAsBytes(), is(Encoding.decodeBase64(base64Body)));
+    assertThat(entity.getFormat(), is(Format.BINARY));
+    assertThat(entity.getData(), nullValue());
+  }
+
+  @Test
+  void deserialisesCorrectlyWhenJsonBodyUsed() {
+    var json = // language=json
+        """
+                {
+                   "url": "https://example.com/post-me",
+                   "method": "POST",
+                   "jsonBody": {
+                     "key": "value"
+                   }
+                 }
+                """;
+
+    WebhookDefinition webhookDefinition = Json.read(json, WebhookDefinition.class);
+
+    assertThat(webhookDefinition.getBody(), jsonEquals("{\"key\":\"value\"}"));
+
+    EntityDefinition entity = webhookDefinition.getBodyEntityDefinition();
+    assertThat(entity.getDataAsString(), jsonEquals("{\"key\":\"value\"}"));
+    assertThat(entity.getFormat(), is(Format.JSON));
+  }
+}

--- a/src/test/resources/test-file-root/__files/webhook-body.json
+++ b/src/test/resources/test-file-root/__files/webhook-body.json
@@ -1,0 +1,4 @@
+{
+  "source": "file",
+  "message": "Hello from file"
+}

--- a/src/test/resources/webhookStore/webhookData
+++ b/src/test/resources/webhookStore/webhookData
@@ -1,0 +1,1 @@
+{ "source": "dataStore", "message": "Hello from store" }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/CreateStubMappingTask.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/CreateStubMappingTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2025 Thomas Akehurst
+ * Copyright (C) 2013-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/EditStubMappingTask.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/EditStubMappingTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/GetAllStubMappingsTask.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/GetAllStubMappingsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/GetStubMappingTask.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/GetStubMappingTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -59,6 +59,18 @@ public class ResponseDefinitionBuilder {
         .build();
   }
 
+  public static ResponseDefinition jsonResponse(Object body, Class<?> view) {
+    return jsonResponse(body, HTTP_OK, view);
+  }
+
+  public static ResponseDefinition jsonResponse(Object body, int status, Class<?> view) {
+    return new ResponseDefinitionBuilder()
+        .withBody(Json.write(body, view))
+        .withStatus(status)
+        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+        .build();
+  }
+
   public ResponseDefinitionBuilder but() {
     return this;
   }
@@ -175,6 +187,13 @@ public class ResponseDefinitionBuilder {
     return responseDefinition()
         .withStatus(HTTP_OK)
         .withBody(Json.write(body))
+        .withHeader(CONTENT_TYPE, APPLICATION_JSON);
+  }
+
+  public static <T> ResponseDefinitionBuilder okForJson(T body, Class<?> view) {
+    return responseDefinition()
+        .withStatus(HTTP_OK)
+        .withBody(Json.write(body, view))
         .withHeader(CONTENT_TYPE, APPLICATION_JSON);
   }
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinition.java
@@ -34,6 +34,7 @@ import com.github.tomakehurst.wiremock.common.Encoding;
 import com.github.tomakehurst.wiremock.common.Gzip;
 import com.github.tomakehurst.wiremock.common.InputStreamSource;
 import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.store.Stores;
 import java.nio.charset.Charset;
 import java.util.function.Consumer;
@@ -104,6 +105,29 @@ public abstract class EntityDefinition {
       throw new IllegalArgumentException(
           "Cannot specify an entity with both filePath and data store reference");
     }
+  }
+
+  public static EntityDefinition resolveFrom(
+      EntityDefinition body, JsonNode jsonBody, String base64Body, String bodyFileName) {
+    EntityDefinition entityDefinition = body;
+    if (jsonBody != null) {
+      entityDefinition = EntityDefinition.json(jsonBody);
+    } else if (base64Body != null) {
+      entityDefinition = EntityDefinition.fromBase64(base64Body);
+    } else if (bodyFileName != null) {
+      entityDefinition = EntityDefinition.builder().setFilePath(bodyFileName).build();
+    }
+
+    return entityDefinition != null ? entityDefinition : EmptyEntityDefinition.INSTANCE;
+  }
+
+  public static EntityDefinition resolveEntityAttributesFromHeaders(
+      HttpHeaders headers, EntityDefinition entityDefinition) {
+    if (entityDefinition.isAbsent()) {
+      return entityDefinition;
+    }
+
+    return entityDefinition.transform(builder -> EntityMetadata.copyFromHeaders(headers, builder));
   }
 
   public @NonNull Entity resolve(@Nullable Stores stores) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -38,7 +38,6 @@ import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.entity.EmptyEntityDefinition;
 import com.github.tomakehurst.wiremock.common.entity.EntityDefinition;
-import com.github.tomakehurst.wiremock.common.entity.EntityMetadata;
 import com.github.tomakehurst.wiremock.common.entity.Format;
 import com.github.tomakehurst.wiremock.common.entity.JsonEntityDefinition;
 import com.github.tomakehurst.wiremock.extension.Extension;
@@ -157,7 +156,7 @@ public class ResponseDefinition {
     this.removeProxyRequestHeaders =
         removeProxyRequestHeaders != null ? List.copyOf(removeProxyRequestHeaders) : List.of();
 
-    this.body = resolveBodyAttributes(this.headers, body);
+    this.body = EntityDefinition.resolveEntityAttributesFromHeaders(this.headers, body);
 
     this.fixedDelayMilliseconds = fixedDelayMilliseconds;
     this.delayDistribution = delayDistribution;
@@ -170,15 +169,6 @@ public class ResponseDefinition {
         transformerParameters != null ? transformerParameters : Parameters.empty();
     this.browserProxyUrl = browserProxyUrl;
     this.wasConfigured = wasConfigured == null || wasConfigured;
-  }
-
-  private static EntityDefinition resolveBodyAttributes(
-      HttpHeaders headers, EntityDefinition entityDefinition) {
-    if (entityDefinition.isAbsent()) {
-      return entityDefinition;
-    }
-
-    return entityDefinition.transform(builder -> EntityMetadata.copyFromHeaders(headers, builder));
   }
 
   public static ResponseDefinition notFound() {

--- a/wiremock-core/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
+++ b/wiremock-core/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
@@ -15,22 +15,30 @@
  */
 package org.wiremock.webhooks;
 
-import static com.github.tomakehurst.wiremock.common.Encoding.decodeBase64;
+import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 import static java.util.Collections.singletonList;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Metadata;
+import com.github.tomakehurst.wiremock.common.entity.EmptyEntityDefinition;
+import com.github.tomakehurst.wiremock.common.entity.EntityDefinition;
+import com.github.tomakehurst.wiremock.common.entity.Format;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.*;
+import com.github.tomakehurst.wiremock.store.Stores;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.NonNull;
 import org.wiremock.annotations.PublishedAPI;
 
 @PublishedAPI
@@ -38,20 +46,15 @@ public class WebhookDefinition {
 
   private String method;
   private String url;
-  private List<HttpHeader> headers;
-  private Body body = Body.none();
+  private HttpHeaders headers = new HttpHeaders();
+
+  private EntityDefinition body = EmptyEntityDefinition.INSTANCE;
+
   private DelayDistribution delay;
   private Parameters parameters;
 
   public static WebhookDefinition from(Parameters parameters) {
-    return new WebhookDefinition(
-        parameters.getString("method", "GET"),
-        parameters.getString("url"),
-        toHttpHeaders(parameters.getMetadata("headers", null)),
-        parameters.getString("body", null),
-        parameters.getString("base64Body", null),
-        getDelayDistribution(parameters.getMetadata("delay", null)),
-        parameters);
+    return Json.mapToObject(parameters, WebhookDefinition.class).withExtraParameters(parameters);
   }
 
   private static HttpHeaders toHttpHeaders(Metadata headerMap) {
@@ -88,23 +91,34 @@ public class WebhookDefinition {
 
   @JsonCreator
   public WebhookDefinition(
+      @JsonProperty("method") String method,
+      @JsonProperty("url") String url,
+      @JsonProperty("headers") HttpHeaders headers,
+      @JsonProperty("body") EntityDefinition body,
+      @JsonProperty("bodyFileName") String bodyFileName,
+      @JsonProperty("base64Body") String base64Body,
+      @JsonProperty("jsonBody") JsonNode jsonBody,
+      @JsonProperty("delay") DelayDistribution delay) {
+    this(
+        method,
+        url,
+        headers,
+        EntityDefinition.resolveFrom(body, jsonBody, base64Body, bodyFileName),
+        delay,
+        Parameters.empty());
+  }
+
+  WebhookDefinition(
       String method,
       String url,
       HttpHeaders headers,
-      String body,
-      String base64Body,
+      EntityDefinition body,
       DelayDistribution delay,
       Parameters parameters) {
     this.method = method;
     this.url = url;
-    this.headers = headers != null ? new ArrayList<>(headers.all()) : null;
-
-    if (body != null) {
-      this.body = new Body(body);
-    } else if (base64Body != null) {
-      this.body = new Body(decodeBase64(base64Body));
-    }
-
+    this.headers = getFirstNonNull(headers, new HttpHeaders());
+    this.body = EntityDefinition.resolveEntityAttributesFromHeaders(this.headers, body);
     this.delay = delay;
     this.parameters = parameters;
   }
@@ -124,16 +138,35 @@ public class WebhookDefinition {
     return url;
   }
 
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  @NonNull
   public HttpHeaders getHeaders() {
-    return new HttpHeaders(headers);
+    return headers;
   }
 
-  public String getBase64Body() {
-    return body.isBinary() ? body.asBase64() : null;
+  @JsonIgnore
+  public EntityDefinition getBodyEntityDefinition() {
+    return body;
   }
 
   public String getBody() {
-    return body.isBinary() ? null : body.asString();
+    if (!body.isBinary() && body.isInline()) {
+      return body.getDataAsString();
+    }
+
+    return null;
+  }
+
+  @JsonIgnore
+  public String getBase64Body() {
+    if (body.isBinary() && body.isInline()) {
+      return body.getDataAsString();
+    }
+    return null;
+  }
+
+  public String getBodyFileName() {
+    return body.getFilePath();
   }
 
   public DelayDistribution getDelay() {
@@ -152,7 +185,12 @@ public class WebhookDefinition {
 
   @JsonIgnore
   public byte[] getBinaryBody() {
-    return body.asBytes();
+    return body.getDataAsBytes();
+  }
+
+  @JsonIgnore
+  public byte[] getResolvedBody(Stores stores) {
+    return body.resolve(stores).getData();
   }
 
   public WebhookDefinition withMethod(String method) {
@@ -176,26 +214,36 @@ public class WebhookDefinition {
   }
 
   public WebhookDefinition withHeaders(List<HttpHeader> headers) {
-    this.headers = headers;
+    this.headers = new HttpHeaders(headers);
     return this;
   }
 
   public WebhookDefinition withHeader(String key, String... values) {
     if (headers == null) {
-      headers = new ArrayList<>();
+      headers = HttpHeaders.noHeaders();
     }
 
-    headers.add(new HttpHeader(key, values));
+    headers = headers.transform(builder -> builder.add(key, values));
     return this;
   }
 
   public WebhookDefinition withBody(String body) {
-    this.body = new Body(body);
+    this.body = EntityDefinition.simple(body);
     return this;
   }
 
   public WebhookDefinition withBinaryBody(byte[] body) {
-    this.body = new Body(body);
+    this.body = EntityDefinition.builder().setFormat(Format.BINARY).setData(body).build();
+    return this;
+  }
+
+  public WebhookDefinition withBodyFileName(String bodyFileName) {
+    this.body = EntityDefinition.builder().setFilePath(bodyFileName).build();
+    return this;
+  }
+
+  public WebhookDefinition withBodyEntity(EntityDefinition body) {
+    this.body = body;
     return this;
   }
 
@@ -224,8 +272,21 @@ public class WebhookDefinition {
     return this;
   }
 
+  public WebhookDefinition withExtraParameters(Parameters parameters) {
+    this.parameters = parameters;
+    return this;
+  }
+
   @JsonIgnore
   public boolean hasBody() {
-    return body != null && body.isPresent();
+    return body != null && !body.isAbsent();
+  }
+
+  @SuppressWarnings("EqualsDoesntCheckParameterClass")
+  public static class EmptyEntityDefinitionFilter {
+    @Override
+    public boolean equals(Object obj) {
+      return EmptyEntityDefinition.INSTANCE.equals(obj);
+    }
   }
 }

--- a/wiremock-core/src/main/java/org/wiremock/webhooks/Webhooks.java
+++ b/wiremock-core/src/main/java/org/wiremock/webhooks/Webhooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 Thomas Akehurst
+ * Copyright (C) 2021-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import com.github.tomakehurst.wiremock.extension.WireMockServices;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.http.client.HttpClient;
+import com.github.tomakehurst.wiremock.store.Stores;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.SubEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
@@ -43,6 +44,7 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
   private final List<WebhookTransformer> transformers;
   private final TemplateEngine templateEngine;
   private final DataTruncationSettings dataTruncationSettings;
+  private final Stores stores;
 
   public Webhooks(
       WireMockServices wireMockServices,
@@ -54,6 +56,7 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
     this.transformers = transformers;
     this.templateEngine = wireMockServices.getTemplateEngine();
     this.dataTruncationSettings = wireMockServices.getOptions().getDataTruncationSettings();
+    this.stores = wireMockServices.getStores();
   }
 
   @Override
@@ -83,7 +86,7 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
         definition = transformer.transform(serveEvent, definition);
       }
       definition = applyTemplating(definition, serveEvent);
-      request = buildRequest(definition);
+      request = buildRequest(definition, stores);
 
       serveEvent.appendSubEvent("WEBHOOK_REQUEST", LoggedRequest.createFrom(request));
     } catch (Exception e) {
@@ -173,7 +176,7 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
     return templateEngine.getUncachedTemplate(value).apply(context);
   }
 
-  private static Request buildRequest(WebhookDefinition definition) {
+  private static Request buildRequest(WebhookDefinition definition, Stores stores) {
     final ImmutableRequest.Builder requestBuilder =
         ImmutableRequest.create()
             .withMethod(definition.getRequestMethod())
@@ -181,7 +184,7 @@ public class Webhooks extends PostServeAction implements ServeEventListener {
             .withHeaders(definition.getHeaders());
 
     if (definition.getRequestMethod().hasEntity() && definition.hasBody()) {
-      requestBuilder.withBody(definition.getBinaryBody());
+      requestBuilder.withBody(definition.getResolvedBody(stores));
     }
 
     return requestBuilder.build();


### PR DESCRIPTION
Switch webhooks to use `EntityDefinition` for the body, enabling support for file paths, json and binary bodies, and the same resolution strategy as for response definitions and messages.

