### PR TITLE
Use configured notifier in request handlers

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/direct/DirectCallHttpServerIntegrationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/direct/DirectCallHttpServerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Thomas Akehurst
+ * Copyright (C) 2021-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,18 @@ import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.http.Response;
 import com.github.tomakehurst.wiremock.matching.MockRequest;
 import com.google.common.base.Stopwatch;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class DirectCallHttpServerIntegrationTest {
@@ -80,5 +85,54 @@ class DirectCallHttpServerIntegrationTest {
     MockRequest mockRequest = mockRequest().url("/test").method(GET);
     Response response = server.stubRequest(mockRequest);
     assertEquals("THINGS!", response.getBodyAsString());
+  }
+
+  @Test
+  void usesConfiguredNotifierForStubRequestLogging() {
+    TestNotifier notifier = new TestNotifier();
+    DirectCallHttpServerFactory factory = new DirectCallHttpServerFactory();
+    WireMockServer wm =
+        new WireMockServer(
+            wireMockConfig()
+                .httpServerFactory(factory)
+                .stubRequestLoggingDisabled(false)
+                .notifier(notifier));
+    wm.start(); // no-op
+
+    DirectCallHttpServer server = factory.getHttpServer();
+    server.stubRequest(mockRequest().url("/not-matched").method(GET));
+
+    assertThat(notifier.infoMessages, hasItem(containsString("Request received:")));
+  }
+
+  @Test
+  void usesConfiguredNotifierForAdminRequestLogging() {
+    TestNotifier notifier = new TestNotifier();
+    DirectCallHttpServerFactory factory = new DirectCallHttpServerFactory();
+    WireMockServer wm =
+        new WireMockServer(wireMockConfig().httpServerFactory(factory).notifier(notifier));
+    wm.start(); // no-op
+
+    DirectCallHttpServer server = factory.getHttpServer();
+    Response response = server.adminRequest(mockRequest().url("/__admin/mappings").method(GET));
+
+    assertEquals(200, response.getStatus());
+    assertThat(notifier.infoMessages, hasItem(containsString("Admin request received:")));
+    assertThat(notifier.infoMessages, hasItem(containsString("GET /__admin/mappings")));
+  }
+
+  private static class TestNotifier implements Notifier {
+    private final List<String> infoMessages = new ArrayList<>();
+
+    @Override
+    public void info(String message) {
+      infoMessages.add(message);
+    }
+
+    @Override
+    public void error(String message) {}
+
+    @Override
+    public void error(String message, Throwable t) {}
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -236,7 +236,8 @@ public class WireMockApp implements StubServer, Admin {
         options.getHttpsRequiredForAdminApi(),
         getAdminRequestFilters(),
         getV2AdminRequestFilters(),
-        options.getDataTruncationSettings());
+        options.getDataTruncationSettings(),
+        options.notifier());
   }
 
   public StubRequestHandler buildStubRequestHandler() {
@@ -284,7 +285,8 @@ public class WireMockApp implements StubServer, Admin {
         getV2StubRequestFilters(),
         options.getStubRequestLoggingDisabled(),
         options.getDataTruncationSettings(),
-        options.getNotMatchedRendererFactory().apply(extensions));
+        options.getNotMatchedRendererFactory().apply(extensions),
+        options.notifier());
   }
 
   public MessageStubRequestHandler buildMessageStubRequestHandler() {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
@@ -49,11 +49,11 @@ public abstract class AbstractRequestHandler implements RequestHandler, RequestE
       List<RequestFilter> requestFilters,
       List<RequestFilterV2> v2RequestFilters,
       DataTruncationSettings dataTruncationSettings,
-      Notifier notifier) {
+      Notifier configuredNotifier) {
     this.responseRenderer = responseRenderer;
     this.filterProcessor = new FilterProcessor(requestFilters, v2RequestFilters);
     this.dataTruncationSettings = dataTruncationSettings;
-    this.notifier = notifier;
+    this.notifier = configuredNotifier != null ? configuredNotifier : notifier();
   }
 
   @Override

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
@@ -19,6 +19,7 @@ import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static com.github.tomakehurst.wiremock.stubbing.ServeEvent.ORIGINAL_SERVE_EVENT_KEY;
 
 import com.github.tomakehurst.wiremock.common.DataTruncationSettings;
+import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.common.RequestCache;
 import com.github.tomakehurst.wiremock.extension.requestfilter.*;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
@@ -31,6 +32,7 @@ public abstract class AbstractRequestHandler implements RequestHandler, RequestE
   protected List<RequestListener> listeners = new ArrayList<>();
   protected final ResponseRenderer responseRenderer;
   protected final FilterProcessor filterProcessor;
