### PR TITLE
Switch to tag-based releases with version derived from tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release
 
 on:
-  workflow_dispatch:
+  push:
+    tags:
+      - '[0-9]*'
 
 jobs:
   publish-core:
@@ -10,27 +12,29 @@ jobs:
       contents: read
       packages: write
     outputs:
-      version: ${{ steps.get_version.outputs.version }}
+      version: ${{ steps.parse_version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+
+      - id: parse_version
+        run: echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           validate-wrappers: true
 
-      - name: Get version
-        id: get_version
-        run: echo "version=$(grep '^version=' wiremock-core/src/main/resources/version.properties | cut -d= -f2)" >> $GITHUB_OUTPUT
+      - name: Apply release version
+        run: ./gradlew apply-release-version -PreleaseVersion=${{ steps.parse_version.outputs.version }} --no-configuration-cache --stacktrace
 
       - name: Publish core package
-        id: publish_package
-        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache --stacktrace
-
+        run: ./gradlew publishAndReleaseToMavenCentral -PreleaseVersion=${{ steps.parse_version.outputs.version }} --no-configuration-cache --stacktrace
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ vars.MAVEN_CENTRAL_USERNAME }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -207,7 +207,6 @@ publishing {
 
 val checkReleasePreconditions by tasks.registering  {
   doLast {
-    if (System.getenv("CI") == "true") return@doLast
     val releaseBranches = listOf("master", "v4.x")
     val currentGitBranch = providers.exec {
       commandLine("git", "rev-parse", "--abbrev-ref", "HEAD")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -207,6 +207,7 @@ publishing {
 
 val checkReleasePreconditions by tasks.registering  {
   doLast {
+    if (System.getenv("CI") == "true") return@doLast
     val releaseBranches = listOf("master", "v4.x")
     val currentGitBranch = providers.exec {
       commandLine("git", "rev-parse", "--abbrev-ref", "HEAD")
@@ -251,7 +252,6 @@ tasks.register("localRelease") {
 fun updateFiles(currentVersion: String, nextVersion: String) {
 
   val filesWithVersion: Map<String, (String) -> String> = mapOf(
-    "buildSrc/src/main/kotlin/wiremock.common-conventions.gradle.kts"    to { "version = \"${it}\"" },
     "ui/package.json"                                                    to { "\"version\": \"${it}\"" },
     "wiremock-core/src/main/resources/version.properties"              to { "version=${it}" },
     "wiremock-core/src/main/resources/swagger/wiremock-admin-api.json" to { "\"version\": \"${it}\"" },
@@ -304,14 +304,31 @@ tasks.register("bump-pre-release-version") {
   }
 }
 
+tasks.register("apply-release-version") {
+  doLast {
+    val releaseVersion = requireNotNull(project.findProperty("releaseVersion")?.toString()) {
+      "releaseVersion property must be specified (e.g. -PreleaseVersion=4.0.1)"
+    }
+    updateFiles("0.0.0-dev", releaseVersion)
+  }
+}
+
 tasks.register("set-snapshot-version") {
   doLast {
-
-    val currentVersion = Version.fromString(project.version.toString())
+    val currentVersionStr = project.version.toString()
     val nextVersion = project.findProperty("snapshotVersion")?.toString()
-      ?: "${currentVersion.incrementMinor()}-SNAPSHOT"
+      ?: run {
+          val baseVersionStr = if (currentVersionStr == "0.0.0-dev") {
+            providers.exec {
+              commandLine("git", "describe", "--tags", "--abbrev=0", "--match=[0-9]*")
+            }.standardOutput.asText.get().trim().removePrefix("v")
+          } else {
+            currentVersionStr
+          }
+          "${Version.fromString(baseVersionStr).incrementMinor()}-SNAPSHOT"
+        }
 
-    updateFiles(currentVersion.toString(), nextVersion)
+    updateFiles(currentVersionStr, nextVersion)
   }
 }
 

--- a/buildSrc/src/main/kotlin/wiremock.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/wiremock.common-conventions.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = "org.wiremock"
-version = "4.0.0-beta.36"
+version = providers.gradleProperty("releaseVersion").getOrElse("0.0.0-dev")
 
 repositories {
   mavenCentral()

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiremock-ui-resources",
-  "version": "4.0.0-beta.36",
+  "version": "0.0.0-dev",
   "description": "WireMock UI resources processor",
   "engines": {
     "node": ">= 0.10.0"

--- a/wiremock-core/src/main/resources/swagger/wiremock-admin-api.json
+++ b/wiremock-core/src/main/resources/swagger/wiremock-admin-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "WireMock",
-    "version": "4.0.0-beta.36",
+    "version": "0.0.0-dev",
     "description": "WireMock offers a REST API for administration, troubleshooting and analysis purposes"
   },
   "servers": [

--- a/wiremock-core/src/main/resources/swagger/wiremock-admin-api.yaml
+++ b/wiremock-core/src/main/resources/swagger/wiremock-admin-api.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 
 info:
   title: WireMock
-  version: 4.0.0-beta.36
+  version: 0.0.0-dev
   description: "WireMock offers a REST API for administration, troubleshooting and analysis purposes"
 
 externalDocs:

--- a/wiremock-core/src/main/resources/version.properties
+++ b/wiremock-core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=4.0.0-beta.36
+version=0.0.0-dev


### PR DESCRIPTION
Releases are now triggered by pushing a semver tag (e.g. 4.0.1) rather than via workflow_dispatch. The version is no longer committed to source — all projects default to 0.0.0-dev, and the release workflow passes -PreleaseVersion=<tag> to Gradle to stamp the build and all version files (version.properties, swagger specs, package.json) transiently via the new apply-release-version task.

The set-snapshot-version task now derives its base version from the latest git tag when the committed version is the 0.0.0-dev placeholder, keeping snapshot publishing working without manual version bumps.
