### PR TITLE
Premature entity definition metadata binding issue fix

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinitionTest.java
@@ -25,11 +25,9 @@ import static com.github.tomakehurst.wiremock.common.entity.CompressionType.NONE
 import static com.github.tomakehurst.wiremock.common.entity.EntityDefinition.DEFAULT_CHARSET;
 import static com.github.tomakehurst.wiremock.common.entity.EntityDefinition.buildEntityDefinition;
 import static com.github.tomakehurst.wiremock.common.entity.Format.BINARY;
-import static com.github.tomakehurst.wiremock.common.entity.Format.HTML;
 import static com.github.tomakehurst.wiremock.common.entity.Format.JSON;
 import static com.github.tomakehurst.wiremock.common.entity.Format.TEXT;
 import static com.github.tomakehurst.wiremock.common.entity.Format.XML;
-import static com.github.tomakehurst.wiremock.common.entity.Format.YAML;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -408,52 +406,6 @@ public class EntityDefinitionTest {
   }
 
   @Test
-  void detectsTextFormatWhenNotSpecified() {
-    assertThat(entity().setData("\n{}  ").build().getFormat(), is(JSON));
-    assertThat(entity().setData("  []").build().getFormat(), is(JSON));
-    assertThat(entity().setData("  \n<things />").build().getFormat(), is(XML));
-
-    String yaml =
-        // language=yaml
-        """
-            root:
-              myList:
-                - one
-                - two
-                - three
-            """;
-    assertThat(entity().setData(yaml).build().getFormat(), is(YAML));
-
-    String html =
-        // language=html
-        """
-            <html lang="">
-              <body>
-                <h1>Hello World</h1>
-              </body>
-            </html>
-            """;
-    assertThat(entity().setData(html).build().getFormat(), is(HTML));
-
-    assertThat(entity().setData("just some prose").build().getFormat(), is(TEXT));
-  }
-
-  @Test
-  void detectsTextFormatWhenNotSpecifiedDuringDeserialization() {
-    var json =
-        // language=json
-        """
-            {
-              "data": "\\n{ \\"key\\": \\"value\\" }  "
-            }
-            """;
-
-    EntityDefinition entity = Json.read(json, EntityDefinition.class);
-
-    assertThat(entity.getFormat(), is(JSON));
-  }
-
-  @Test
   void serialisesSimpleStringEntityDefinitionAsString() {
     EntityDefinition entityDefinition = EntityDefinition.simple("simple text");
     String json = Json.write(entityDefinition);
@@ -642,19 +594,8 @@ public class EntityDefinitionTest {
 
   @Test
   void deserialisedAndBuiltInstancesAreEquivalent() {
-    var json =
-        // language=json
-        """
-            {
-              "data": "{}",
-              "format": "json",
-              "compression": "none",
-              "charset": "utf-8"
-            }
-            """;
-
     var deserialised = Json.read("\"blah\"", EntityDefinition.class);
-    var built = EntityDefinition.builder().setData("blah").setFormat(TEXT).build();
+    var built = EntityDefinition.builder().setData("blah").setFormat(null).build();
 
     assertEquals(deserialised, built);
   }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static com.github.tomakehurst.wiremock.stubbing.ServeEventFactory.newPostMatchServeEvent;
 import static java.time.temporal.ChronoUnit.DAYS;
@@ -1380,6 +1381,20 @@ public class ResponseTemplateTransformerTest {
 
     String result5 = transform("{{arrayJoin \" - * - \" (array 'One' 'Two' 'Three')}}");
     assertThat(result5, equalToCompressingWhiteSpace("One - * - Two - * - Three"));
+  }
+
+  @Test
+  void templateCanBeUsedForWithBinaryContentType() {
+    String bodyBase64 = "ZmFrZWJpbmFyeQo=";
+
+    ResponseDefinition result =
+        transform(
+            mockRequest().url("/bin").method(POST).body(bodyBase64),
+            aResponse()
+                .withHeader("Content-Type", "application/octet-stream")
+                .withBody("{{request.body}}"));
+
+    assertThat(result.getTextBody(), is(bodyBase64));
   }
 
   private Integer transformToInt(String responseBodyTemplate) {

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ResponseDefinitionTest.java
@@ -501,46 +501,6 @@ public class ResponseDefinitionTest {
   }
 
   @Test
-  void takesCharsetFromContentTypeHeaderWhenAvailableAndNotSetExplicitly() {
-    var json =
-        // language=JSON
-        """
-            {
-              "headers": {
-                "Content-Type": "text/plain; charset=UTF-16"
-              },
-              "body": {
-                "data": "odd charset"
-              }
-            }
-            """;
-
-    ResponseDefinition responseDefinition = Json.read(json, ResponseDefinition.class);
-
-    assertThat(responseDefinition.getBodyEntity().getCharset(), is(StandardCharsets.UTF_16));
-  }
-
-  @Test
-  void takesContentEncodingFromHeaderWhenAvailable() {
-    var json =
-        // language=JSON
-        """
-            {
-              "headers": {
-                "Content-Encoding": "gzip"
-              },
-              "body": {
-                "data": "compressed"
-              }
-            }
-            """;
-
-    ResponseDefinition responseDefinition = Json.read(json, ResponseDefinition.class);
-
-    assertThat(responseDefinition.getBodyEntity().getCompression(), is(CompressionType.GZIP));
-  }
-
-  @Test
   void absentBodyFieldResultInEmptyBody() {
     var json =
         // language=JSON
@@ -597,8 +557,6 @@ public class ResponseDefinitionTest {
 
     EntityDefinition body = responseDefinition.getBodyEntity();
     assertThat(body.getFilePath(), is("bodies/data.json"));
-    assertThat(body.getCharset(), is(StandardCharsets.UTF_16));
-    assertThat(body.getFormat(), is(JSON));
     assertThat(body.getCompression(), is(CompressionType.NONE));
   }
 
@@ -616,5 +574,25 @@ public class ResponseDefinitionTest {
     EntityDefinition entity = responseDefinition.getBodyEntity();
     assertThat(entity.getFormat(), is(JSON)); // JSON detectd from the actual body string
     assertThat(entity.getCharset(), is(UTF_8)); // default
+  }
+
+  @Test
+  void templatedBodyWithBinaryHeaderIsPreserved() {
+    var json =
+        // language=json
+        """
+            {
+              "status": 200,
+              "headers": {
+                "Content-Type": "application/octet-stream"
+              },
+              "body": "{{request.body}}"
+            }
+            """;
+
+    ResponseDefinition responseDefinition = Json.read(json, ResponseDefinition.class);
+
+    assertThat(Json.write(responseDefinition), jsonEquals(json));
+    assertThat(responseDefinition.getBody(), is("{{request.body}}"));
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ResponseDefinitionTest.java
@@ -572,7 +572,7 @@ public class ResponseDefinitionTest {
             .build();
 
     EntityDefinition entity = responseDefinition.getBodyEntity();
-    assertThat(entity.getFormat(), is(JSON)); // JSON detectd from the actual body string
+    assertThat(entity.getFormat(), nullValue());
     assertThat(entity.getCharset(), is(UTF_8)); // default
   }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformerTest.java
@@ -17,11 +17,13 @@ package com.github.tomakehurst.wiremock.recording;
 
 import static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.responseDefinition;
 import static com.github.tomakehurst.wiremock.common.Limit.UNLIMITED;
+import static com.github.tomakehurst.wiremock.common.entity.Format.TEXT;
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.github.tomakehurst.wiremock.common.entity.EntityDefinition;
 import com.github.tomakehurst.wiremock.http.*;
 import org.junit.jupiter.api.Test;
 
@@ -46,8 +48,13 @@ public class LoggedResponseDefinitionTransformerTest {
                 .body("foo")
                 .build(),
             UNLIMITED);
+
     final ResponseDefinition expected =
-        responseDefinition().withHeader("Content-Type", "text/plain").withBody("foo").build();
+        responseDefinition()
+            .withHeader("Content-Type", "text/plain")
+            .withEntityBody(EntityDefinition.builder().setData("foo").setFormat(TEXT).build())
+            .build();
+
     assertEquals(expected, aTransformer().apply(response));
   }
 

--- a/src/test/java/org/wiremock/webhooks/WebhookDefinitionTest.java
+++ b/src/test/java/org/wiremock/webhooks/WebhookDefinitionTest.java
@@ -110,7 +110,6 @@ public class WebhookDefinitionTest {
     EntityDefinition entity = webhookDefinition.getBodyEntityDefinition();
     assertThat(entity.getFilePath(), nullValue());
     assertThat(entity.getDataAsString(), is("<stuff />"));
-    assertThat(entity.getFormat(), is(Format.XML));
   }
 
   @Test
@@ -133,7 +132,6 @@ public class WebhookDefinitionTest {
 
     EntityDefinition entity = webhookDefinition.getBodyEntityDefinition();
     assertThat(entity.getFilePath(), is("webhooks/body.json"));
-    assertThat(entity.getFormat(), is(Format.JSON));
     assertThat(entity.getData(), nullValue());
   }
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinition.java
@@ -15,6 +15,14 @@
  */
 package com.github.tomakehurst.wiremock.common.entity;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
+import static com.github.tomakehurst.wiremock.common.Strings.bytesFromString;
+import static com.github.tomakehurst.wiremock.common.entity.CompressionType.GZIP;
+import static com.github.tomakehurst.wiremock.common.entity.CompressionType.NONE;
+import static com.github.tomakehurst.wiremock.common.entity.Format.BINARY;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -26,22 +34,12 @@ import com.github.tomakehurst.wiremock.common.Gzip;
 import com.github.tomakehurst.wiremock.common.InputStreamSource;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.store.Stores;
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-import org.wiremock.annotations.PublishedAPI;
-
 import java.nio.charset.Charset;
 import java.util.Objects;
 import java.util.function.Consumer;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
-import static com.github.tomakehurst.wiremock.common.Strings.bytesFromString;
-import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
-import static com.github.tomakehurst.wiremock.common.entity.CompressionType.GZIP;
-import static com.github.tomakehurst.wiremock.common.entity.CompressionType.NONE;
-import static com.github.tomakehurst.wiremock.common.entity.Format.BINARY;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.wiremock.annotations.PublishedAPI;
 
 @PublishedAPI
 @JsonInclude(NON_NULL)
@@ -406,22 +404,14 @@ public abstract class EntityDefinition {
 
     CompressionType correctCompression = tryToGuessCompressionTypeIfNotSpecified(compression, data);
     Charset correctCharset = getFirstNonNull(charset, DEFAULT_CHARSET);
-    Format correctFormat;
-    if (format == null && data != null) {
-      correctFormat = Format.detectFormat(stringFromBytes(data, correctCharset));
-    } else {
-      correctFormat = getFirstNonNull(format, DEFAULT_FORMAT);
-    }
 
     if (data != null) {
       return new SimpleEntityDefinition(
-          simpleStringStyle, correctCompression, correctFormat, correctCharset, data);
+          simpleStringStyle, correctCompression, format, correctCharset, data);
     } else if (dataStoreRef != null) {
-      return new DataRefEntityDefinition(
-          correctCompression, correctFormat, correctCharset, dataStoreRef);
+      return new DataRefEntityDefinition(correctCompression, format, correctCharset, dataStoreRef);
     } else if (filePath != null) {
-      return new FilePathEntityDefinition(
-          correctCompression, correctFormat, correctCharset, filePath);
+      return new FilePathEntityDefinition(correctCompression, format, correctCharset, filePath);
     } else {
       return EmptyEntityDefinition.INSTANCE;
     }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinition.java
@@ -15,15 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.common.entity;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
-import static com.github.tomakehurst.wiremock.common.Strings.bytesFromString;
-import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
-import static com.github.tomakehurst.wiremock.common.entity.CompressionType.GZIP;
-import static com.github.tomakehurst.wiremock.common.entity.CompressionType.NONE;
-import static com.github.tomakehurst.wiremock.common.entity.Format.BINARY;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -34,14 +25,23 @@ import com.github.tomakehurst.wiremock.common.Encoding;
 import com.github.tomakehurst.wiremock.common.Gzip;
 import com.github.tomakehurst.wiremock.common.InputStreamSource;
 import com.github.tomakehurst.wiremock.common.Json;
-import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.store.Stores;
-import java.nio.charset.Charset;
-import java.util.Objects;
-import java.util.function.Consumer;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.wiremock.annotations.PublishedAPI;
+
+import java.nio.charset.Charset;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
+import static com.github.tomakehurst.wiremock.common.Strings.bytesFromString;
+import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
+import static com.github.tomakehurst.wiremock.common.entity.CompressionType.GZIP;
+import static com.github.tomakehurst.wiremock.common.entity.CompressionType.NONE;
+import static com.github.tomakehurst.wiremock.common.entity.Format.BINARY;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 @PublishedAPI
 @JsonInclude(NON_NULL)
@@ -120,15 +120,6 @@ public abstract class EntityDefinition {
     }
 
     return entityDefinition != null ? entityDefinition : EmptyEntityDefinition.INSTANCE;
-  }
-
-  public static EntityDefinition resolveEntityAttributesFromHeaders(
-      HttpHeaders headers, EntityDefinition entityDefinition) {
-    if (entityDefinition.isAbsent()) {
-      return entityDefinition;
-    }
-
-    return entityDefinition.transform(builder -> EntityMetadata.copyFromHeaders(headers, builder));
   }
 
   public @NonNull Entity resolve(@Nullable Stores stores) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinition.java
@@ -235,6 +235,10 @@ public abstract class EntityDefinition {
     return builder.build();
   }
 
+  public EntityDefinition decompressIfPossible() {
+    return isDecompressable() ? decompress() : this;
+  }
+
   public EntityDefinition decompress() {
     final CompressionType compression = getCompression();
     if (GZIP.equals(compression)) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinitionDeserializer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/EntityDefinitionDeserializer.java
@@ -18,8 +18,6 @@ package com.github.tomakehurst.wiremock.common.entity;
 import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 import static com.github.tomakehurst.wiremock.common.Strings.bytesFromString;
 import static com.github.tomakehurst.wiremock.common.entity.EntityDefinition.DEFAULT_CHARSET;
-import static com.github.tomakehurst.wiremock.common.entity.Format.TEXT;
-import static com.github.tomakehurst.wiremock.common.entity.Format.detectFormat;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -46,7 +44,7 @@ public class EntityDefinitionDeserializer extends StdDeserializer<EntityDefiniti
       return EntityDefinition.buildEntityDefinition(
           true,
           CompressionType.NONE,
-          TEXT,
+          null,
           charset,
           null,
           bytesFromString(node.asText(), charset),
@@ -129,11 +127,7 @@ public class EntityDefinitionDeserializer extends StdDeserializer<EntityDefiniti
       return Format.BINARY;
     }
 
-    if (data != null) {
-      return detectFormat(data);
-    }
-
-    return EntityDefinition.DEFAULT_FORMAT;
+    return null;
   }
 
   private static @Nullable DataStoreRef buildDataRef(

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/SimpleEntityDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/entity/SimpleEntityDefinition.java
@@ -42,7 +42,7 @@ public class SimpleEntityDefinition extends EntityDefinition {
   }
 
   SimpleEntityDefinition(@NonNull String text, @NonNull Charset charset) {
-    this(true, NONE, Format.TEXT, charset, bytesFromString(text, charset));
+    this(true, NONE, null, charset, bytesFromString(text, charset));
   }
 
   SimpleEntityDefinition(

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -157,7 +157,8 @@ public class ResponseDefinition {
     this.removeProxyRequestHeaders =
         removeProxyRequestHeaders != null ? List.copyOf(removeProxyRequestHeaders) : List.of();
 
-    this.body = EntityDefinition.resolveEntityAttributesFromHeaders(this.headers, body);
+    //    this.body = EntityDefinition.resolveEntityAttributesFromHeaders(this.headers, body);
+    this.body = body;
 
     this.fixedDelayMilliseconds = fixedDelayMilliseconds;
     this.delayDistribution = delayDistribution;

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/LoggedResponseDefinitionTransformer.java
@@ -18,10 +18,9 @@ package com.github.tomakehurst.wiremock.recording;
 import static com.github.tomakehurst.wiremock.common.ContentTypes.*;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
-import com.github.tomakehurst.wiremock.common.Gzip;
 import com.github.tomakehurst.wiremock.common.entity.EntityDefinition;
+import com.github.tomakehurst.wiremock.common.entity.EntityMetadata;
 import com.github.tomakehurst.wiremock.http.*;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -45,16 +44,11 @@ public class LoggedResponseDefinitionTransformer
         new ResponseDefinitionBuilder().withStatus(response.getStatus());
 
     if (response.getBody() != null && response.getBody().length > 0) {
-
-      byte[] body = bodyDecompressedIfRequired(response);
-      String mimeType = response.getMimeType();
-      Charset charset = response.getCharset();
-      if (determineIsTextFromMimeType(mimeType)) {
-        responseDefinitionBuilder.withEntityBody(
-            EntityDefinition.builder().setCharset(charset).setData(body).build());
-      } else {
-        responseDefinitionBuilder.withBody(body);
-      }
+      final EntityDefinition.Builder bodyBuilder =
+          EntityDefinition.builder().setData(response.getBody());
+      EntityMetadata.copyFromHeaders(response.getHeaders(), bodyBuilder);
+      final EntityDefinition body = bodyBuilder.build();
+      responseDefinitionBuilder.withEntityBody(body.decompressIfPossible());
     }
 
     if (response.getHeaders() != null) {
@@ -62,14 +56,6 @@ public class LoggedResponseDefinitionTransformer
     }
 
     return responseDefinitionBuilder.build();
-  }
-
-  private byte[] bodyDecompressedIfRequired(LoggedResponse response) {
-    if (response.getHeaders() != null
-        && response.getHeaders().getHeader(CONTENT_ENCODING).containsValue("gzip")) {
-      return Gzip.unGzip(response.getBody());
-    }
-    return response.getBody();
   }
 
   private HttpHeaders withoutContentEncodingAndContentLength(LoggedResponse response) {

--- a/wiremock-core/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
+++ b/wiremock-core/src/main/java/org/wiremock/webhooks/WebhookDefinition.java
@@ -82,7 +82,7 @@ public class WebhookDefinition {
     this.method = method;
     this.url = url;
     this.headers = getFirstNonNull(headers, new HttpHeaders());
-    this.body = EntityDefinition.resolveEntityAttributesFromHeaders(this.headers, body);
+    this.body = body;
     this.delay = delay;
     this.parameters = parameters;
   }

--- a/wiremock-url/wiremock-url/src/test/java/org/wiremock/url/whatwg/WhatWGUrlInvariantTests.java
+++ b/wiremock-url/wiremock-url/src/test/java/org/wiremock/url/whatwg/WhatWGUrlInvariantTests.java
@@ -35,10 +35,8 @@ import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 import org.wiremock.url.AbsoluteUrl;
@@ -47,8 +45,9 @@ import org.wiremock.url.Rfc3986Validator;
 class WhatWGUrlInvariantTests {
 
   @Test
-//  @EnabledIf("remoteDataReachable")
-  @Disabled("we should update this in a separate lifecycle rather than forcing it during unrelated work")
+  //  @EnabledIf("remoteDataReachable")
+  @Disabled(
+      "we should update this in a separate lifecycle rather than forcing it during unrelated work")
   void test_data_is_up_to_date() throws IOException {
     String expected = WhatWGUrlTestManagement.readRemote();
     try {


### PR DESCRIPTION
The refactor to `EntityDefinition` as the underlying body implementation for `ResponseDefinition` included some logic to try to eagerly determine metadata - format, charset and compression from headers.

However, this made it impossible to use response templating with binary responses, as a binary mime type would cause the entity definition to switch to base64 representation and thus reject Handlebars template syntax.

This PR removes the eager binding of these values, in particular keeping the format field blank until it's affirmatively determined. 