### PR TITLE
chore: Move errorprone into conventions plugin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   implementation("com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:9.2.2")
   implementation("org.sonarqube:org.sonarqube.gradle.plugin:6.2.0.5505")
   implementation("com.vanniktech.maven.publish.base:com.vanniktech.maven.publish.base.gradle.plugin:0.35.0")
+  implementation("net.ltgt.errorprone:net.ltgt.errorprone.gradle.plugin:5.1.0")
 }
 
 java {

--- a/buildSrc/src/main/kotlin/wiremock.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/wiremock.common-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import net.ltgt.gradle.errorprone.CheckSeverity
+import net.ltgt.gradle.errorprone.errorprone
 import org.gradle.api.JavaVersion.VERSION_17
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import java.net.URI
@@ -12,6 +14,7 @@ plugins {
   id("com.gradleup.shadow")
   id("org.sonarqube")
   id("com.vanniktech.maven.publish.base")
+  id("net.ltgt.errorprone")
 }
 
 group = "org.wiremock"
@@ -19,6 +22,26 @@ version = "4.0.0-beta.36"
 
 repositories {
   mavenCentral()
+}
+
+dependencies {
+  annotationProcessor("com.uber.nullaway:nullaway:0.13.4")
+  errorprone("com.google.errorprone:error_prone_core:2.42.0")
+}
+
+tasks.compileJava {
+  options.errorprone {
+    check("NullAway", CheckSeverity.ERROR)
+    check("NullableOptional", CheckSeverity.OFF)
+    check("ClassInitializationDeadlock", CheckSeverity.OFF)
+    option("NullAway:AnnotatedPackages", "org.wiremock.url")
+  }
+}
+
+tasks.compileTestJava {
+  options.errorprone {
+    disableAllChecks = true
+  }
 }
 
 java {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/DateTimeOffset.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/DateTimeOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 Thomas Akehurst
+ * Copyright (C) 2021-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock.common;
 
 import static com.github.tomakehurst.wiremock.common.DateTimeUnit.SECONDS;
 
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
@@ -71,7 +71,7 @@ public class DateTimeOffset {
       return date;
     }
 
-    final ZonedDateTime input = ZonedDateTime.ofInstant(date.toInstant(), ZoneId.of("Z"));
+    final ZonedDateTime input = ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC);
     ZonedDateTime output = shift(input);
     return Date.from(output.toInstant());
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/Dates.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/Dates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock.common;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -34,6 +34,6 @@ public class Dates {
   }
 
   public static String format(Date date) {
-    return DateTimeFormatter.ISO_ZONED_DATE_TIME.format(date.toInstant().atZone(ZoneId.of("Z")));
+    return DateTimeFormatter.ISO_ZONED_DATE_TIME.format(date.toInstant().atZone(ZoneOffset.UTC));
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/IncomingMessageTrigger.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/IncomingMessageTrigger.java
@@ -25,10 +25,8 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.matching.ContentPattern;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import java.util.Objects;
-import org.jspecify.annotations.NullMarked;
 
 @JsonInclude(NON_EMPTY)
-@NullMarked
 public class IncomingMessageTrigger implements MessageTrigger {
 
   public static final IncomingMessageTrigger ANYTHING = new IncomingMessageTrigger(null, null);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/Message.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/Message.java
@@ -46,8 +46,7 @@ public class Message {
   }
 
   @JsonIgnore
-  @Nullable
-  public byte[] getBodyAsBytes() {
+  public byte @Nullable [] getBodyAsBytes() {
     if (body == Entity.EMPTY) {
       return null;
     }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/ChannelProvider.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/ChannelProvider.java
@@ -30,7 +30,7 @@ public class ChannelProvider {
 
   private final String name;
   private final String driverType;
-  @Nullable private final Map<String, Object> settings;
+  private final Map<String, Object> settings;
 
   @JsonCreator
   public ChannelProvider(

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedMessageChannel.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedMessageChannel.java
@@ -47,11 +47,12 @@ public sealed interface LoggedMessageChannel
           fixedChannel.getProviderName(),
           fixedChannel.getChannelName());
     }
-    LoggedRequest loggedRequest = null;
     if (channel instanceof RequestInitiatedMessageChannel requestChannel) {
-      loggedRequest = LoggedRequest.createFrom(requestChannel.getInitiatingRequest());
+      LoggedRequest loggedRequest = LoggedRequest.createFrom(requestChannel.getInitiatingRequest());
+      return new LoggedRequestInitiatedChannel(
+          channel.getId(), channel.getType(), loggedRequest, channel.isOpen());
     }
-    return new LoggedRequestInitiatedChannel(
-        channel.getId(), channel.getType(), loggedRequest, channel.isOpen());
+    throw new IllegalArgumentException(
+        "Unsupported message channel type: " + channel.getClass().getName());
   }
 }

--- a/wiremock-url/wiremock-string-parser-jackson2/build.gradle.kts
+++ b/wiremock-url/wiremock-string-parser-jackson2/build.gradle.kts
@@ -1,11 +1,7 @@
 @file:Suppress("VulnerableLibrariesLocal")
 
-import net.ltgt.gradle.errorprone.CheckSeverity
-import net.ltgt.gradle.errorprone.errorprone
-
 plugins {
   id("wiremock.common-conventions")
-  id("net.ltgt.errorprone") version "5.1.0"
 }
 
 tasks.jar {
@@ -17,18 +13,6 @@ dependencies {
   api(project(":wiremock-url:wiremock-string-parser"))
   api("com.fasterxml.jackson.core:jackson-core:2.5.0")
   api("com.fasterxml.jackson.core:jackson-databind:2.5.0")
-
-  annotationProcessor("com.uber.nullaway:nullaway:0.13.4")
-  errorprone("com.google.errorprone:error_prone_core:2.42.0")
-}
-
-tasks.compileJava {
-  options.errorprone {
-    check("NullAway", CheckSeverity.ERROR)
-    check("NullableOptional", CheckSeverity.OFF)
-    check("ClassInitializationDeadlock", CheckSeverity.OFF)
-    option("NullAway:AnnotatedPackages", "org.wiremock.url")
-  }
 }
 
 publishing {

--- a/wiremock-url/wiremock-string-parser-jackson3/build.gradle.kts
+++ b/wiremock-url/wiremock-string-parser-jackson3/build.gradle.kts
@@ -1,9 +1,5 @@
-import net.ltgt.gradle.errorprone.CheckSeverity
-import net.ltgt.gradle.errorprone.errorprone
-
 plugins {
   id("wiremock.common-conventions")
-  id("net.ltgt.errorprone") version "5.1.0"
 }
 
 tasks.jar {
@@ -15,18 +11,6 @@ dependencies {
   api(project(":wiremock-url:wiremock-string-parser"))
   api("tools.jackson.core:jackson-core:3.0.0")
   api("tools.jackson.core:jackson-databind:3.0.0")
-
-  annotationProcessor("com.uber.nullaway:nullaway:0.13.4")
-  errorprone("com.google.errorprone:error_prone_core:2.42.0")
-}
-
-tasks.compileJava {
-  options.errorprone {
-    check("NullAway", CheckSeverity.ERROR)
-    check("NullableOptional", CheckSeverity.OFF)
-    check("ClassInitializationDeadlock", CheckSeverity.OFF)
-    option("NullAway:AnnotatedPackages", "org.wiremock.url")
-  }
 }
 
 publishing {

--- a/wiremock-url/wiremock-string-parser/build.gradle.kts
+++ b/wiremock-url/wiremock-string-parser/build.gradle.kts
@@ -1,9 +1,5 @@
-import net.ltgt.gradle.errorprone.CheckSeverity
-import net.ltgt.gradle.errorprone.errorprone
-
 plugins {
   id("wiremock.common-conventions")
-  id("net.ltgt.errorprone") version "5.1.0"
 }
 
 tasks.jar {
@@ -12,18 +8,6 @@ tasks.jar {
 
 dependencies {
   api("org.jspecify:jspecify:1.0.0")
-
-  annotationProcessor("com.uber.nullaway:nullaway:0.13.4")
-  errorprone("com.google.errorprone:error_prone_core:2.42.0")
-}
-
-tasks.compileJava {
-  options.errorprone {
-    check("NullAway", CheckSeverity.ERROR)
-    check("NullableOptional", CheckSeverity.OFF)
-    check("ClassInitializationDeadlock", CheckSeverity.OFF)
-    option("NullAway:AnnotatedPackages", "org.wiremock.url")
-  }
 }
 
 publishing {

--- a/wiremock-url/wiremock-url-jackson2/build.gradle.kts
+++ b/wiremock-url/wiremock-url-jackson2/build.gradle.kts
@@ -1,11 +1,7 @@
 @file:Suppress("VulnerableLibrariesLocal")
 
-import net.ltgt.gradle.errorprone.CheckSeverity
-import net.ltgt.gradle.errorprone.errorprone
-
 plugins {
   id("wiremock.common-conventions")
-  id("net.ltgt.errorprone") version "5.1.0"
 }
 
 tasks.jar {
@@ -32,24 +28,6 @@ dependencies {
 
   testRuntimeOnly(libs.junit.jupiter)
   testRuntimeOnly(libs.junit.platform.launcher)
-
-  annotationProcessor("com.uber.nullaway:nullaway:0.13.4")
-  errorprone("com.google.errorprone:error_prone_core:2.42.0")
-}
-
-tasks.compileJava {
-  options.errorprone {
-    check("NullAway", CheckSeverity.ERROR)
-    check("NullableOptional", CheckSeverity.OFF)
-    check("ClassInitializationDeadlock", CheckSeverity.OFF)
-    option("NullAway:AnnotatedPackages", "org.wiremock.url")
-  }
-}
-
-tasks.compileTestJava {
-  options.errorprone {
-    disableAllChecks = true
-  }
 }
 
 publishing {

--- a/wiremock-url/wiremock-url-jackson3/build.gradle.kts
+++ b/wiremock-url/wiremock-url-jackson3/build.gradle.kts
@@ -1,9 +1,5 @@
-import net.ltgt.gradle.errorprone.CheckSeverity
-import net.ltgt.gradle.errorprone.errorprone
-
 plugins {
   id("wiremock.common-conventions")
-  id("net.ltgt.errorprone") version "5.1.0"
 }
 
 tasks.jar {
@@ -28,24 +24,6 @@ dependencies {
 
   testRuntimeOnly(libs.junit.jupiter)
   testRuntimeOnly(libs.junit.platform.launcher)
-
-  annotationProcessor("com.uber.nullaway:nullaway:0.13.4")
-  errorprone("com.google.errorprone:error_prone_core:2.42.0")
-}
-
-tasks.compileJava {
-  options.errorprone {
-    check("NullAway", CheckSeverity.ERROR)
-    check("NullableOptional", CheckSeverity.OFF)
-    check("ClassInitializationDeadlock", CheckSeverity.OFF)
-    option("NullAway:AnnotatedPackages", "org.wiremock.url")
-  }
-}
-
-tasks.compileTestJava {
-  options.errorprone {
-    disableAllChecks = true
-  }
 }
 
 publishing {

--- a/wiremock-url/wiremock-url/build.gradle.kts
+++ b/wiremock-url/wiremock-url/build.gradle.kts
@@ -1,10 +1,6 @@
-import net.ltgt.gradle.errorprone.CheckSeverity
-import net.ltgt.gradle.errorprone.errorprone
-
 plugins {
   id("wiremock.common-conventions")
   alias(libs.plugins.jmh)
-  id("net.ltgt.errorprone") version "5.1.0"
 }
 
 tasks.jar {
@@ -40,24 +36,6 @@ dependencies {
   jmh(libs.jackson.core)
   jmh(libs.jackson.databind)
   jmh(libs.commons.lang)
-
-  annotationProcessor("com.uber.nullaway:nullaway:0.13.4")
-  errorprone("com.google.errorprone:error_prone_core:2.42.0")
-}
-
-tasks.compileJava {
-  options.errorprone {
-    check("NullAway", CheckSeverity.ERROR)
-    check("NullableOptional", CheckSeverity.OFF)
-    check("ClassInitializationDeadlock", CheckSeverity.OFF)
-    option("NullAway:AnnotatedPackages", "org.wiremock.url")
-  }
-}
-
-tasks.compileTestJava {
-  options.errorprone {
-    disableAllChecks = true
-  }
 }
 
 jmh {


### PR DESCRIPTION
The errorprone/NullAway setup was duplicated across the six wiremock-url build files. Applying it from the shared wiremock.common-conventions precompiled script plugin removes that duplication and extends the same static analysis to every module. Precompiled script plugins can't use the version catalog's alias(), so the plugin is declared in buildSrc and the now-unused catalog entry is dropped.

Extending NullAway to wiremock-core surfaced real issues, fixed at source rather than by loosening the checks: two ZoneId.of("Z") uses flagged by ZoneIdOfZ, an always-assigned field wrongly marked @Nullable, a @Nullable bound to the byte element instead of the array, and a createFrom path that could build a request-initiated channel with no request.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
