### PR TITLE
Add deleteChannel to ChannelProviderDriver and wire through on removal

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/CustomChannelDriverAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CustomChannelDriverAcceptanceTest.java
@@ -23,6 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.fixedChannel;
 import static com.github.tomakehurst.wiremock.client.WireMock.message;
 import static com.github.tomakehurst.wiremock.client.WireMock.messageStubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.registerChannelProvider;
+import static com.github.tomakehurst.wiremock.client.WireMock.removeMessageChannel;
 import static com.github.tomakehurst.wiremock.client.WireMock.resetMessageJournal;
 import static com.github.tomakehurst.wiremock.client.WireMock.resetMessageStubs;
 import static com.github.tomakehurst.wiremock.client.WireMock.sendMessage;
@@ -31,6 +32,8 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.waitAtMost;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 
 import com.github.tomakehurst.wiremock.message.Message;
 import com.github.tomakehurst.wiremock.message.channel.ChannelProvider;
@@ -40,6 +43,7 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.AfterAll;
@@ -92,6 +96,16 @@ public class CustomChannelDriverAcceptanceTest {
   }
 
   @Test
+  void deletingFixedChannelInvokesDriverDeleteChannel() {
+    UUID tempId =
+        createFixedChannel(fixedChannel().onProvider("custom-events").named("temp-delete"));
+
+    removeMessageChannel(tempId);
+
+    assertThat(driver.getDeletedChannels(), hasItem("temp-delete"));
+  }
+
+  @Test
   void inboundMessageViaCustomDriverTriggersSend() {
     messageStubFor(
         message()
@@ -110,6 +124,7 @@ public class CustomChannelDriverAcceptanceTest {
 
     private final Map<String, InboundMessageSink> sinks = new ConcurrentHashMap<>();
     private final Map<String, List<String>> sentMessages = new ConcurrentHashMap<>();
+    private final List<String> deletedChannels = new CopyOnWriteArrayList<>();
 
     @Override
     public String getName() {
@@ -134,6 +149,15 @@ public class CustomChannelDriverAcceptanceTest {
           .add(message.getBodyAsString());
     }
 
+    @Override
+    public void deleteChannel(ChannelProvider provider, String channelName) {
+      deletedChannels.add(channelName);
+    }
+
+    public List<String> getDeletedChannels() {
+      return deletedChannels;
+    }
+
     public void receive(String channelName, String body) {
       InboundMessageSink sink = sinks.get(channelName);
       sink.receive(Message.builder().withTextBody(body).build());
@@ -145,6 +169,7 @@ public class CustomChannelDriverAcceptanceTest {
 
     public void reset() {
       sentMessages.clear();
+      deletedChannels.clear();
     }
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/InMemoryChannelDriverReceiveAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/InMemoryChannelDriverReceiveAcceptanceTest.java
@@ -28,8 +28,10 @@ import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import com.github.tomakehurst.wiremock.verification.MessageServeEvent;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -72,6 +74,16 @@ public class InMemoryChannelDriverReceiveAcceptanceTest {
   void resetPerTest() {
     resetMessageStubs();
     resetMessageJournal();
+  }
+
+  @Test
+  void deletedChannelSinkIsRemovedFromDriver() {
+    UUID tempId = createFixedChannel(fixedChannel().onProvider(PROVIDER).named("temp"));
+    removeMessageChannel(tempId);
+
+    Assertions.assertThrows(
+        IllegalStateException.class,
+        () -> driver.receive(PROVIDER, "temp", Message.builder().withTextBody("test").build()));
   }
 
   @Test

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/FixedChannel.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/FixedChannel.java
@@ -56,7 +56,9 @@ public class FixedChannel implements MessageChannel {
   }
 
   @Override
-  public void close() {}
+  public void close() {
+    driver.deleteChannel(provider, channelName);
+  }
 
   public String getProviderName() {
     return provider.getName();

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/MessageChannels.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/MessageChannels.java
@@ -49,10 +49,7 @@ public class MessageChannels {
   }
 
   public void remove(UUID id) {
-    store
-        .get(id)
-        .filter(RequestInitiatedMessageChannel.class::isInstance)
-        .ifPresent(MessageChannel::close);
+    store.get(id).ifPresent(MessageChannel::close);
     store.remove(id);
   }
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/ChannelProviderDriver.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/ChannelProviderDriver.java
@@ -24,4 +24,6 @@ public interface ChannelProviderDriver {
   void createChannel(ChannelProvider provider, String channelName, InboundMessageSink sink);
 
   void send(ChannelProvider provider, String channelName, Message message);
+
+  void deleteChannel(ChannelProvider provider, String channelName);
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/InMemoryChannelProviderDriver.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/InMemoryChannelProviderDriver.java
@@ -41,6 +41,11 @@ public class InMemoryChannelProviderDriver implements ChannelProviderDriver {
     // The in-memory driver has no additional transport to perform.
   }
 
+  @Override
+  public void deleteChannel(ChannelProvider provider, String channelName) {
+    sinks.remove(key(provider.getName(), channelName));
+  }
+
   /**
    * Simulates an inbound message arriving on the named channel. Routes directly into WireMock's
    * stub-matching pipeline via the sink registered at channel-creation time.


### PR DESCRIPTION
ChannelProviderDriver now has a deleteChannel method so drivers can clean up resources when a fixed channel is removed. FixedChannel.close() calls it, and MessageChannels.remove() now calls close() on all channel types rather than only RequestInitiatedMessageChannel. InMemoryChannelProviderDriver removes the registered sink on deletion.

