### PR TITLE
Fix message channel bugs: routing, templating, required field validation

### DIFF
--- a/.github/workflows/publish-branch-snapshot.yml
+++ b/.github/workflows/publish-branch-snapshot.yml
@@ -1,0 +1,42 @@
+name: Publish Branch Snapshots
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - message-mapping-fixes
+
+jobs:
+  publish-branch-snapshot:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          validate-wrappers: true
+
+      - name: Compute branch snapshot version
+        id: version
+        run: |
+          BASE_VERSION=$(grep '^version=' wiremock-core/src/main/resources/version.properties | cut -d= -f2)
+          BRANCH_SLUG=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+          echo "snapshot_version=${BASE_VERSION}-${BRANCH_SLUG}-SNAPSHOT" >> "$GITHUB_OUTPUT"
+
+      - name: Set snapshot version
+        run: ./gradlew set-snapshot-version --stacktrace -PsnapshotVersion=${{ steps.version.outputs.snapshot_version }}
+
+      - name: Publish to GitHub Packages
+        run: ./gradlew publishMavenJavaPublicationToGitHubPackagesRepository --stacktrace
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-branch-snapshot.yml
+++ b/.github/workflows/publish-branch-snapshot.yml
@@ -2,9 +2,6 @@ name: Publish Branch Snapshots
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - message-mapping-fixes
 
 jobs:
   publish-branch-snapshot:

--- a/src/test/java/com/github/tomakehurst/wiremock/CustomChannelDriverAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CustomChannelDriverAcceptanceTest.java
@@ -27,6 +27,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.removeMessageChann
 import static com.github.tomakehurst.wiremock.client.WireMock.resetMessageJournal;
 import static com.github.tomakehurst.wiremock.client.WireMock.resetMessageStubs;
 import static com.github.tomakehurst.wiremock.client.WireMock.sendMessage;
