### PR TITLE
Preserve recorded text response charset bytes

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.github.tomakehurst.wiremock.recording;
 import static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.responseDefinition;
 import static com.github.tomakehurst.wiremock.common.Limit.UNLIMITED;
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.tomakehurst.wiremock.http.*;
@@ -47,6 +49,24 @@ public class LoggedResponseDefinitionTransformerTest {
     final ResponseDefinition expected =
         responseDefinition().withHeader("Content-Type", "text/plain").withBody("foo").build();
     assertEquals(expected, aTransformer().apply(response));
+  }
+
+  @Test
+  public void applyWithTextBodyPreservesOriginalCharsetBytes() {
+    final String body = "Grüße, Köln";
+    final byte[] bodyBytes = body.getBytes(ISO_8859_1);
+    final LoggedResponse response =
+        LoggedResponse.from(
+            Response.response()
+                .headers(new HttpHeaders(new ContentTypeHeader("text/plain; charset=ISO-8859-1")))
+                .body(bodyBytes)
+                .build(),
+            UNLIMITED);
+
+    final ResponseDefinition result = aTransformer().apply(response);
+
+    assertEquals(body, result.getTextBody());
+    assertArrayEquals(bodyBytes, result.getByteBody());
   }
 
   @Test

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Thomas Akehurst
+ * Copyright (C) 2017-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import static com.github.tomakehurst.wiremock.common.ContentTypes.*;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.common.Gzip;
-import com.github.tomakehurst.wiremock.common.Strings;
+import com.github.tomakehurst.wiremock.common.entity.EntityDefinition;
 import com.github.tomakehurst.wiremock.http.*;
 import java.nio.charset.Charset;
 import java.util.List;
@@ -50,7 +50,8 @@ public class LoggedResponseDefinitionTransformer
       String mimeType = response.getMimeType();
       Charset charset = response.getCharset();
       if (determineIsTextFromMimeType(mimeType)) {
-        responseDefinitionBuilder.withBody(Strings.stringFromBytes(body, charset));
+        responseDefinitionBuilder.withEntityBody(
+            EntityDefinition.builder().setCharset(charset).setData(body).build());
       } else {
         responseDefinitionBuilder.withBody(body);
       }


### PR DESCRIPTION
## Summary

Fixes #3414.

This preserves the original bytes for recorded text response bodies when the response declares a non-UTF-8 charset.

Previously, `LoggedResponseDefinitionTransformer` decoded text response bytes using the response charset, then stored the result through `withBody(String)`. When the recorded body was later extracted to a file, the body bytes could be written as UTF-8 instead of the original charset bytes.

The change stores the original response bytes with the detected charset metadata, so recorded text remains readable while file extraction preserves the original bytes.

## References

- Fixes #3414


## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)