### PR TITLE
Fix standalone service descriptor merging

### DIFF
--- a/wiremock-standalone/build.gradle.kts
+++ b/wiremock-standalone/build.gradle.kts
@@ -64,6 +64,10 @@ tasks.shadowJar {
     exclude(dependency("junit:junit"))
   }
 
+  filesMatching("META-INF/services/**") {
+    duplicatesStrategy = org.gradle.api.file.DuplicatesStrategy.INCLUDE
+  }
+
   mergeServiceFiles()
 
   exclude("META-INF/maven/**")


### PR DESCRIPTION
This fixes standalone JAR service descriptor merging so the Apache HTTP client factory is preserved in `META-INF/services/com.github.tomakehurst.wiremock.extension.Extension`.

Shadow 9.x applies duplicate handling before resource transformers. Since duplicate resources can be excluded before `mergeServiceFiles()` runs, the standalone JAR can drop service provider entries such as `ApacheHttpClientFactory`.

This adds a targeted duplicate strategy override for `META-INF/services/**` while keeping the existing `mergeServiceFiles()` configuration.

Validation performed:

* Ran `git diff --check`
* Ran `./gradlew :wiremock-standalone:shadowJar`
* Inspected `wiremock-standalone/build/libs/wiremock-standalone-4.0.0-beta.36.jar`
* Verified `META-INF/services/com.github.tomakehurst.wiremock.extension.Extension` contains:

  * `com.github.tomakehurst.wiremock.jetty.JettyHttpServerFactory`
  * `com.github.tomakehurst.wiremock.http.client.apache5.ApacheHttpClientFactory`

## References

* Fixes #3452
* Related: #3406

## Submitter checklist

* [ ] Recommended: Join [[WireMock Slack](https://slack.wiremock.org/)](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
* [x] The PR request is well described and justified, including the body and the references
* [x] The PR title represents the desired changelog entry
* [x] The repository's code style is followed (see the contributing guide)
* [x] Test coverage that demonstrates that the change works as expected
* [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [[wiremock.org](https://github.com/wiremock/wiremock.org)](https://github.com/wiremock/wiremock.org)