+  protected final Notifier notifier;
 
   private final DataTruncationSettings dataTruncationSettings;
 
@@ -39,9 +41,19 @@ public abstract class AbstractRequestHandler implements RequestHandler, RequestE
       List<RequestFilter> requestFilters,
       List<RequestFilterV2> v2RequestFilters,
       DataTruncationSettings dataTruncationSettings) {
+    this(responseRenderer, requestFilters, v2RequestFilters, dataTruncationSettings, notifier());
+  }
+
+  public AbstractRequestHandler(
+      ResponseRenderer responseRenderer,
+      List<RequestFilter> requestFilters,
+      List<RequestFilterV2> v2RequestFilters,
+      DataTruncationSettings dataTruncationSettings,
+      Notifier notifier) {
     this.responseRenderer = responseRenderer;
     this.filterProcessor = new FilterProcessor(requestFilters, v2RequestFilters);
     this.dataTruncationSettings = dataTruncationSettings;
+    this.notifier = notifier;
   }
 
   @Override
@@ -79,14 +91,13 @@ public abstract class AbstractRequestHandler implements RequestHandler, RequestE
     serveEvent = serveEvent.complete(response, dataTruncationSettings);
 
     if (logRequests()) {
-      notifier()
-          .info(
-              "Request received:\n"
-                  + formatRequest(request)
-                  + "\n\nMatched response definition:\n"
-                  + responseDefinition
-                  + "\n\nResponse:\n"
-                  + response);
+      notifier.info(
+          "Request received:\n"
+              + formatRequest(request)
+              + "\n\nMatched response definition:\n"
+              + responseDefinition
+              + "\n\nResponse:\n"
+              + response);
     }
 
     for (RequestListener listener : listeners) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandler.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandler.java
@@ -15,7 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static com.github.tomakehurst.wiremock.core.WireMockApp.ADMIN_CONTEXT_ROOT_SEGMENT;
 import static org.wiremock.url.SchemeRegistry.https;
 
@@ -56,6 +55,23 @@ public class AdminRequestHandler extends AbstractRequestHandler {
     this.requireHttps = requireHttps;
   }
 
