### PR TITLE
Fix concurrent scenario mapping removals

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ScenariosTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ScenariosTest.java
@@ -21,7 +21,14 @@ import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -418,6 +425,52 @@ public class ScenariosTest {
     Set<String> possibleStates = scenarios.getByName("one").getPossibleStates();
     assertThat(possibleStates, hasItems("Started", "step two"));
     assertThat(possibleStates.size(), is(2));
+  }
+
+  @Test
+  public void removesScenarioCompletelyWhenAllMappingsAreRemovedConcurrently() throws Exception {
+    int mappingCount = 100;
+    StubMapping[] mappings = new StubMapping[mappingCount];
+
+    for (int i = 0; i < mappingCount; i++) {
+      mappings[i] =
+          get("/scenarios/" + i)
+              .inScenario("one")
+              .whenScenarioStateIs(STARTED)
+              .willSetStateTo("step_" + i)
+              .willReturn(ok())
+              .build();
+      scenarios.onStubMappingAdded(mappings[i]);
+    }
+
+    CountDownLatch ready = new CountDownLatch(mappingCount);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executorService = Executors.newFixedThreadPool(mappingCount);
+    List<Future<?>> futures = new ArrayList<>();
+
+    try {
+      for (StubMapping mapping : mappings) {
+        futures.add(
+            executorService.submit(
+                () -> {
+                  ready.countDown();
+                  start.await();
+                  scenarios.onStubMappingRemoved(mapping);
+                  return null;
+                }));
+      }
+
+      assertThat(ready.await(10, TimeUnit.SECONDS), is(true));
+      start.countDown();
+    } finally {
+      executorService.shutdown();
+    }
+
+    assertThat(executorService.awaitTermination(10, TimeUnit.SECONDS), is(true));
+    for (Future<?> future : futures) {
+      future.get();
+    }
+    assertThat(scenarios.getByName("one"), nullValue());
   }
 
   @Test

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/AbstractScenarios.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/stubbing/AbstractScenarios.java
@@ -31,17 +31,17 @@ public abstract class AbstractScenarios implements Scenarios {
   }
 
   @Override
-  public Scenario getByName(String name) {
+  public synchronized Scenario getByName(String name) {
     return store.get(name).orElse(null);
   }
 
   @Override
-  public List<Scenario> getAll() {
+  public synchronized List<Scenario> getAll() {
     return store.getAll().collect(toList());
   }
 
   @Override
-  public void onStubMappingAdded(StubMapping mapping) {
+  public synchronized void onStubMappingAdded(StubMapping mapping) {
     if (mapping.isInScenario()) {
       String scenarioName = mapping.getScenarioName();
       Scenario scenario =
@@ -53,7 +53,7 @@ public abstract class AbstractScenarios implements Scenarios {
   }
 
   @Override
-  public void onStubMappingUpdated(StubMapping oldMapping, StubMapping newMapping) {
+  public synchronized void onStubMappingUpdated(StubMapping oldMapping, StubMapping newMapping) {
     if (oldMapping.isInScenario()
         && !oldMapping.getScenarioName().equals(newMapping.getScenarioName())) {
       Scenario scenarioForOldMapping =
@@ -80,7 +80,7 @@ public abstract class AbstractScenarios implements Scenarios {
   }
 
   @Override
-  public void onStubMappingRemoved(StubMapping mapping) {
+  public synchronized void onStubMappingRemoved(StubMapping mapping) {
     if (mapping.isInScenario()) {
       final String scenarioName = mapping.getScenarioName();
       Scenario scenario =
@@ -98,7 +98,7 @@ public abstract class AbstractScenarios implements Scenarios {
   }
 
   @Override
-  public void onStubServed(StubMapping mapping) {
+  public synchronized void onStubServed(StubMapping mapping) {
     if (mapping.isInScenario()) {
       final String scenarioName = mapping.getScenarioName();
       Scenario scenario = store.get(scenarioName).orElseThrow(IllegalStateException::new);
@@ -112,17 +112,17 @@ public abstract class AbstractScenarios implements Scenarios {
   }
 
   @Override
-  public void reset() {
+  public synchronized void reset() {
     store.getAll().map(Scenario::reset).forEach(scenario -> store.put(scenario.getId(), scenario));
   }
 
   @Override
-  public void resetSingle(String name) {
+  public synchronized void resetSingle(String name) {
     setSingleScenarioState(name, Scenario::reset);
   }
 
   @Override
-  public void setSingle(String name, String state) {
+  public synchronized void setSingle(String name, String state) {
     setSingleScenarioState(name, scenario -> scenario.setState(state));
   }
 
@@ -137,12 +137,12 @@ public abstract class AbstractScenarios implements Scenarios {
   }
 
   @Override
-  public void clear() {
+  public synchronized void clear() {
     store.clear();
   }
 
   @Override
-  public boolean mappingMatchesScenarioState(StubMapping mapping) {
+  public synchronized boolean mappingMatchesScenarioState(StubMapping mapping) {
     String currentScenarioState = getByName(mapping.getScenarioName()).getState();
     return mapping.getRequiredScenarioState().equals(currentScenarioState);
   }


### PR DESCRIPTION
Fixes #1999

### Summary
- Synchronize scenario access in `AbstractScenarios` so concurrent read-modify-write operations cannot overwrite each other with stale `Scenario` instances.
- Add a regression test that removes all mappings from the same scenario concurrently and verifies the scenario is fully removed.

### Root cause
Scenario state is stored as immutable `Scenario` instances. Concurrent removals could read the same original scenario, remove different mappings independently, and write stale scenarios back to the store.

### Verification
- `./gradlew :test --tests com.github.tomakehurst.wiremock.stubbing.ScenariosTest`

### Disclosure
This contribution was prepared with AI assistance and reviewed before submission.