+import static com.github.tomakehurst.wiremock.client.WireMock.sendMessageToFixedChannel;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern;
@@ -103,6 +104,13 @@ public class CustomChannelDriverAcceptanceTest {
     removeMessageChannel(tempId);
 
     assertThat(driver.getDeletedChannels(), hasItem("temp-delete"));
+  }
+
+  @Test
+  void adminApiSendChannelMessageRoutesToDriverSend() {
+    sendMessageToFixedChannel("custom-events", "orders", "published-message");
+
+    waitAtMost(5, SECONDS).until(() -> driver.getMessages("orders").contains("published-message"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/FixedMessageChannelAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/FixedMessageChannelAcceptanceTest.java
@@ -29,15 +29,19 @@ import com.github.tomakehurst.wiremock.common.ConflictException;
 import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.message.MessageStubMapping;
 import com.github.tomakehurst.wiremock.verification.MessageServeEvent;
+import com.github.tomakehurst.wiremock.message.SendMessageAction;
+import com.github.tomakehurst.wiremock.testsupport.WebsocketTestClient;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class FixedMessageChannelAcceptanceTest extends AcceptanceTestBase {
+public class FixedMessageChannelAcceptanceTest extends WebsocketAcceptanceTestBase {
 
   static UUID channelId;
 
@@ -227,6 +231,28 @@ public class FixedMessageChannelAcceptanceTest extends AcceptanceTestBase {
 
     assertThat(event.isPresent(), is(true));
     assertThat(event.get().getMessage().getBodyAsString(), is("pong"));
+  }
+
+  @Test
+  void inboundFixedChannelMessageIsForwardedToMatchingRequestInitiatedChannels() {
+    messageStubFor(
+        message()
+            .withName("Forward fixed channel message to WebSocket subscribers")
+            .triggeredByMessageOnChannel("events", "orders")
+            .withBody(equalTo("forward-me"))
+            .triggersAction(
+                sendMessage("forwarded")
+                    .onChannelsMatching(newRequestPattern().withUrl("/ws-subscribers")))
+            .build());
+
+    WebsocketTestClient wsClient = new WebsocketTestClient();
+    wsClient.connect(websocketUrl("/ws-subscribers"));
+    Awaitility.waitAtMost(5, TimeUnit.SECONDS).until(wsClient::isConnected);
+
+    sendMessageToFixedChannel("events", "orders", "forward-me");
+
+    Awaitility.waitAtMost(5, TimeUnit.SECONDS)
+        .until(() -> wsClient.getMessages().contains("forwarded"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/FixedMessageChannelAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/FixedMessageChannelAcceptanceTest.java
@@ -219,7 +219,7 @@ public class FixedMessageChannelAcceptanceTest extends WebsocketAcceptanceTestBa
         message()
             .withName("Template fixed channel echo")
             .triggeredByMessageOnChannel("events", "orders")
-            .withBody(matching(".*"))
+            .withBody(equalTo("hello"))
             .willTriggerActions(
                 sendMessage("Received: {{message.body}}").onChannel("events", "orders")));
 

--- a/src/test/java/com/github/tomakehurst/wiremock/FixedMessageChannelAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/FixedMessageChannelAcceptanceTest.java
@@ -28,9 +28,8 @@ import com.github.tomakehurst.wiremock.common.ClientError;
 import com.github.tomakehurst.wiremock.common.ConflictException;
 import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.message.MessageStubMapping;
-import com.github.tomakehurst.wiremock.verification.MessageServeEvent;
-import com.github.tomakehurst.wiremock.message.SendMessageAction;
 import com.github.tomakehurst.wiremock.testsupport.WebsocketTestClient;
+import com.github.tomakehurst.wiremock.verification.MessageServeEvent;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -212,6 +211,26 @@ public class FixedMessageChannelAcceptanceTest extends WebsocketAcceptanceTestBa
 
     UUID secondId = createFixedChannel(fixedChannel().onProvider("events").named("recreatable"));
     removeMessageChannel(secondId);
+  }
+
+  @Test
+  void templatesMessageBodyWhenInboundFixedChannelMessageTriggersFixedChannelSend() {
+    messageStubFor(
+        message()
+            .withName("Template fixed channel echo")
+            .triggeredByMessageOnChannel("events", "orders")
+            .withBody(matching(".*"))
+            .willTriggerActions(
+                sendMessage("Received: {{message.body}}").onChannel("events", "orders")));
+
+    sendMessageToFixedChannel("events", "orders", "hello");
+
+    Optional<MessageServeEvent> event =
+        waitForMessageEvent(
+            messagePattern().withBody(equalTo("Received: hello")).build(), Duration.ofSeconds(5));
+
+    assertThat(event.isPresent(), is(true));
+    assertThat(event.get().getMessage().getBodyAsString(), is("Received: hello"));
   }
 
   @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/MessageChannelApiValidationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MessageChannelApiValidationAcceptanceTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2026 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MessageChannelApiValidationAcceptanceTest extends AcceptanceTestBase {
+
+  private static final String PROVIDER = "validation-test-provider";
+
+  @BeforeEach
+  void registerProvider() {
+    testClient.postWithBody(
+        "/__admin/channel-providers",
+        // language=json
+        """
+        {
+          "name": "%s",
+          "driverType": "in-memory"
+        }
+        """
+            .formatted(PROVIDER),
+        "application/json");
+  }
+
+  @AfterEach
+  void removeProvider() {
+    testClient.delete("/__admin/channel-providers/" + PROVIDER);
+  }
+
+  @Test
+  void registeringChannelProviderWithNoNameReturns422() {
+    WireMockResponse response =
+        testClient.postWithBody(
+            "/__admin/channel-providers",
+            // language=json
+            """
+            {
+              "driverType": "in-memory"
+            }
+            """,
+            "application/json");
+
+    assertThat(response.statusCode(), is(422));
+    assertThat(
+        response.content(),
+        jsonEquals(
+            // language=json
+            """
+            {
+              "errors": [
+                {
+                  "code": 10,
+                  "source": { "pointer": "name" },
+                  "title": "name is required"
+                }
+              ]
+            }
+            """));
+  }
+
+  @Test
+  void creatingFixedChannelWithNoProviderNameReturns422() {
+    WireMockResponse response =
+        testClient.postWithBody(
+            "/__admin/channels",
+            // language=json
+            """
+            {
+              "channelName": "orders"
+            }
+            """,
+            "application/json");
+
+    assertThat(response.statusCode(), is(422));
+    assertThat(
+        response.content(),
+        jsonEquals(
+            // language=json
+            """
+            {
+              "errors": [
+                {
+                  "code": 10,
+                  "source": { "pointer": "providerName" },
+                  "title": "providerName is required"
+                }
+              ]
+            }
+            """));
+  }
+
+  @Test
+  void creatingFixedChannelWithNoFieldsReturns422() {
+    WireMockResponse response =
+        testClient.postWithBody("/__admin/channels", "{}", "application/json");
+
+    assertThat(response.statusCode(), is(422));
+    assertThat(
+        response.content(),
+        jsonEquals(
+            // language=json
+            """
+            {
+              "errors": [
+                {
+                  "code": 10,
+                  "source": { "pointer": "providerName" },
+                  "title": "providerName is required"
+                }
+              ]
+            }
+            """));
+  }
+
+  @Test
+  void updatingChannelProviderWithNoNameInBodyReturns422() {
+    WireMockResponse response =
+        testClient.putWithBody(
+            "/__admin/channel-providers/" + PROVIDER,
+            // language=json
+            """
+            {
+              "driverType": "in-memory"
+            }
+            """,
+            "application/json");
+
+    assertThat(response.statusCode(), is(422));
+    assertThat(
+        response.content(),
+        jsonEquals(
+            // language=json
+            """
+            {
+              "errors": [
+                {
+                  "code": 10,
+                  "source": { "pointer": "name" },
+                  "title": "name is required"
+                }
+              ]
+            }
+            """));
+  }
+
+  @Test
+  void sendingMessageToFixedChannelWithNoMessageBodyReturns422() {
+    WireMockResponse response =
+        testClient.postWithBody(
+            "/__admin/channels/send",
+            // language=json
+            """
+            {
+              "type": "FIXED",
+              "providerName": "%s",
+              "channelName": "orders"
+            }
+            """
+                .formatted(PROVIDER),
+            "application/json");
+
+    assertThat(response.statusCode(), is(422));
+    assertThat(
+        response.content(),
+        jsonEquals(
+            // language=json
+            """
+            {
+              "errors": [
+                {
+                  "code": 10,
+                  "source": { "pointer": "message" },
+                  "title": "message is required"
+                }
+              ]
+            }
+            """));
+  }
+
+  @Test
+  void sendingMessageToWebsocketChannelsWithNoMessageBodyReturns422() {
+    WireMockResponse response =
+        testClient.postWithBody(
+            "/__admin/channels/send",
+            // language=json
+            """
+            {
+              "type": "WEBSOCKET",
+              "initiatingRequest": { "url": "/ws" }
+            }
+            """,
+            "application/json");
+
+    assertThat(response.statusCode(), is(422));
+    assertThat(
+        response.content(),
+        jsonEquals(
+            // language=json
+            """
+            {
+              "errors": [
+                {
+                  "code": 10,
+                  "source": { "pointer": "message" },
+                  "title": "message is required"
+                }
+              ]
+            }
+            """));
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/MessageMappingValidationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MessageMappingValidationAcceptanceTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2026 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class MessageMappingValidationAcceptanceTest extends AcceptanceTestBase {
+
+  @AfterEach
+  void resetStubs() {
+    testClient.delete("/__admin/message-mappings");
+  }
+
+  @Test
+  void sendActionWithNoMessageReturns422() {
+    WireMockResponse response =
+        testClient.postWithBody(
+            "/__admin/message-mappings",
+            // language=json
+            """
+            {
+              "actions": [
+                {
+                  "type": "send",
+                  "channelTarget": { "type": "originating" }
+                }
+              ]
+            }
+            """,
+            "application/json");
+
+    assertThat(response.statusCode(), is(422));
+    assertThat(
+        response.content(),
+        jsonEquals(
+            // language=json
+            """
+            {
+              "errors": [
+                {
+                  "code": 10,
+                  "source": { "pointer": "message" },
+                  "title": "message is required"
+                }
+              ]
+            }
+            """));
+  }
+
+  @Test
+  void fixedChannelTargetWithNoProviderNameReturns422() {
+    WireMockResponse response =
+        testClient.postWithBody(
+            "/__admin/message-mappings",
+            // language=json
+            """
+            {
+              "actions": [
+                {
+                  "type": "send",
+                  "message": { "body": "test" },
+                  "channelTarget": {
+                    "type": "fixed-channel",
+                    "channelName": "orders"
+                  }
+                }
+              ]
+            }
+            """,
+            "application/json");
+
+    assertThat(response.statusCode(), is(422));
+    assertThat(
+        response.content(),
+        jsonEquals(
+            // language=json
+            """
+            {
+              "errors": [
+                {
+                  "code": 10,
+                  "source": { "pointer": "providerName" },
+                  "title": "providerName is required"
+                }
+              ]
+            }
+            """));
+  }
+
+  @Test
+  void fixedChannelTargetWithNoChannelNameReturns422() {
+    WireMockResponse response =
+        testClient.postWithBody(
+            "/__admin/message-mappings",
+            // language=json
+            """
+            {
+              "actions": [
+                {
+                  "type": "send",
+                  "message": { "body": "test" },
+                  "channelTarget": {
+                    "type": "fixed-channel",
+                    "providerName": "events"
+                  }
+                }
+              ]
+            }
+            """,
+            "application/json");
+
+    assertThat(response.statusCode(), is(422));
+    assertThat(
+        response.content(),
+        jsonEquals(
+            // language=json
+            """
+            {
+              "errors": [
+                {
+                  "code": 10,
+                  "source": { "pointer": "channelName" },
+                  "title": "channelName is required"
+                }
+              ]
+            }
+            """));
+  }
+
+  @Test
+  void httpRequestTriggerWithNoRequestPatternReturns422() {
+    WireMockResponse response =
+        testClient.postWithBody(
+            "/__admin/message-mappings",
+            // language=json
+            """
+            {
+              "trigger": { "type": "http-request" },
+              "actions": [
+                {
+                  "type": "send",
+                  "message": { "body": "test" }
+                }
+              ]
+            }
+            """,
+            "application/json");
+
+    assertThat(response.statusCode(), is(422));
+    assertThat(
+        response.content(),
+        jsonEquals(
+            // language=json
+            """
+            {
+              "errors": [
+                {
+                  "code": 10,
+                  "source": { "pointer": "requestPattern" },
+                  "title": "requestPattern is required"
+                }
+              ]
+            }
+            """));
+  }
+
+  @Test
+  void httpStubTriggerWithNoStubIdReturns422() {
+    WireMockResponse response =
+        testClient.postWithBody(
+            "/__admin/message-mappings",
+            // language=json
+            """
+            {
+              "trigger": { "type": "http-stub" },
+              "actions": [
+                {
+                  "type": "send",
+                  "message": { "body": "test" }
+                }
+              ]
+            }
+            """,
+            "application/json");
+
+    assertThat(response.statusCode(), is(422));
+    assertThat(
+        response.content(),
+        jsonEquals(
+            // language=json
+            """
+            {
+              "errors": [
+                {
+                  "code": 10,
+                  "source": { "pointer": "stubId" },
+                  "title": "stubId is required"
+                }
+              ]
+            }
+            """));
+  }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServerTest.java
@@ -97,7 +97,8 @@ public class JettyHttpServerTest {
             messageChannels,
             new InMemoryMessageJournal(null),
             stores,
-            Collections.emptyList());
+            Collections.emptyList(),
+            Collections.emptyMap());
   }
 
   @Test

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/admin/model/SendChannelMessageRequest.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/admin/model/SendChannelMessageRequest.java
@@ -40,7 +40,7 @@ public class SendChannelMessageRequest {
       @JsonProperty("initiatingRequest") RequestPattern initiatingRequestPattern,
       @JsonProperty("providerName") String providerName,
       @JsonProperty("channelName") String channelName,
-      @JsonProperty("message") MessageDefinition message) {
+      @JsonProperty(value = "message", required = true) MessageDefinition message) {
     this.type = type;
     this.initiatingRequestPattern = initiatingRequestPattern;
     this.providerName = providerName;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/JsonException.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/JsonException.java
@@ -17,17 +17,31 @@ package com.github.tomakehurst.wiremock.common;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 public class JsonException extends InvalidInputException {
+
+  private static final Pattern MISSING_REQUIRED_PROPERTY =
+      Pattern.compile("Missing required creator property '([^']+)'");
 
   protected JsonException(Errors errors) {
     super(errors);
   }
 
   public static JsonException fromJackson(JsonProcessingException processingException) {
+    if (processingException instanceof MismatchedInputException mie) {
+      Matcher matcher = MISSING_REQUIRED_PROPERTY.matcher(mie.getOriginalMessage());
+      if (matcher.find()) {
+        String fieldName = matcher.group(1);
+        return new JsonException(Errors.validation(fieldName, fieldName + " is required"));
+      }
+    }
+
     Throwable rootCause = getRootCause(processingException);
 
     String message = rootCause.getMessage();

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -790,7 +790,7 @@ public class WireMockApp implements StubServer, Admin {
   public void sendChannelMessage(
       String providerName, String channelName, MessageDefinition messageDefinition) {
     Message incomingMessage = new Message(messageDefinition.getBody().resolve(stores));
-    receiveInboundFixedChannelMessage(providerName, channelName, incomingMessage);
+    messageChannels.requireFixed(providerName, channelName).sendMessage(incomingMessage);
   }
 
   private void receiveInboundFixedChannelMessage(

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -24,8 +24,6 @@ import com.github.tomakehurst.wiremock.admin.AdminRoutes;
 import com.github.tomakehurst.wiremock.admin.LimitAndOffsetPaginator;
 import com.github.tomakehurst.wiremock.admin.model.*;
 import com.github.tomakehurst.wiremock.common.BrowserProxySettings;
-import com.github.tomakehurst.wiremock.common.Errors;
-import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.common.xml.Xml;
 import com.github.tomakehurst.wiremock.extension.*;
 import com.github.tomakehurst.wiremock.extension.requestfilter.RequestFilter;
@@ -715,9 +713,6 @@ public class WireMockApp implements StubServer, Admin {
   @Override
   public SendChannelMessageResult sendChannelMessage(
       ChannelType type, RequestPattern requestPattern, MessageDefinition messageDefinition) {
-    if (messageDefinition == null) {
-      throw new InvalidInputException(Errors.validation("message", "message is required"));
-    }
     Map<String, RequestMatcherExtension> customMatchers =
         extensions.ofType(RequestMatcherExtension.class);
     Message message = new Message(messageDefinition.getBody().resolve(stores));
@@ -790,9 +785,6 @@ public class WireMockApp implements StubServer, Admin {
   @Override
   public void sendChannelMessage(
       String providerName, String channelName, MessageDefinition messageDefinition) {
-    if (messageDefinition == null) {
-      throw new InvalidInputException(Errors.validation("message", "message is required"));
-    }
     Message incomingMessage = new Message(messageDefinition.getBody().resolve(stores));
     receiveInboundFixedChannelMessage(providerName, channelName, incomingMessage);
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -37,19 +37,15 @@ import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.message.ChannelType;
 import com.github.tomakehurst.wiremock.message.FixedChannel;
-import com.github.tomakehurst.wiremock.message.FixedChannelTarget;
 import com.github.tomakehurst.wiremock.message.HttpStubServeEventListener;
 import com.github.tomakehurst.wiremock.message.Message;
-import com.github.tomakehurst.wiremock.message.MessageAction;
 import com.github.tomakehurst.wiremock.message.MessageChannels;
 import com.github.tomakehurst.wiremock.message.MessageDefinition;
 import com.github.tomakehurst.wiremock.message.MessagePattern;
 import com.github.tomakehurst.wiremock.message.MessageStubMapping;
 import com.github.tomakehurst.wiremock.message.MessageStubMappings;
 import com.github.tomakehurst.wiremock.message.MessageStubRequestHandler;
-import com.github.tomakehurst.wiremock.message.RequestInitiatedChannelTarget;
 import com.github.tomakehurst.wiremock.message.RequestInitiatedMessageChannel;
-import com.github.tomakehurst.wiremock.message.SendMessageAction;
 import com.github.tomakehurst.wiremock.message.channel.ChannelProvider;
 import com.github.tomakehurst.wiremock.message.channel.ChannelProviderRegistry;
 import com.github.tomakehurst.wiremock.message.channel.CustomChannelProviderDriver;
@@ -102,6 +98,7 @@ public class WireMockApp implements StubServer, Admin {
   private final MessageChannels messageChannels;
   private final MessageStubMappings messageStubMappings;
   private final ChannelProviderRegistry channelProviderRegistry;
+  private MessageStubRequestHandler messageStubRequestHandler;
 
   private final Options options;
 
@@ -165,6 +162,9 @@ public class WireMockApp implements StubServer, Admin {
         .values()
         .forEach(channelProviderRegistry::registerDriver);
 
+    List<MessageActionTransformer> messageActionTransformers =
+        List.copyOf(extensions.ofType(MessageActionTransformer.class).values());
+
     HttpStubServeEventListener httpStubListener =
         new HttpStubServeEventListener(
             messageStubMappings,
@@ -172,7 +172,16 @@ public class WireMockApp implements StubServer, Admin {
             messageJournal,
             stores,
             customMatchers,
-            List.copyOf(extensions.ofType(MessageActionTransformer.class).values()));
+            messageActionTransformers);
+
+    messageStubRequestHandler =
+        new MessageStubRequestHandler(
+            messageStubMappings,
+            messageChannels,
+            messageJournal,
+            stores,
+            messageActionTransformers,
+            customMatchers);
     Map<String, ServeEventListener> extensionListeners =
         extensions.ofType(ServeEventListener.class);
     Map<String, ServeEventListener> combinedListeners = new HashMap<>(extensionListeners);
@@ -279,12 +288,7 @@ public class WireMockApp implements StubServer, Admin {
   }
 
   public MessageStubRequestHandler buildMessageStubRequestHandler() {
-    return new MessageStubRequestHandler(
-        messageStubMappings,
-        messageChannels,
-        messageJournal,
-        stores,
-        List.copyOf(extensions.ofType(MessageActionTransformer.class).values()));
+    return messageStubRequestHandler;
   }
 
   private List<RequestFilter> getAdminRequestFilters() {
@@ -792,42 +796,7 @@ public class WireMockApp implements StubServer, Admin {
   private void receiveInboundFixedChannelMessage(
       String providerName, String channelName, Message message) {
     FixedChannel inboundChannel = messageChannels.requireFixed(providerName, channelName);
-    Optional<MessageStubMapping> matchingStub =
-        messageStubMappings.findMatchingStub(inboundChannel, message);
-
-    if (matchingStub.isEmpty()) {
-      messageJournal.messageReceived(MessageServeEvent.receivedUnmatched(inboundChannel, message));
-    } else {
-      MessageStubMapping stub = matchingStub.get();
-      messageJournal.messageReceived(
-          MessageServeEvent.receivedMatched(inboundChannel, message, stub));
-      for (MessageAction action : stub.getActions()) {
-        if (action instanceof SendMessageAction sendAction) {
-          Message outMessage = new Message(sendAction.getMessage().getBody().resolve(stores));
-          if (sendAction.getChannelTarget() instanceof FixedChannelTarget fixedTarget) {
-            FixedChannel outboundChannel =
-                messageChannels.requireFixed(
-                    fixedTarget.getProviderName(), fixedTarget.getChannelName());
-            outboundChannel.sendMessage(outMessage);
-            messageJournal.messageReceived(MessageServeEvent.sent(outboundChannel, outMessage));
-          } else if (sendAction.getChannelTarget()
-              instanceof RequestInitiatedChannelTarget requestTarget) {
-            List<RequestInitiatedMessageChannel> matchingChannels =
-                requestTarget.getChannelType() != null
-                    ? messageChannels.findByTypeAndRequestPattern(
-                        requestTarget.getChannelType(),
-                        requestTarget.getRequestPattern(),
-                        customMatchers)
-                    : messageChannels.findByRequestPattern(
-                        requestTarget.getRequestPattern(), customMatchers);
-            for (RequestInitiatedMessageChannel channel : matchingChannels) {
-              channel.sendMessage(outMessage);
-              messageJournal.messageReceived(MessageServeEvent.sent(channel, outMessage));
-            }
-          }
-        }
-      }
-    }
+    messageStubRequestHandler.processMessage(inboundChannel, message);
   }
 
   @Override

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -24,6 +24,8 @@ import com.github.tomakehurst.wiremock.admin.AdminRoutes;
 import com.github.tomakehurst.wiremock.admin.LimitAndOffsetPaginator;
 import com.github.tomakehurst.wiremock.admin.model.*;
 import com.github.tomakehurst.wiremock.common.BrowserProxySettings;
+import com.github.tomakehurst.wiremock.common.Errors;
+import com.github.tomakehurst.wiremock.common.InvalidInputException;
 import com.github.tomakehurst.wiremock.common.xml.Xml;
 import com.github.tomakehurst.wiremock.extension.*;
 import com.github.tomakehurst.wiremock.extension.requestfilter.RequestFilter;
@@ -713,6 +715,9 @@ public class WireMockApp implements StubServer, Admin {
   @Override
   public SendChannelMessageResult sendChannelMessage(
       ChannelType type, RequestPattern requestPattern, MessageDefinition messageDefinition) {
+    if (messageDefinition == null) {
+      throw new InvalidInputException(Errors.validation("message", "message is required"));
+    }
     Map<String, RequestMatcherExtension> customMatchers =
         extensions.ofType(RequestMatcherExtension.class);
     Message message = new Message(messageDefinition.getBody().resolve(stores));
@@ -785,6 +790,9 @@ public class WireMockApp implements StubServer, Admin {
   @Override
   public void sendChannelMessage(
       String providerName, String channelName, MessageDefinition messageDefinition) {
+    if (messageDefinition == null) {
+      throw new InvalidInputException(Errors.validation("message", "message is required"));
+    }
     Message incomingMessage = new Message(messageDefinition.getBody().resolve(stores));
     receiveInboundFixedChannelMessage(providerName, channelName, incomingMessage);
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -47,6 +47,7 @@ import com.github.tomakehurst.wiremock.message.MessagePattern;
 import com.github.tomakehurst.wiremock.message.MessageStubMapping;
 import com.github.tomakehurst.wiremock.message.MessageStubMappings;
 import com.github.tomakehurst.wiremock.message.MessageStubRequestHandler;
+import com.github.tomakehurst.wiremock.message.RequestInitiatedChannelTarget;
 import com.github.tomakehurst.wiremock.message.RequestInitiatedMessageChannel;
 import com.github.tomakehurst.wiremock.message.SendMessageAction;
 import com.github.tomakehurst.wiremock.message.channel.ChannelProvider;
@@ -105,6 +106,7 @@ public class WireMockApp implements StubServer, Admin {
   private final Options options;
 
   private final Extensions extensions;
+  private Map<String, RequestMatcherExtension> customMatchers;
 
   public WireMockApp(Options options, Container container) {
     if (!options.getDisableOptimizeXmlFactoriesLoading() && !FACTORIES_LOADING_OPTIMIZED.get()) {
@@ -139,8 +141,7 @@ public class WireMockApp implements StubServer, Admin {
             options.filesRoot().child(FILES_ROOT));
     extensions.load();
 
-    Map<String, RequestMatcherExtension> customMatchers =
-        extensions.ofType(RequestMatcherExtension.class);
+    customMatchers = extensions.ofType(RequestMatcherExtension.class);
 
     requestJournal =
         options.requestJournalDisabled()
@@ -809,6 +810,20 @@ public class WireMockApp implements StubServer, Admin {
                     fixedTarget.getProviderName(), fixedTarget.getChannelName());
             outboundChannel.sendMessage(outMessage);
             messageJournal.messageReceived(MessageServeEvent.sent(outboundChannel, outMessage));
+          } else if (sendAction.getChannelTarget()
+              instanceof RequestInitiatedChannelTarget requestTarget) {
+            List<RequestInitiatedMessageChannel> matchingChannels =
+                requestTarget.getChannelType() != null
+                    ? messageChannels.findByTypeAndRequestPattern(
+                        requestTarget.getChannelType(),
+                        requestTarget.getRequestPattern(),
+                        customMatchers)
+                    : messageChannels.findByRequestPattern(
+                        requestTarget.getRequestPattern(), customMatchers);
+            for (RequestInitiatedMessageChannel channel : matchingChannels) {
+              channel.sendMessage(outMessage);
+              messageJournal.messageReceived(MessageServeEvent.sent(channel, outMessage));
+            }
           }
         }
       }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/FixedChannelTarget.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/FixedChannelTarget.java
@@ -28,8 +28,8 @@ public class FixedChannelTarget implements ChannelTarget {
 
   @JsonCreator
   public FixedChannelTarget(
-      @JsonProperty("providerName") String providerName,
-      @JsonProperty("channelName") String channelName) {
+      @JsonProperty(value = "providerName", required = true) String providerName,
+      @JsonProperty(value = "channelName", required = true) String channelName) {
     this.providerName = providerName;
     this.channelName = channelName;
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/HttpRequestTrigger.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/HttpRequestTrigger.java
@@ -37,7 +37,8 @@ public class HttpRequestTrigger implements MessageTrigger {
   private final RequestPattern requestPattern;
 
   @JsonCreator
-  public HttpRequestTrigger(@JsonProperty("requestPattern") RequestPattern requestPattern) {
+  public HttpRequestTrigger(
+      @JsonProperty(value = "requestPattern", required = true) RequestPattern requestPattern) {
     this.requestPattern = requestPattern;
   }
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/HttpStubTrigger.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/HttpStubTrigger.java
@@ -32,7 +32,7 @@ public class HttpStubTrigger implements MessageTrigger {
   private final UUID stubId;
 
   @JsonCreator
-  public HttpStubTrigger(@JsonProperty("stubId") UUID stubId) {
+  public HttpStubTrigger(@JsonProperty(value = "stubId", required = true) UUID stubId) {
     this.stubId = stubId;
   }
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/MessageStubRequestHandler.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/MessageStubRequestHandler.java
@@ -17,11 +17,13 @@ package com.github.tomakehurst.wiremock.message;
 
 import com.github.tomakehurst.wiremock.common.entity.Entity;
 import com.github.tomakehurst.wiremock.extension.MessageActionTransformer;
+import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
 import com.github.tomakehurst.wiremock.store.Stores;
 import com.github.tomakehurst.wiremock.verification.MessageJournal;
 import com.github.tomakehurst.wiremock.verification.MessageServeEvent;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class MessageStubRequestHandler {
@@ -31,19 +33,22 @@ public class MessageStubRequestHandler {
   private final MessageJournal messageJournal;
   private final Stores stores;
   private final List<MessageActionTransformer> actionTransformers;
+  private final Map<String, RequestMatcherExtension> customMatchers;
 
   public MessageStubRequestHandler(
       MessageStubMappings messageStubMappings,
       MessageChannels messageChannels,
       MessageJournal messageJournal,
       Stores stores,
-      List<MessageActionTransformer> actionTransformers) {
+      List<MessageActionTransformer> actionTransformers,
+      Map<String, RequestMatcherExtension> customMatchers) {
     this.messageStubMappings = messageStubMappings;
     this.messageChannels = messageChannels;
     this.messageJournal = messageJournal;
     this.stores = stores;
     this.actionTransformers =
         actionTransformers != null ? actionTransformers : Collections.emptyList();
+    this.customMatchers = customMatchers != null ? customMatchers : Collections.emptyMap();
   }
 
   public void processTextMessage(MessageChannel channel, String text) {
@@ -105,18 +110,20 @@ public class MessageStubRequestHandler {
     if (target instanceof OriginatingChannelTarget) {
       originatingChannel.sendMessage(message);
       messageJournal.messageReceived(MessageServeEvent.sent(originatingChannel, message));
+    } else if (target instanceof FixedChannelTarget fixedTarget) {
+      FixedChannel outboundChannel =
+          messageChannels.requireFixed(fixedTarget.getProviderName(), fixedTarget.getChannelName());
+      outboundChannel.sendMessage(message);
+      messageJournal.messageReceived(MessageServeEvent.sent(outboundChannel, message));
     } else if (target instanceof RequestInitiatedChannelTarget requestTarget) {
       List<RequestInitiatedMessageChannel> matchingChannels;
       if (requestTarget.getChannelType() != null) {
         matchingChannels =
             messageChannels.findByTypeAndRequestPattern(
-                requestTarget.getChannelType(),
-                requestTarget.getRequestPattern(),
-                Collections.emptyMap());
+                requestTarget.getChannelType(), requestTarget.getRequestPattern(), customMatchers);
       } else {
         matchingChannels =
-            messageChannels.findByRequestPattern(
-                requestTarget.getRequestPattern(), Collections.emptyMap());
+            messageChannels.findByRequestPattern(requestTarget.getRequestPattern(), customMatchers);
       }
       for (RequestInitiatedMessageChannel channel : matchingChannels) {
         channel.sendMessage(message);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/SendMessageAction.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/SendMessageAction.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/SendMessageAction.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/SendMessageAction.java
@@ -30,22 +30,24 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+@NullMarked
 @JsonInclude(NON_EMPTY)
 public class SendMessageAction implements MessageAction {
 
-  @NonNull private final MessageDefinition message;
-  @NonNull private final ChannelTarget channelTarget;
-  @NonNull private final List<String> transformers;
-  @NonNull private final Parameters transformerParameters;
+  private final MessageDefinition message;
+  private final ChannelTarget channelTarget;
+  private final List<String> transformers;
+  private final Parameters transformerParameters;
 
   @JsonCreator
   public SendMessageAction(
       @JsonProperty("message") MessageDefinition message,
-      @JsonProperty("channelTarget") ChannelTarget channelTarget,
-      @JsonProperty("transformers") List<String> transformers,
-      @JsonProperty("transformerParameters") Parameters transformerParameters) {
+      @Nullable @JsonProperty("channelTarget") ChannelTarget channelTarget,
+      @Nullable @JsonProperty("transformers") List<String> transformers,
+      @Nullable @JsonProperty("transformerParameters") Parameters transformerParameters) {
     this.message = message;
     this.channelTarget = channelTarget != null ? channelTarget : OriginatingChannelTarget.INSTANCE;
     this.transformers = transformers != null ? new ArrayList<>(transformers) : new ArrayList<>();
@@ -106,7 +108,7 @@ public class SendMessageAction implements MessageAction {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || getClass() != o.getClass()) return false;
+    if (getClass() != o.getClass()) return false;
     SendMessageAction that = (SendMessageAction) o;
     return Objects.equals(message, that.message)
         && Objects.equals(channelTarget, that.channelTarget)

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/SendMessageAction.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/SendMessageAction.java
@@ -44,7 +44,7 @@ public class SendMessageAction implements MessageAction {
 
   @JsonCreator
   public SendMessageAction(
-      @JsonProperty("message") MessageDefinition message,
+      @JsonProperty(value = "message", required = true) MessageDefinition message,
       @Nullable @JsonProperty("channelTarget") ChannelTarget channelTarget,
       @Nullable @JsonProperty("transformers") List<String> transformers,
       @Nullable @JsonProperty("transformerParameters") Parameters transformerParameters) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/ChannelProvider.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/ChannelProvider.java
@@ -34,8 +34,8 @@ public class ChannelProvider {
 
   @JsonCreator
   public ChannelProvider(
-      @JsonProperty("name") String name,
-      @JsonProperty("driverType") String driverType,
+      @JsonProperty(value = "name", required = true) String name,
+      @JsonProperty(value = "driverType", required = true) String driverType,
       @Nullable @JsonProperty("settings") Map<String, Object> settings) {
     this.name = name;
     this.driverType = driverType;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/ChannelProviderRegistry.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/ChannelProviderRegistry.java
@@ -49,6 +49,9 @@ public class ChannelProviderRegistry {
   }
 
   public ChannelProvider renameProvider(String currentName, ChannelProvider update) {
+    if (update.getName() == null) {
+      throw new InvalidInputException(Errors.validation("name", "name is required"));
+    }
     ChannelProvider existing =
         providerStore
             .get(currentName)
@@ -73,6 +76,9 @@ public class ChannelProviderRegistry {
   }
 
   public void registerProvider(ChannelProvider provider) {
+    if (provider.getName() == null) {
+      throw new InvalidInputException(Errors.validation("name", "name is required"));
+    }
     if (!drivers.containsKey(provider.getDriverType())) {
       throw new InvalidInputException(
           Errors.single(10, "No driver registered for type: " + provider.getDriverType()));
@@ -86,6 +92,9 @@ public class ChannelProviderRegistry {
 
   public FixedChannel createChannel(
       FixedChannelDefinition channelDefinition, InboundMessageSink sink) {
+    if (channelDefinition.getProviderName() == null) {
+      throw new InvalidInputException(Errors.validation("providerName", "providerName is required"));
+    }
     ChannelProvider provider = requireProvider(channelDefinition.getProviderName());
     ChannelProviderDriver driver = drivers.get(provider.getDriverType());
     driver.createChannel(provider, channelDefinition.getChannelName(), sink);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/ChannelProviderRegistry.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/ChannelProviderRegistry.java
@@ -49,9 +49,6 @@ public class ChannelProviderRegistry {
   }
 
   public ChannelProvider renameProvider(String currentName, ChannelProvider update) {
-    if (update.getName() == null) {
-      throw new InvalidInputException(Errors.validation("name", "name is required"));
-    }
     ChannelProvider existing =
         providerStore
             .get(currentName)
@@ -76,9 +73,6 @@ public class ChannelProviderRegistry {
   }
 
   public void registerProvider(ChannelProvider provider) {
-    if (provider.getName() == null) {
-      throw new InvalidInputException(Errors.validation("name", "name is required"));
-    }
     if (!drivers.containsKey(provider.getDriverType())) {
       throw new InvalidInputException(
           Errors.single(10, "No driver registered for type: " + provider.getDriverType()));
@@ -92,9 +86,6 @@ public class ChannelProviderRegistry {
 
   public FixedChannel createChannel(
       FixedChannelDefinition channelDefinition, InboundMessageSink sink) {
-    if (channelDefinition.getProviderName() == null) {
-      throw new InvalidInputException(Errors.validation("providerName", "providerName is required"));
-    }
     ChannelProvider provider = requireProvider(channelDefinition.getProviderName());
     ChannelProviderDriver driver = drivers.get(provider.getDriverType());
     driver.createChannel(provider, channelDefinition.getChannelName(), sink);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/FixedChannelDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/FixedChannelDefinition.java
@@ -29,8 +29,8 @@ public class FixedChannelDefinition {
 
   @JsonCreator
   public FixedChannelDefinition(
-      @JsonProperty("providerName") String providerName,
-      @JsonProperty("channelName") String channelName) {
+      @JsonProperty(value = "providerName", required = true) String providerName,
+      @JsonProperty(value = "channelName", required = true) String channelName) {
     this.providerName = providerName;
     this.channelName = channelName;
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/InMemoryChannelProviderDriver.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/message/channel/InMemoryChannelProviderDriver.java
@@ -37,8 +37,7 @@ public class InMemoryChannelProviderDriver implements ChannelProviderDriver {
 
   @Override
   public void send(ChannelProvider provider, String channelName, Message message) {
-    // Delivery is handled by ChannelProviderRegistry which records to the journal.
-    // The in-memory driver has no additional transport to perform.
+    receive(provider.getName(), channelName, message);
   }
 
   @Override


### PR DESCRIPTION
Several bugs fixed in the message channel infrastructure, along with input validation improvements.

Fixed `receiveInboundFixedChannelMessage` to correctly dispatch `RequestInitiatedChannelTarget` actions rather than dropping them. Fixed `sendChannelMessage` to route through `driver.send()` so messages are delivered via the underlying transport rather than being lost. Fixed response templating for inbound fixed channel message actions where the template model was not being populated correctly.

Added required field validation on the channel provider registration and channel send endpoints, using `@JsonProperty(required=true)` to surface clear errors on missing fields. New acceptance tests cover both the API validation rules (`MessageChannelApiValidationAcceptanceTest`) and message mapping behaviour (`MessageMappingValidationAcceptanceTest`).

Also adds a `workflow_dispatch`-only GitHub Actions workflow for publishing branch snapshots to GitHub Packages when needed during development.