+  public AdminRequestHandler(
+      AdminRoutes adminRoutes,
+      Admin admin,
+      ResponseRenderer responseRenderer,
+      Authenticator authenticator,
+      boolean requireHttps,
+      List<RequestFilter> requestFilters,
+      List<RequestFilterV2> v2RequestFilters,
+      DataTruncationSettings dataTruncationSettings,
+      Notifier notifier) {
+    super(responseRenderer, requestFilters, v2RequestFilters, dataTruncationSettings, notifier);
+    this.adminRoutes = adminRoutes;
+    this.admin = admin;
+    this.authenticator = authenticator;
+    this.requireHttps = requireHttps;
+  }
+
   @Override
   public ServeEvent handleRequest(ServeEvent initialServeEvent) {
     final Request request = initialServeEvent.getRequest();
@@ -63,22 +79,21 @@ public class AdminRequestHandler extends AbstractRequestHandler {
     final boolean isRequestHttps = request.getTypedAbsoluteUrl().getScheme().equals(https);
 
     if (requireHttps && !isRequestHttps) {
-      notifier().info("HTTPS is required for admin requests, sending upgrade redirect");
+      notifier.info("HTTPS is required for admin requests, sending upgrade redirect");
       return initialServeEvent.withResponseDefinition(
           ResponseDefinition.notPermitted("HTTPS is required for accessing the admin API"));
     }
 
     if (!authenticator.authenticate(request)) {
-      notifier()
-          .info(
-              "Authentication failed for "
-                  + request.getMethod()
-                  + " "
-                  + request.getPathAndQueryWithoutPrefix());
+      notifier.info(
+          "Authentication failed for "
+              + request.getMethod()
+              + " "
+              + request.getPathAndQueryWithoutPrefix());
       return initialServeEvent.withResponseDefinition(ResponseDefinition.notAuthorised());
     }
 
-    notifier().info("Admin request received:\n" + formatRequest(request));
+    notifier.info("Admin request received:\n" + formatRequest(request));
     Path path = withoutAdminRoot(request.getPathAndQueryWithoutPrefix().getPath());
 
     try {
@@ -104,7 +119,7 @@ public class AdminRequestHandler extends AbstractRequestHandler {
     } catch (ConflictException ce) {
       return initialServeEvent.withResponseDefinition(ResponseDefinition.conflict(ce.getErrors()));
     } catch (Throwable t) {
-      notifier().error("Unrecoverable error handling admin request", t);
+      notifier.error("Unrecoverable error handling admin request", t);
       throw t;
     }
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/StubRequestHandler.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/StubRequestHandler.java
@@ -15,11 +15,12 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static com.github.tomakehurst.wiremock.extension.ServeEventListener.RequestPhase.*;
 import static com.github.tomakehurst.wiremock.extension.ServeEventListenerUtils.triggerListeners;
 
 import com.github.tomakehurst.wiremock.common.DataTruncationSettings;
+import com.github.tomakehurst.wiremock.common.LocalNotifier;
+import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.common.url.PathParams;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.core.StubServer;
@@ -57,7 +58,35 @@ public class StubRequestHandler extends AbstractRequestHandler {
       boolean loggingDisabled,
       DataTruncationSettings dataTruncationSettings,
       NotMatchedRenderer notMatchedRenderer) {
-    super(responseRenderer, requestFilters, v2RequestFilters, dataTruncationSettings);
+    this(
+        stubServer,
+        responseRenderer,
+        admin,
+        postServeActions,
+        serveEventListeners,
+        requestJournal,
+        requestFilters,
+        v2RequestFilters,
+        loggingDisabled,
+        dataTruncationSettings,
+        notMatchedRenderer,
+        LocalNotifier.notifier());
+  }
+
+  public StubRequestHandler(
+      StubServer stubServer,
+      ResponseRenderer responseRenderer,
+      Admin admin,
+      Map<String, PostServeAction> postServeActions,
+      Map<String, ServeEventListener> serveEventListeners,
+      RequestJournal requestJournal,
+      List<RequestFilter> requestFilters,
+      List<RequestFilterV2> v2RequestFilters,
+      boolean loggingDisabled,
+      DataTruncationSettings dataTruncationSettings,
+      NotMatchedRenderer notMatchedRenderer,
+      Notifier notifier) {
+    super(responseRenderer, requestFilters, v2RequestFilters, dataTruncationSettings, notifier);
     this.stubServer = stubServer;
     this.admin = admin;
     this.postServeActions = postServeActions;
@@ -127,7 +156,7 @@ public class StubRequestHandler extends AbstractRequestHandler {
         Parameters parameters = postServeActionDef.getParameters();
         action.doAction(serveEvent, admin, parameters);
       } else {
-        notifier().error("No extension was found named \"" + postServeActionDef.getName() + "\"");
+        notifier.error("No extension was found named \"" + postServeActionDef.getName() + "\"");
       }
     }
   }

--- a/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/servlet/WarConfiguration.java
+++ b/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/servlet/WarConfiguration.java
@@ -117,7 +117,7 @@ public class WarConfiguration implements Options {
 
   @Override
   public Notifier notifier() {
-    return null;
+    return (Notifier) servletContext.getAttribute(Notifier.KEY);
   }
 
   @Override

--- a/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/servlet/WireMockWebContextListener.java
+++ b/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/servlet/WireMockWebContextListener.java
@@ -39,6 +39,9 @@ public class WireMockWebContextListener implements ServletContextListener {
         Boolean.parseBoolean(
             getFirstNonNull(context.getInitParameter("verboseLoggingEnabled"), "true"));
 
+    Notifier notifier = new Slf4jNotifier(verboseLoggingEnabled);
+    context.setAttribute(Notifier.KEY, notifier);
+
     WireMockApp wireMockApp =
         new WireMockApp(new WarConfiguration(context), new NotImplementedContainer());
 
@@ -46,7 +49,6 @@ public class WireMockWebContextListener implements ServletContextListener {
     context.setAttribute(StubRequestHandler.class.getName(), wireMockApp.buildStubRequestHandler());
     context.setAttribute(
         AdminRequestHandler.class.getName(), wireMockApp.buildAdminRequestHandler());
-    context.setAttribute(Notifier.KEY, new Slf4jNotifier(verboseLoggingEnabled));
   }
 
   @Override


### PR DESCRIPTION
Fixes #3285.

This wires the configured `Notifier` into the admin and stub request handlers created by `WireMockApp`, so non-Jetty/custom `HttpServerFactory` implementations receive request logging without needing to set `LocalNotifier` themselves.

The existing handler constructors are preserved and continue to fall back to `LocalNotifier`, and the `HttpServerFactory` API is unchanged.

DirectCall HTTP server integration tests cover both stub and admin request logging through the custom-server path.

Tested with:

```
./gradlew :test --tests com.github.tomakehurst.wiremock.direct.DirectCallHttpServerIntegrationTest --tests com.github.tomakehurst.wiremock.stubbing.AdminRequestHandlerTest --tests com.github.tomakehurst.wiremock.http.AdminRequestHandlerTest
./gradlew spotlessCheck
```