### PR TITLE
Add Entity body getter to Request interface

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
@@ -24,6 +24,7 @@ import static java.util.Arrays.asList;
 import com.github.tomakehurst.wiremock.MultipartParserLoader;
 import com.github.tomakehurst.wiremock.common.entity.CompressionType;
 import com.github.tomakehurst.wiremock.common.entity.Entity;
+import com.github.tomakehurst.wiremock.common.entity.Format;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import java.util.*;
@@ -270,7 +271,11 @@ public class MockRequest implements Request {
 
   @Override
   public Entity getBodyEntity() {
-    return Entity.forRequest(body, contentTypeHeader(), CompressionType.NONE);
+    return Entity.builder()
+        .setFormat(Format.fromContentTypeHeader(contentTypeHeader()))
+        .setCompression(CompressionType.NONE)
+        .setData(body != null ? body : new byte[0])
+        .build();
   }
 
   @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
@@ -22,6 +22,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 
 import com.github.tomakehurst.wiremock.MultipartParserLoader;
+import com.github.tomakehurst.wiremock.common.entity.CompressionType;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import java.util.*;
@@ -264,6 +266,11 @@ public class MockRequest implements Request {
   @Override
   public String getBodyAsBase64() {
     return "";
+  }
+
+  @Override
+  public Entity getBodyEntity() {
+    return Entity.forRequest(body, contentTypeHeader(), CompressionType.NONE);
   }
 
   @Override

--- a/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
+++ b/src/testFixtures/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
@@ -19,6 +19,9 @@ import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
 import static org.mockito.Mockito.when;
 
+import com.github.tomakehurst.wiremock.common.entity.CompressionType;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
+import com.github.tomakehurst.wiremock.common.entity.Format;
 import com.github.tomakehurst.wiremock.http.*;
 import java.util.*;
 import org.mockito.Mockito;
@@ -155,6 +158,13 @@ public class MockRequestBuilder {
     when(request.getBody()).thenReturn(body.getBytes());
     when(request.getBodyAsString()).thenReturn(body);
     when(request.getBodyAsBase64()).thenReturn(bodyAsBase64);
+    when(request.getBodyEntity())
+        .thenReturn(
+            Entity.builder()
+                .setFormat(Format.fromContentTypeHeader(headers.getContentTypeHeader()))
+                .setCompression(CompressionType.NONE)
+                .setData(body.getBytes())
+                .build());
     when(request.getAbsoluteUrl()).thenReturn("http://localhost:8080" + url);
     when(request.getTypedAbsoluteUrl())
         .thenReturn(AbsoluteUrl.parse("http://localhost:8080" + url));

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/Entity.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/Entity.java
@@ -151,6 +151,19 @@ public class Entity {
     return Entity.builder().setFormat(format).setData(content).build();
   }
 
+  public static Entity forRequest(
+      byte[] rawBytes, ContentTypeHeader contentTypeHeader, CompressionType compression) {
+    Charset charset =
+        contentTypeHeader != null
+            ? contentTypeHeader.charset().orElse(DEFAULT_CHARSET)
+            : DEFAULT_CHARSET;
+    return new Entity(
+        Format.fromContentTypeHeader(contentTypeHeader),
+        charset,
+        getFirstNonNull(compression, DEFAULT_COMPRESSION),
+        StreamSources.forBytes(rawBytes));
+  }
+
   public static Builder builder() {
     return new Builder();
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/Entity.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/Entity.java
@@ -151,19 +151,6 @@ public class Entity {
     return Entity.builder().setFormat(format).setData(content).build();
   }
 
-  public static Entity forRequest(
-      byte[] rawBytes, ContentTypeHeader contentTypeHeader, CompressionType compression) {
-    Charset charset =
-        contentTypeHeader != null
-            ? contentTypeHeader.charset().orElse(DEFAULT_CHARSET)
-            : DEFAULT_CHARSET;
-    return new Entity(
-        Format.fromContentTypeHeader(contentTypeHeader),
-        charset,
-        getFirstNonNull(compression, DEFAULT_COMPRESSION),
-        StreamSources.forBytes(rawBytes));
-  }
-
   public static Builder builder() {
     return new Builder();
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/Entity.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/Entity.java
@@ -22,7 +22,6 @@ import static com.github.tomakehurst.wiremock.common.entity.CompressionType.NONE
 import static com.github.tomakehurst.wiremock.common.entity.EntityDefinition.DEFAULT_CHARSET;
 import static com.github.tomakehurst.wiremock.common.entity.EntityDefinition.DEFAULT_COMPRESSION;
 
-import com.github.tomakehurst.wiremock.common.ContentTypes;
 import com.github.tomakehurst.wiremock.common.Encoding;
 import com.github.tomakehurst.wiremock.common.Exceptions;
 import com.github.tomakehurst.wiremock.common.Gzip;
@@ -30,7 +29,7 @@ import com.github.tomakehurst.wiremock.common.InputStreamSource;
 import com.github.tomakehurst.wiremock.common.Limit;
 import com.github.tomakehurst.wiremock.common.StreamSources;
 import com.github.tomakehurst.wiremock.common.Strings;
-import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.Objects;
@@ -142,13 +141,14 @@ public class Entity {
     return format == Format.BINARY;
   }
 
-  public static Entity ofBinaryOrText(byte[] content, ContentTypeHeader contentTypeHeader) {
-    Format format =
-        contentTypeHeader != null
-                && ContentTypes.determineIsTextFromMimeType(contentTypeHeader.mimeTypePart())
-            ? Format.TEXT
-            : Format.BINARY;
-    return Entity.builder().setFormat(format).setData(content).build();
+  public static Entity of(byte[] data, HttpHeaders headers) {
+    if (data == null) {
+      return EMPTY;
+    }
+
+    final Builder builder = Entity.builder().setData(data);
+    EntityMetadata.copyFromHeaders(headers, builder);
+    return builder.build();
   }
 
   public static Builder builder() {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityMetadata.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityMetadata.java
@@ -26,6 +26,10 @@ import java.util.Optional;
 public class EntityMetadata {
 
   public static void copyFromHeaders(HttpHeaders headers, EntityMetadataBuilder<?> builder) {
+    if (headers == null) {
+      return;
+    }
+
     final ContentTypeHeader contentTypeHeader = headers.getContentTypeHeader();
     final String mimeType = contentTypeHeader.mimeTypePart();
     final Optional<Charset> charset = contentTypeHeader.charset();

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/Format.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/Format.java
@@ -17,6 +17,8 @@ package com.github.tomakehurst.wiremock.common.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.github.tomakehurst.wiremock.common.ContentTypes;
+import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
 
 public class Format {
 
@@ -57,7 +59,35 @@ public class Format {
     }
 
     MimeType parsed = MimeType.parse(mimeType);
-    return fromString(parsed.getType());
+
+    // Primary type — covers "application/json" → "json", "text/xml" → "xml", etc.
+    if (isWellKnownType(parsed.getType())) {
+      return fromString(parsed.getType());
+    }
+
+    // Subtype after '+' — covers "application/vnd.api+json" → subType "json"
+    String subType = parsed.getSubType();
+    if (subType != null && isWellKnownType(subType)) {
+      return fromString(subType);
+    }
+
+    return ContentTypes.determineIsTextFromMimeType(mimeType) ? TEXT : BINARY;
+  }
+
+  public static Format fromContentTypeHeader(ContentTypeHeader contentTypeHeader) {
+    if (contentTypeHeader == null || !contentTypeHeader.isPresent()) {
+      return BINARY;
+    }
+    String mimeType = contentTypeHeader.mimeTypePart();
+    return mimeType != null ? fromMimeType(mimeType) : BINARY;
+  }
+
+  private static boolean isWellKnownType(String value) {
+    if (value == null) return false;
+    return switch (value.toLowerCase()) {
+      case "json", "html", "text", "xml", "yaml", "csv", "binary" -> true;
+      default -> false;
+    };
   }
 
   public static Format detectFormat(String data) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapper.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/requestfilter/RequestWrapper.java
@@ -15,7 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.extension.requestfilter;
 
-import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
 import static com.github.tomakehurst.wiremock.common.Lazy.lazy;
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 import static java.util.Objects.requireNonNull;
@@ -229,34 +228,24 @@ public class RequestWrapper implements Request {
   }
 
   @Override
-  public byte[] getBody() {
-    if (bodyTransformer != null) {
-      byte[] bodyBytes = delegate.getBody();
-      if (bodyBytes == null) return null;
-      return bodyTransformer
-          .transform(Entity.ofBinaryOrText(bodyBytes, delegate.contentTypeHeader()))
-          .asBytes();
-    }
+  public Entity getBodyEntity() {
+    Entity delegateEntity = delegate.getBodyEntity();
+    return bodyTransformer != null ? bodyTransformer.transform(delegateEntity) : delegateEntity;
+  }
 
-    return delegate.getBody();
+  @Override
+  public byte[] getBody() {
+    return getBodyEntity().decompress().asBytes();
   }
 
   @Override
   public String getBodyAsString() {
-    if (bodyTransformer != null) {
-      byte[] bodyBytes = delegate.getBody();
-      if (bodyBytes == null) return null;
-      return bodyTransformer
-          .transform(Entity.ofBinaryOrText(bodyBytes, delegate.contentTypeHeader()))
-          .asString();
-    }
-
-    return delegate.getBodyAsString();
+    return getBodyEntity().decompress().asString();
   }
 
   @Override
   public String getBodyAsBase64() {
-    return encodeBase64(getBody());
+    return getBodyEntity().decompress().asBase64();
   }
 
   @Override

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -104,6 +104,10 @@ public class RequestTemplateModel {
     return cookies;
   }
 
+  public Entity getBodyEntity() {
+    return body;
+  }
+
   public String getBody() {
     return body.asString();
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -27,7 +27,6 @@ import com.github.jknack.handlebars.helper.ext.AssignHelper;
 import com.github.jknack.handlebars.helper.ext.NumberHelper;
 import com.github.tomakehurst.wiremock.common.Exceptions;
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
-import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.TemplateModelDataProviderExtension;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.SystemValueHelper;
@@ -176,7 +175,7 @@ public class TemplateEngine {
         adaptedHeaders,
         adaptedCookies,
         request.isMultipart(),
-        Entity.ofBinaryOrText(request.getBody(), request.contentTypeHeader()),
+        request.getBodyEntity(),
         buildRequestPartModel(request));
   }
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
@@ -16,9 +16,11 @@
 package com.github.tomakehurst.wiremock.http;
 
 import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
+import static com.github.tomakehurst.wiremock.common.entity.CompressionType.NONE;
 import static java.util.Objects.requireNonNull;
 
 import com.github.tomakehurst.wiremock.common.Strings;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -185,6 +187,11 @@ public class ImmutableRequest implements Request {
   @Override
   public String getBodyAsBase64() {
     return encodeBase64(getBody());
+  }
+
+  @Override
+  public Entity getBodyEntity() {
+    return Entity.forRequest(body, contentTypeHeader(), NONE);
   }
 
   @Override

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ImmutableRequest.java
@@ -15,12 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
-import static com.github.tomakehurst.wiremock.common.entity.CompressionType.NONE;
 import static java.util.Objects.requireNonNull;
 
-import com.github.tomakehurst.wiremock.common.Strings;
 import com.github.tomakehurst.wiremock.common.entity.Entity;
+import com.github.tomakehurst.wiremock.common.entity.EntityMetadata;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,7 +44,7 @@ public class ImmutableRequest implements Request {
   private final int port;
   private final String clientIp;
   private final HttpHeaders headers;
-  private final byte[] body;
+  private final Entity body;
   private final boolean multipart;
 
   private final Map<String, Part> parts;
@@ -62,7 +60,7 @@ public class ImmutableRequest implements Request {
       String protocol,
       String clientIp,
       HttpHeaders headers,
-      byte[] body,
+      Entity body,
       boolean multipart,
       boolean browserProxyRequest) {
     this.absoluteUrl = absoluteUrl;
@@ -176,22 +174,22 @@ public class ImmutableRequest implements Request {
 
   @Override
   public byte[] getBody() {
-    return body;
+    return body.asBytes();
   }
 
   @Override
   public String getBodyAsString() {
-    return Strings.stringFromBytes(body);
+    return body.asString();
   }
 
   @Override
   public String getBodyAsBase64() {
-    return encodeBase64(getBody());
+    return body.asBase64();
   }
 
   @Override
   public Entity getBodyEntity() {
-    return Entity.forRequest(body, contentTypeHeader(), NONE);
+    return body;
   }
 
   @Override
@@ -290,13 +288,16 @@ public class ImmutableRequest implements Request {
     }
 
     public ImmutableRequest build() {
+      HttpHeaders builtHeaders = new HttpHeaders(headers);
+      final Entity.Builder entityBuilder = Entity.builder().setData(body);
+      EntityMetadata.copyFromHeaders(builtHeaders, entityBuilder);
       return new ImmutableRequest(
           absoluteUrl,
           requestMethod,
           protocol,
           clientIp,
-          new HttpHeaders(headers),
-          body,
+          builtHeaders,
+          entityBuilder.build(),
           multipart,
           browserProxyRequest);
     }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -123,7 +123,9 @@ public interface Request {
 
   String getBodyAsBase64();
 
-  Entity getBodyEntity();
+  default Entity getBodyEntity() {
+    return Entity.of(getBody(), getHeaders());
+  }
 
   boolean isMultipart();
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -123,6 +123,8 @@ public interface Request {
 
   String getBodyAsBase64();
 
+  Entity getBodyEntity();
+
   boolean isMultipart();
 
   Collection<Part> getParts();

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/RequestIdDecorator.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/RequestIdDecorator.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.http;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.common.url.PathParams;
 import java.util.Collection;
 import java.util.Map;
@@ -155,6 +156,11 @@ public class RequestIdDecorator implements Request {
   @Override
   public String getBodyAsBase64() {
     return request.getBodyAsBase64();
+  }
+
+  @Override
+  public Entity getBodyEntity() {
+    return request.getBodyEntity();
   }
 
   @Override

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/RequestPathParamsDecorator.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/RequestPathParamsDecorator.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.common.url.PathParams;
 import com.github.tomakehurst.wiremock.common.url.PathTemplate;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
@@ -161,6 +162,11 @@ public class RequestPathParamsDecorator implements Request {
   @Override
   public String getBodyAsBase64() {
     return request.getBodyAsBase64();
+  }
+
+  @Override
+  public Entity getBodyEntity() {
+    return request.getBodyEntity();
   }
 
   @Override

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.http.multipart;
 
 import com.github.tomakehurst.wiremock.common.entity.Entity;
+import com.github.tomakehurst.wiremock.common.entity.Format;
 import com.github.tomakehurst.wiremock.http.*;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -66,7 +67,9 @@ public class FileItemPartAdapter implements Request.Part {
 
   @Override
   public Entity getBodyEntity() {
-    return Entity.ofBinaryOrText(fileItem.get(), new ContentTypeHeader(fileItem.getContentType()));
+    final ContentTypeHeader contentTypeHeader = new ContentTypeHeader(fileItem.getContentType());
+    final Format format = Format.fromContentTypeHeader(contentTypeHeader);
+    return Entity.builder().setFormat(format).setData(fileItem.get()).build();
   }
 
   public static final Function<FileItem, Request.Part> TO_PARTS = FileItemPartAdapter::new;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -16,24 +16,18 @@
 package com.github.tomakehurst.wiremock.verification;
 
 import static com.github.tomakehurst.wiremock.common.Encoding.decodeBase64;
-import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
-import static com.github.tomakehurst.wiremock.common.Lazy.lazy;
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.ensureImmutable;
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
-import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
 import static com.github.tomakehurst.wiremock.common.Urls.toQueryParameterMap;
-import static com.github.tomakehurst.wiremock.common.entity.EntityDefinition.DEFAULT_CHARSET;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.fasterxml.jackson.annotation.*;
 import com.github.tomakehurst.wiremock.common.Dates;
 import com.github.tomakehurst.wiremock.common.Json;
-import com.github.tomakehurst.wiremock.common.Lazy;
-import com.github.tomakehurst.wiremock.common.entity.CompressionType;
 import com.github.tomakehurst.wiremock.common.entity.Entity;
+import com.github.tomakehurst.wiremock.common.entity.EntityMetadata;
 import com.github.tomakehurst.wiremock.common.url.PathParams;
 import com.github.tomakehurst.wiremock.http.*;
-import java.nio.charset.Charset;
 import java.util.*;
 import java.util.function.Consumer;
 import org.jspecify.annotations.NonNull;
@@ -59,15 +53,11 @@ public class LoggedRequest implements Request {
   private final Map<String, Cookie> cookies;
   private final Map<String, QueryParameter> queryParams;
   private final Map<String, FormParameter> formParameters;
-  private final byte[] body;
+  private final Entity body;
   private final boolean isBrowserProxyRequest;
   private final Date loggedDate;
   private final Collection<Part> multiparts;
   private final String protocol;
-
-  private final Lazy<String> lazyBodyAsString;
-  private final Lazy<String> lazyBodyAsBase64;
-  private final Lazy<Entity> lazyBodyEntity;
 
   public static LoggedRequest createFrom(Request request) {
     return new LoggedRequest(
@@ -84,7 +74,7 @@ public class LoggedRequest implements Request {
         request.getCookies(),
         request.isBrowserProxyRequest(),
         new Date(),
-        request.getBody(),
+        request.getBodyEntity().decompress(),
         request.getParts(),
         request.getProtocol(),
         request.formParameters());
@@ -118,7 +108,7 @@ public class LoggedRequest implements Request {
         cookies,
         isBrowserProxyRequest,
         loggedDate,
-        decodeBase64(bodyAsBase64),
+        buildEntity(decodeBase64(bodyAsBase64), headers),
         multiparts,
         protocol,
         new HashMap<>());
@@ -138,7 +128,7 @@ public class LoggedRequest implements Request {
       Map<String, Cookie> cookies,
       boolean isBrowserProxyRequest,
       Date loggedDate,
-      byte[] body,
+      Entity body,
       Collection<Part> multiparts,
       String protocol,
       Map<String, FormParameter> formParameters) {
@@ -169,10 +159,12 @@ public class LoggedRequest implements Request {
     this.loggedDate = loggedDate;
     this.multiparts = ensureImmutable(multiparts);
     this.protocol = protocol;
+  }
 
-    lazyBodyAsString = lazy(() -> stringFromBytes(body, encodingFromContentTypeHeaderOrUtf8()));
-    lazyBodyAsBase64 = lazy(() -> encodeBase64(body));
-    lazyBodyEntity = lazy(() -> Entity.forRequest(body, contentTypeHeader(), CompressionType.NONE));
+  private static Entity buildEntity(byte[] bytes, HttpHeaders headers) {
+    final Entity.Builder entityBuilder = Entity.builder().setData(bytes);
+    EntityMetadata.copyFromHeaders(headers, entityBuilder);
+    return entityBuilder.build();
   }
 
   @Override
@@ -249,14 +241,6 @@ public class LoggedRequest implements Request {
     return null;
   }
 
-  private Charset encodingFromContentTypeHeaderOrUtf8() {
-    ContentTypeHeader contentTypeHeader = contentTypeHeader();
-    if (contentTypeHeader != null) {
-      return contentTypeHeader.charset().orElse(DEFAULT_CHARSET);
-    }
-    return DEFAULT_CHARSET;
-  }
-
   @Override
   public boolean containsHeader(String key) {
     return getHeader(key) != null;
@@ -275,25 +259,25 @@ public class LoggedRequest implements Request {
 
   @Override
   public byte[] getBody() {
-    return body;
+    return body.asBytes();
   }
 
   @Override
   @JsonProperty("body")
   public String getBodyAsString() {
-    return lazyBodyAsString.get();
+    return body.asString();
   }
 
   @Override
   @JsonProperty("bodyAsBase64")
   public String getBodyAsBase64() {
-    return lazyBodyAsBase64.get();
+    return body.asBase64();
   }
 
   @Override
   @JsonIgnore
   public Entity getBodyEntity() {
-    return lazyBodyEntity.get();
+    return body;
   }
 
   @Override
@@ -427,7 +411,7 @@ public class LoggedRequest implements Request {
       this.cookies = original.cookies;
       this.isBrowserProxyRequest = original.isBrowserProxyRequest;
       this.loggedDate = original.loggedDate;
-      this.body = original.body != null ? Arrays.copyOf(original.body, original.body.length) : null;
+      this.body = original.body.asBytes();
       this.multiparts = original.multiparts;
       this.protocol = original.protocol;
       this.formParameters = original.formParameters;
@@ -606,7 +590,7 @@ public class LoggedRequest implements Request {
           cookies,
           isBrowserProxyRequest,
           loggedDate,
-          body,
+          buildEntity(body, headers),
           multiparts,
           protocol,
           formParameters);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.annotation.*;
 import com.github.tomakehurst.wiremock.common.Dates;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.Lazy;
+import com.github.tomakehurst.wiremock.common.entity.CompressionType;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.common.url.PathParams;
 import com.github.tomakehurst.wiremock.http.*;
 import java.nio.charset.Charset;
@@ -65,6 +67,7 @@ public class LoggedRequest implements Request {
 
   private final Lazy<String> lazyBodyAsString;
   private final Lazy<String> lazyBodyAsBase64;
+  private final Lazy<Entity> lazyBodyEntity;
 
   public static LoggedRequest createFrom(Request request) {
     return new LoggedRequest(
@@ -169,6 +172,7 @@ public class LoggedRequest implements Request {
 
     lazyBodyAsString = lazy(() -> stringFromBytes(body, encodingFromContentTypeHeaderOrUtf8()));
     lazyBodyAsBase64 = lazy(() -> encodeBase64(body));
+    lazyBodyEntity = lazy(() -> Entity.forRequest(body, contentTypeHeader(), CompressionType.NONE));
   }
 
   @Override
@@ -284,6 +288,12 @@ public class LoggedRequest implements Request {
   @JsonProperty("bodyAsBase64")
   public String getBodyAsBase64() {
     return lazyBodyAsBase64.get();
+  }
+
+  @Override
+  @JsonIgnore
+  public Entity getBodyEntity() {
+    return lazyBodyEntity.get();
   }
 
   @Override

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -74,7 +74,7 @@ public class LoggedRequest implements Request {
         request.getCookies(),
         request.isBrowserProxyRequest(),
         new Date(),
-        request.getBodyEntity().decompress(),
+        getFirstNonNull(request.getBodyEntity(), Entity.EMPTY).decompress(),
         request.getParts(),
         request.getProtocol(),
         request.formParameters());

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
@@ -453,7 +453,7 @@ public class Diff {
 
   private void addBodySectionIfPresent(List<DiffLine<?>> builder) {
     List<ContentPattern<?>> bodyPatterns = requestPattern.getBodyPatterns();
-    Entity body = Entity.ofBinaryOrText(request.getBody(), request.contentTypeHeader());
+    Entity body = Entity.of(request.getBody(), request.getHeaders());
     addBodySectionIfPresent(bodyPatterns, body, builder);
   }
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/diff/EmptyToStringRequestWrapper.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/diff/EmptyToStringRequestWrapper.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.verification.diff;
 
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.http.*;
 import java.util.Collection;
 import java.util.Map;
@@ -141,6 +142,11 @@ public class EmptyToStringRequestWrapper implements Request {
   @Override
   public String getBodyAsBase64() {
     return target.getBodyAsBase64();
+  }
+
+  @Override
+  public Entity getBodyEntity() {
+    return target.getBodyEntity();
   }
 
   @Override

--- a/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/WireMockHttpServletRequestAdapter.java
+++ b/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/WireMockHttpServletRequestAdapter.java
@@ -17,16 +17,14 @@ package com.github.tomakehurst.wiremock.jetty;
 
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 import static com.github.tomakehurst.wiremock.common.Strings.isNullOrEmpty;
-import static com.github.tomakehurst.wiremock.common.entity.CompressionType.GZIP;
-import static com.github.tomakehurst.wiremock.common.entity.CompressionType.NONE;
 import static com.github.tomakehurst.wiremock.jetty.proxy.HttpProxyDetectingHandler.IS_HTTP_PROXY_REQUEST_ATTRIBUTE;
 import static com.github.tomakehurst.wiremock.jetty.proxy.HttpsProxyDetectingHandler.IS_HTTPS_PROXY_REQUEST_ATTRIBUTE;
 import static java.util.Collections.list;
 
 import com.github.tomakehurst.wiremock.common.Exceptions;
-import com.github.tomakehurst.wiremock.common.Gzip;
 import com.github.tomakehurst.wiremock.common.Lazy;
 import com.github.tomakehurst.wiremock.common.entity.Entity;
+import com.github.tomakehurst.wiremock.common.entity.EntityMetadata;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.http.multipart.PartParser;
 import com.google.common.collect.ImmutableMultimap;
@@ -167,13 +165,10 @@ public class WireMockHttpServletRequestAdapter implements Request {
   private Entity adaptBodyEntity() {
     byte[] rawBytes =
         Exceptions.uncheck(() -> request.getInputStream().readAllBytes(), byte[].class);
-    boolean isGzipped = hasGzipEncoding() || Gzip.isGzipped(rawBytes);
-    return Entity.forRequest(rawBytes, contentTypeHeader(), isGzipped ? GZIP : NONE);
-  }
 
-  private boolean hasGzipEncoding() {
-    String encodingHeader = request.getHeader("Content-Encoding");
-    return encodingHeader != null && encodingHeader.contains("gzip");
+    final Entity.Builder builder = Entity.builder().setData(rawBytes);
+    EntityMetadata.copyFromHeaders(getHeaders(), builder);
+    return builder.build();
   }
 
   @Override

--- a/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/WireMockHttpServletRequestAdapter.java
+++ b/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/WireMockHttpServletRequestAdapter.java
@@ -51,6 +51,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
   private final Lazy<@NonNull String> absoluteUrl;
   private final Lazy<@NonNull AbsoluteUrl> typedAbsoluteUrl;
   private final Lazy<Entity> bodyEntity;
+  private final Lazy<Entity> bodyEntityDecompressed;
   private final Lazy<Map<String, Cookie>> cookies;
   private final Lazy<Map<String, FormParameter>> formParameters;
   private final Lazy<Collection<Part>> multiParts;
@@ -72,6 +73,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
     this.headers = Lazy.lazy(this::adaptHeaders);
     this.cookies = Lazy.lazy(this::adaptCookies);
     this.bodyEntity = Lazy.lazy(this::adaptBodyEntity);
+    this.bodyEntityDecompressed = Lazy.lazy(() -> bodyEntity.get().decompress());
     this.formParameters = Lazy.lazy(() -> adaptFormParameters(request));
     this.multiParts = Lazy.lazy(this::adaptParts);
   }
@@ -159,7 +161,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
 
   @Override
   public byte[] getBody() {
-    return bodyEntity.get().decompress().asBytes();
+    return bodyEntityDecompressed.get().asBytes();
   }
 
   private Entity adaptBodyEntity() {
@@ -173,12 +175,12 @@ public class WireMockHttpServletRequestAdapter implements Request {
 
   @Override
   public String getBodyAsString() {
-    return bodyEntity.get().decompress().asString();
+    return bodyEntityDecompressed.get().asString();
   }
 
   @Override
   public String getBodyAsBase64() {
-    return bodyEntity.get().decompress().asBase64();
+    return bodyEntityDecompressed.get().asBase64();
   }
 
   @Override

--- a/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/WireMockHttpServletRequestAdapter.java
+++ b/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/WireMockHttpServletRequestAdapter.java
@@ -15,11 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.jetty;
 
-import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 import static com.github.tomakehurst.wiremock.common.Strings.isNullOrEmpty;
-import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
-import static com.github.tomakehurst.wiremock.common.entity.EntityDefinition.DEFAULT_CHARSET;
+import static com.github.tomakehurst.wiremock.common.entity.CompressionType.GZIP;
+import static com.github.tomakehurst.wiremock.common.entity.CompressionType.NONE;
 import static com.github.tomakehurst.wiremock.jetty.proxy.HttpProxyDetectingHandler.IS_HTTP_PROXY_REQUEST_ATTRIBUTE;
 import static com.github.tomakehurst.wiremock.jetty.proxy.HttpsProxyDetectingHandler.IS_HTTPS_PROXY_REQUEST_ATTRIBUTE;
 import static java.util.Collections.list;
@@ -27,6 +26,7 @@ import static java.util.Collections.list;
 import com.github.tomakehurst.wiremock.common.Exceptions;
 import com.github.tomakehurst.wiremock.common.Gzip;
 import com.github.tomakehurst.wiremock.common.Lazy;
+import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.http.multipart.PartParser;
 import com.google.common.collect.ImmutableMultimap;
@@ -52,7 +52,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
   private final Lazy<@NonNull PathAndQuery> pathAndQuery;
   private final Lazy<@NonNull String> absoluteUrl;
   private final Lazy<@NonNull AbsoluteUrl> typedAbsoluteUrl;
-  private final Lazy<byte[]> body;
+  private final Lazy<Entity> bodyEntity;
   private final Lazy<Map<String, Cookie>> cookies;
   private final Lazy<Map<String, FormParameter>> formParameters;
   private final Lazy<Collection<Part>> multiParts;
@@ -73,7 +73,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
     this.typedAbsoluteUrl = Lazy.lazy(this::adaptTypedAbsoluteUrl);
     this.headers = Lazy.lazy(this::adaptHeaders);
     this.cookies = Lazy.lazy(this::adaptCookies);
-    this.body = Lazy.lazy(this::adaptBody);
+    this.bodyEntity = Lazy.lazy(this::adaptBodyEntity);
     this.formParameters = Lazy.lazy(() -> adaptFormParameters(request));
     this.multiParts = Lazy.lazy(this::adaptParts);
   }
@@ -161,21 +161,14 @@ public class WireMockHttpServletRequestAdapter implements Request {
 
   @Override
   public byte[] getBody() {
-    return body.get();
+    return bodyEntity.get().decompress().asBytes();
   }
 
-  private byte[] adaptBody() {
-    byte[] body = Exceptions.uncheck(() -> request.getInputStream().readAllBytes(), byte[].class);
-    boolean isGzipped = hasGzipEncoding() || Gzip.isGzipped(body);
-    return isGzipped ? Gzip.unGzip(body) : body;
-  }
-
-  private Charset encodingFromContentTypeHeaderOrUtf8() {
-    ContentTypeHeader contentTypeHeader = contentTypeHeader();
-    if (contentTypeHeader != null) {
-      return contentTypeHeader.charset().orElse(DEFAULT_CHARSET);
-    }
-    return DEFAULT_CHARSET;
+  private Entity adaptBodyEntity() {
+    byte[] rawBytes =
+        Exceptions.uncheck(() -> request.getInputStream().readAllBytes(), byte[].class);
+    boolean isGzipped = hasGzipEncoding() || Gzip.isGzipped(rawBytes);
+    return Entity.forRequest(rawBytes, contentTypeHeader(), isGzipped ? GZIP : NONE);
   }
 
   private boolean hasGzipEncoding() {
@@ -185,12 +178,17 @@ public class WireMockHttpServletRequestAdapter implements Request {
 
   @Override
   public String getBodyAsString() {
-    return stringFromBytes(getBody(), encodingFromContentTypeHeaderOrUtf8());
+    return bodyEntity.get().decompress().asString();
   }
 
   @Override
   public String getBodyAsBase64() {
-    return encodeBase64(getBody());
+    return bodyEntity.get().decompress().asBase64();
+  }
+
+  @Override
+  public Entity getBodyEntity() {
+    return bodyEntity.get();
   }
 
   @Override

--- a/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/servlet/WireMockHttpServletMultipartAdapter.java
+++ b/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/servlet/WireMockHttpServletMultipartAdapter.java
@@ -77,7 +77,7 @@ public class WireMockHttpServletMultipartAdapter implements Request.Part {
           header.isPresent()
               ? new ContentTypeHeader(header.firstValue())
               : ContentTypeHeader.absent();
-      return Entity.ofBinaryOrText(bytes, contentTypeHeader);
+      return Entity.of(bytes, headers);
     } catch (IOException e) {
       return throwUnchecked(e, Entity.class);
     }


### PR DESCRIPTION
Add an extra method to `Request` returning the body as an Entity. Make use of this at call sites.