### PR TITLE
Deprecate Body

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Thomas Akehurst
+ * Copyright (C) 2019-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapperTest.java
@@ -21,6 +21,7 @@ import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.matching.MockRequest;
 import java.util.stream.Collectors;
@@ -167,10 +168,9 @@ public class RequestWrapperTest {
     Request wrappedRequest =
         RequestWrapper.create()
             .transformBody(
-                existingBody -> {
-                  String newValue = existingBody.asString().replace("One", "Two");
-                  return new Body(newValue);
-                })
+                (Entity existingBody) ->
+                    existingBody.transform(
+                        b -> b.setData(existingBody.asString().replace("One", "Two"))))
             .wrap(request);
 
     assertThat(wrappedRequest.getBodyAsString(), is("Two"));
@@ -185,7 +185,10 @@ public class RequestWrapperTest {
     MockRequest request = mockRequest().body(initialBytes);
 
     Request wrappedRequest =
-        RequestWrapper.create().transformBody(existingBody -> new Body(finalBytes)).wrap(request);
+        RequestWrapper.create()
+            .transformBody(
+                (Entity existingBody) -> existingBody.transform(b -> b.setData(finalBytes)))
+            .wrap(request);
 
     assertThat(wrappedRequest.getBody(), is(finalBytes));
     assertThat(wrappedRequest.getBodyAsBase64(), is(encodeBase64(finalBytes)));
@@ -207,8 +210,8 @@ public class RequestWrapperTest {
                         : mockPart().name("two").filename("sample2.txt").body("2222"))
             .wrap(request);
 
-    assertThat(wrappedRequest.getPart("one").getBody().asString(), is("1111"));
-    assertThat(wrappedRequest.getPart("two").getBody().asString(), is("2222"));
+    assertThat(wrappedRequest.getPart("one").getBodyEntity().asString(), is("1111"));
+    assertThat(wrappedRequest.getPart("two").getBodyEntity().asString(), is("2222"));
     assertThat(
         wrappedRequest.getParts(),
         hasItem(mockPart().name("one").filename("text1.txt").body("1111")));

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockMultipart.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockMultipart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 Thomas Akehurst
+ * Copyright (C) 2018-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.matching;
 
-import com.github.tomakehurst.wiremock.http.Body;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
+import com.github.tomakehurst.wiremock.common.entity.Format;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.Request;
@@ -28,7 +29,7 @@ public class MockMultipart implements Request.Part {
   private String name;
   private String filename;
   private List<HttpHeader> headers = new ArrayList<>();
-  private Body body;
+  private Entity body;
 
   public static MockMultipart mockPart() {
     return new MockMultipart();
@@ -55,12 +56,12 @@ public class MockMultipart implements Request.Part {
   }
 
   public MockMultipart body(String body) {
-    this.body = new Body(body);
+    this.body = Entity.builder().setFormat(Format.TEXT).setData(body).build();
     return this;
   }
 
   public MockMultipart body(byte[] body) {
-    this.body = new Body(body);
+    this.body = Entity.builder().setFormat(Format.BINARY).setData(body).build();
     return this;
   }
 
@@ -85,7 +86,7 @@ public class MockMultipart implements Request.Part {
   }
 
   @Override
-  public Body getBody() {
+  public Entity getBodyEntity() {
     return body;
   }
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/Entity.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/Entity.java
@@ -22,13 +22,15 @@ import static com.github.tomakehurst.wiremock.common.entity.CompressionType.NONE
 import static com.github.tomakehurst.wiremock.common.entity.EntityDefinition.DEFAULT_CHARSET;
 import static com.github.tomakehurst.wiremock.common.entity.EntityDefinition.DEFAULT_COMPRESSION;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.tomakehurst.wiremock.common.ContentTypes;
+import com.github.tomakehurst.wiremock.common.Encoding;
 import com.github.tomakehurst.wiremock.common.Exceptions;
 import com.github.tomakehurst.wiremock.common.Gzip;
 import com.github.tomakehurst.wiremock.common.InputStreamSource;
 import com.github.tomakehurst.wiremock.common.Limit;
 import com.github.tomakehurst.wiremock.common.StreamSources;
 import com.github.tomakehurst.wiremock.common.Strings;
+import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.Objects;
@@ -91,9 +93,16 @@ public class Entity {
     return this;
   }
 
-  @JsonIgnore
-  public String getDataAsString() {
+  public String asString() {
     return Exceptions.uncheck(() -> Strings.stringFromBytes(getData(), charset), String.class);
+  }
+
+  public String asBase64() {
+    return Encoding.encodeBase64(getData());
+  }
+
+  public byte[] asBytes() {
+    return getData();
   }
 
   public byte[] getData() {
@@ -129,6 +138,19 @@ public class Entity {
     return streamSource;
   }
 
+  public boolean isBinary() {
+    return format == Format.BINARY;
+  }
+
+  public static Entity ofBinaryOrText(byte[] content, ContentTypeHeader contentTypeHeader) {
+    Format format =
+        contentTypeHeader != null
+                && ContentTypes.determineIsTextFromMimeType(contentTypeHeader.mimeTypePart())
+            ? Format.TEXT
+            : Format.BINARY;
+    return Entity.builder().setFormat(format).setData(content).build();
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -144,7 +166,7 @@ public class Entity {
       return transform(
           builder -> {
             final String plainText =
-                compression == GZIP ? Gzip.unGzipToString(getData()) : getDataAsString();
+                compression == GZIP ? Gzip.unGzipToString(getData()) : asString();
 
             final String transformed = transformer.apply(plainText);
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapper.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapper.java
@@ -21,6 +21,7 @@ import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonN
 import static java.util.Objects.requireNonNull;
 
 import com.github.tomakehurst.wiremock.common.Lazy;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.http.*;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -40,7 +41,7 @@ public class RequestWrapper implements Request {
   private final Map<String, Cookie> additionalCookies;
   private final List<String> cookiesToRemove;
   private final Map<String, FieldTransformer<Cookie>> cookieTransformers;
-  private final FieldTransformer<Body> bodyTransformer;
+  private final FieldTransformer<Entity> bodyTransformer;
   private final FieldTransformer<Part> multipartTransformer;
 
   public RequestWrapper(Request delegate) {
@@ -68,7 +69,7 @@ public class RequestWrapper implements Request {
       Map<String, Cookie> additionalCookies,
       List<String> cookiesToRemove,
       Map<String, FieldTransformer<Cookie>> cookieTransformers,
-      FieldTransformer<Body> bodyTransformer,
+      FieldTransformer<Entity> bodyTransformer,
       FieldTransformer<Part> multipartTransformer) {
     this.delegate = delegate;
 
@@ -230,7 +231,11 @@ public class RequestWrapper implements Request {
   @Override
   public byte[] getBody() {
     if (bodyTransformer != null) {
-      return bodyTransformer.transform(new Body(delegate.getBody())).asBytes();
+      byte[] bodyBytes = delegate.getBody();
+      if (bodyBytes == null) return null;
+      return bodyTransformer
+          .transform(Entity.ofBinaryOrText(bodyBytes, delegate.contentTypeHeader()))
+          .asBytes();
     }
 
     return delegate.getBody();
@@ -239,7 +244,11 @@ public class RequestWrapper implements Request {
   @Override
   public String getBodyAsString() {
     if (bodyTransformer != null) {
-      return bodyTransformer.transform(new Body(delegate.getBodyAsString())).asString();
+      byte[] bodyBytes = delegate.getBody();
+      if (bodyBytes == null) return null;
+      return bodyTransformer
+          .transform(Entity.ofBinaryOrText(bodyBytes, delegate.contentTypeHeader()))
+          .asString();
     }
 
     return delegate.getBodyAsString();
@@ -304,7 +313,7 @@ public class RequestWrapper implements Request {
     private final List<String> cookiesToRemove = new ArrayList<>();
     private final Map<String, FieldTransformer<Cookie>> cookieTransformers = new HashMap<>();
 
-    private FieldTransformer<Body> bodyTransformer;
+    private FieldTransformer<Entity> bodyTransformer;
     private FieldTransformer<Part> mutlipartTransformer;
 
     public Builder addHeader(String key, String... values) {
@@ -347,7 +356,7 @@ public class RequestWrapper implements Request {
           mutlipartTransformer);
     }
 
-    public Builder transformBody(FieldTransformer<Body> transformer) {
+    public Builder transformBody(FieldTransformer<Entity> transformer) {
       bodyTransformer = transformer;
       return this;
     }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestPartTemplateModel.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestPartTemplateModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Thomas Akehurst
+ * Copyright (C) 2024-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
-import com.github.tomakehurst.wiremock.http.Body;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.TreeMap;
@@ -25,10 +25,10 @@ public class RequestPartTemplateModel {
 
   private final String name;
   private final Map<String, ListOrSingle<String>> headers;
-  private final Body body;
+  private final Entity body;
 
   public RequestPartTemplateModel(
-      String name, Map<String, ListOrSingle<String>> headers, Body body) {
+      String name, Map<String, ListOrSingle<String>> headers, Entity body) {
     this.name = name;
     this.headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     this.headers.putAll(headers);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -16,7 +16,7 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
-import com.github.tomakehurst.wiremock.http.Body;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import java.util.Map;
 
@@ -28,7 +28,7 @@ public class RequestTemplateModel {
   private final Map<String, ListOrSingle<String>> cookies;
 
   private final boolean isMultipart;
-  private final Body body;
+  private final Entity body;
   private final Map<String, RequestPartTemplateModel> parts;
 
   protected RequestTemplateModel(
@@ -37,7 +37,7 @@ public class RequestTemplateModel {
       Map<String, ListOrSingle<String>> headers,
       Map<String, ListOrSingle<String>> cookies,
       boolean isMultipart,
-      Body body,
+      Entity body,
       Map<String, RequestPartTemplateModel> parts) {
     this.id = id;
     this.requestLine = requestLine;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -96,7 +96,7 @@ public class ResponseTemplateTransformer
 
       if (bodyIsInlineOrTemplatingPermitted) {
         final HandlebarsOptimizedTemplate bodyTemplate =
-            templateEngine.getTemplate(templateCacheKey, initialBody.getDataAsString());
+            templateEngine.getTemplate(templateCacheKey, initialBody.asString());
 
         bodyDefinition = applyTemplateToBodyEntity(model, bodyTemplate);
       }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 Thomas Akehurst
+ * Copyright (C) 2021-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,11 @@ import com.github.jknack.handlebars.helper.ext.AssignHelper;
 import com.github.jknack.handlebars.helper.ext.NumberHelper;
 import com.github.tomakehurst.wiremock.common.Exceptions;
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.TemplateModelDataProviderExtension;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.SystemValueHelper;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.WireMockHelpers;
-import com.github.tomakehurst.wiremock.http.Body;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
@@ -176,7 +176,7 @@ public class TemplateEngine {
         adaptedHeaders,
         adaptedCookies,
         request.isMultipart(),
-        Body.ofBinaryOrText(request.getBody(), request.contentTypeHeader()),
+        Entity.ofBinaryOrText(request.getBody(), request.contentTypeHeader()),
         buildRequestPartModel(request));
   }
 
@@ -204,7 +204,7 @@ public class TemplateEngine {
                                 throw new IllegalStateException("Duplicate header name");
                               },
                               LinkedHashMap::new)),
-                  part.getBody()));
+                  part.getBodyEntity()));
         }
 
         return result;
@@ -225,7 +225,7 @@ public class TemplateEngine {
                                           throw new IllegalStateException("Duplicate header name");
                                         },
                                         LinkedHashMap::new)),
-                            part.getBody()),
+                            part.getBodyEntity()),
                     (e1, e2) -> {
                       throw new IllegalStateException("Duplicate request part name");
                     },

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2025 Thomas Akehurst
+ * Copyright (C) 2015-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,10 @@ import com.github.tomakehurst.wiremock.common.Strings;
 import java.util.Arrays;
 import java.util.Objects;
 
+/**
+ * @deprecated use {@link com.github.tomakehurst.wiremock.common.entity.Entity}
+ */
+@Deprecated
 public class Body {
 
   private final byte[] content;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -50,6 +50,10 @@ public interface Request {
 
     Entity getBodyEntity();
 
+    /**
+     * @deprecated use {@link #getBodyEntity()}
+     */
+    @Deprecated
     default Body getBody() {
       return new Body(getBodyEntity().asBytes());
     }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.http;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.common.url.PathParams;
 import java.util.Collection;
 import java.util.Map;
@@ -47,7 +48,11 @@ public interface Request {
 
     HttpHeaders getHeaders();
 
-    Body getBody();
+    Entity getBodyEntity();
+
+    default Body getBody() {
+      return new Body(getBodyEntity().asBytes());
+    }
   }
 
   @Deprecated // use getPathAndQueryWithoutPrefix()

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 Thomas Akehurst
+ * Copyright (C) 2019-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.http.multipart;
 
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.http.*;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -64,8 +65,8 @@ public class FileItemPartAdapter implements Request.Part {
   }
 
   @Override
-  public Body getBody() {
-    return Body.ofBinaryOrText(fileItem.get(), new ContentTypeHeader(fileItem.getContentType()));
+  public Entity getBodyEntity() {
+    return Entity.ofBinaryOrText(fileItem.get(), new ContentTypeHeader(fileItem.getContentType()));
   }
 
   public static final Function<FileItem, Request.Part> TO_PARTS = FileItemPartAdapter::new;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/MultipartValuePattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/MultipartValuePattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock.matching;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.github.tomakehurst.wiremock.http.Body;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.http.Request;
 import java.util.Collection;
 import java.util.List;
@@ -145,13 +145,13 @@ public class MultipartValuePattern implements ValueMatcher<Request.Part> {
   }
 
   private static MatchResult matchBody(Request.Part part, ContentPattern<?> bodyPattern) {
-    Body body = part.getBody();
+    Entity body = part.getBodyEntity();
     if (body == null) {
       return MatchResult.noMatch();
     }
 
     if (BinaryEqualToPattern.class.isAssignableFrom(bodyPattern.getClass())) {
-      return ((BinaryEqualToPattern) bodyPattern).match(body.asBytes());
+      return ((BinaryEqualToPattern) bodyPattern).match(body.getData());
     }
 
     return ((StringValuePattern) bodyPattern).match(body.asString());

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
@@ -23,10 +23,10 @@ import static com.github.tomakehurst.wiremock.verification.diff.SpacerLine.SPACE
 
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.common.url.PathParams;
 import com.github.tomakehurst.wiremock.common.url.PathTemplate;
 import com.github.tomakehurst.wiremock.common.xml.Xml;
-import com.github.tomakehurst.wiremock.http.Body;
 import com.github.tomakehurst.wiremock.http.Cookie;
 import com.github.tomakehurst.wiremock.http.FormParameter;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
@@ -190,7 +190,8 @@ public class Diff {
             if (!pattern.match(part).isExactMatch()) {
               addHeaderSectionWithSpacerIfPresent(
                   pattern.getHeaders(), part.getHeaders(), diffLineList);
-              addBodySectionIfPresent(pattern.getBodyPatterns(), part.getBody(), diffLineList);
+              addBodySectionIfPresent(
+                  pattern.getBodyPatterns(), part.getBodyEntity(), diffLineList);
               diffLineList.add(SPACER);
             }
 
@@ -400,7 +401,7 @@ public class Diff {
   }
 
   private void addBodySectionIfPresent(
-      List<ContentPattern<?>> bodyPatterns, Body body, List<DiffLine<?>> diffLineList) {
+      List<ContentPattern<?>> bodyPatterns, Entity body, List<DiffLine<?>> diffLineList) {
     if (bodyPatterns != null && !bodyPatterns.isEmpty()) {
       for (ContentPattern<?> pattern : bodyPatterns) {
         String formattedBody = formatIfJsonOrXml(pattern, body);
@@ -452,11 +453,11 @@ public class Diff {
 
   private void addBodySectionIfPresent(List<DiffLine<?>> builder) {
     List<ContentPattern<?>> bodyPatterns = requestPattern.getBodyPatterns();
-    Body body = new Body(request.getBody());
+    Entity body = Entity.ofBinaryOrText(request.getBody(), request.contentTypeHeader());
     addBodySectionIfPresent(bodyPatterns, body, builder);
   }
 
-  private static String getExpressionResultString(Body body, PathPattern pathPattern) {
+  private static String getExpressionResultString(Entity body, PathPattern pathPattern) {
     String bodyStr = body.asString();
     if (isEmpty(bodyStr)) {
       return null;
@@ -511,14 +512,14 @@ public class Diff {
     return stubMappingName;
   }
 
-  private static String formatIfJsonOrXml(ContentPattern<?> pattern, Body body) {
-    if (body == null || body.isAbsent()) {
+  private static String formatIfJsonOrXml(ContentPattern<?> pattern, Entity body) {
+    if (body == null || body.getData() == null) {
       return "";
     }
 
     try {
       return pattern.getClass().equals(EqualToJsonPattern.class)
-          ? Json.prettyPrint(Json.write(body.asJson()))
+          ? Json.prettyPrint(Json.write(Json.node(body.asString())))
           : pattern.getClass().equals(EqualToXmlPattern.class)
               ? Xml.prettyPrint(body.asString())
               : pattern.getClass().equals(BinaryEqualToPattern.class)

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/diff/MissingMultipart.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/diff/MissingMultipart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 Thomas Akehurst
+ * Copyright (C) 2018-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.verification.diff;
 
-import com.github.tomakehurst.wiremock.http.Body;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.Request;
@@ -43,7 +43,7 @@ public class MissingMultipart implements Request.Part {
   }
 
   @Override
-  public Body getBody() {
+  public Entity getBodyEntity() {
     return null;
   }
 }

--- a/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/servlet/WireMockHttpServletMultipartAdapter.java
+++ b/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/servlet/WireMockHttpServletMultipartAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2025 Thomas Akehurst
+ * Copyright (C) 2013-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.jetty.servlet;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.http.*;
 import jakarta.servlet.http.Part;
 import java.io.IOException;
@@ -68,7 +69,7 @@ public class WireMockHttpServletMultipartAdapter implements Request.Part {
   }
 
   @Override
-  public Body getBody() {
+  public Entity getBodyEntity() {
     try {
       byte[] bytes = mPart.getInputStream().readAllBytes();
       HttpHeader header = getHeader(ContentTypeHeader.KEY);
@@ -76,9 +77,9 @@ public class WireMockHttpServletMultipartAdapter implements Request.Part {
           header.isPresent()
               ? new ContentTypeHeader(header.firstValue())
               : ContentTypeHeader.absent();
-      return Body.ofBinaryOrText(bytes, contentTypeHeader);
+      return Entity.ofBinaryOrText(bytes, contentTypeHeader);
     } catch (IOException e) {
-      return throwUnchecked(e, Body.class);
+      return throwUnchecked(e, Entity.class);
     }
   }
 }


### PR DESCRIPTION
Switch remaining uses of `Body` to `Entity` (except where it makes sense to preserve backwards compatibility) and deprecate `Body`.