### PR TITLE
Strip foreign module-info.class from standalone jar and add Automatic-Module-Name

### DIFF
--- a/wiremock-standalone/build.gradle.kts
+++ b/wiremock-standalone/build.gradle.kts
@@ -29,7 +29,10 @@ tasks.shadowJar {
     project.configurations.runtimeClasspath.get(),
   )
   manifest {
-    attributes("Main-Class" to "wiremock.Run")
+    attributes(
+      "Main-Class" to "wiremock.Run",
+      "Automatic-Module-Name" to "wiremock.standalone",
+    )
   }
   relocate("org.mortbay", "wiremock.org.mortbay")
   relocate("org.eclipse", "wiremock.org.eclipse")
@@ -75,6 +78,7 @@ tasks.shadowJar {
   exclude("META-INF/versions/21/**")
   exclude("META-INF/versions/22/**")
   exclude("module-info.class")
+  exclude("META-INF/versions/*/module-info.class")
   exclude("handlebars-*.js")
 }
 


### PR DESCRIPTION
## Problem

The `wiremock-standalone` uber-jar bundles foreign multi-release module descriptors. For example, the current stable release (`3.13.1`) contains `META-INF/versions/9/module-info.class` which is **Guava's** descriptor:

```
module com.google.common@33.4.8-jre
  requires java.logging, com.google.common.util.concurrent.internal,
           com.google.errorprone.annotations, com.google.j2objc.annotations, org.jspecify
  exports com/google/common/{annotations,base,cache,collect, ...}   // 16 packages
```

On the module path this is broken: the uber-jar relocates Guava to `wiremock.com.google.*`, so this descriptor (a) **misnames** the whole standalone jar as `com.google.common`, (b) `requires` modules that are not bundled, and (c) `exports` packages that no longer exist in the jar. `jar --describe-module` on `3.13.1` finds no usable root module — only this foreign versioned one.

## Root cause

The build's `exclude("module-info.class")` is an Ant-style pattern that only matches the **root** path. The module descriptors of multi-release dependencies (Guava, Jackson, SLF4J, BouncyCastle, error-prone, …) live under `META-INF/versions/9/module-info.class` and slip through. The version-specific excludes only cover `META-INF/versions/{17,21,22}`.

## Fix

- Explicitly exclude `META-INF/versions/*/module-info.class` so foreign module descriptors can never leak, regardless of the shadow plugin's internal multi-release handling. Legitimate multi-release classes under those version directories are preserved — only the `module-info.class` files are dropped.
- Declare an `Automatic-Module-Name` of `wiremock.standalone` so the artifact resolves as a well-named automatic module. This matches the name the JDK already derives from the artifact filename, so it is non-breaking.

## Validation

Built `:wiremock-standalone:shadowJar` and inspected the produced jar:

- `module-info.class` entries: **0** (previously 1 in `3.13.1`).
- Manifest now contains `Automatic-Module-Name: wiremock.standalone`.
- `jar --describe-module` reports a clean `wiremock.standalone automatic` module (with merged `provides` service entries intact) instead of `com.google.common`.
- Legitimate `META-INF/versions/9/` and `META-INF/versions/11/` relocated classes (e.g. BouncyCastle) remain present.