### PR TITLE
Add missing scenario state path to admin OpenAPI spec

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -819,6 +819,8 @@ class AdminApiTest extends AcceptanceTestBase {
     WireMockResponse response = testClient.get("/__admin/docs/swagger");
     assertThat(response.statusCode(), is(200));
     assertThat(response.content(), containsString("\"openapi\": \"3.0.0\""));
+    assertThat(response.content(), containsString("\"/__admin/scenarios/{name}/state\""));
+    assertThat(response.content(), containsString("\"setScenarioState\""));
   }
 
   @Test

--- a/wiremock-core/src/main/resources/swagger/wiremock-admin-api.json
+++ b/wiremock-core/src/main/resources/swagger/wiremock-admin-api.json
@@ -1228,6 +1228,34 @@
         }
       }
     },
+    "/__admin/scenarios/{name}/state": {
+      "parameters": [
+        {
+          "description": "The name of the scenario",
+          "in": "path",
+          "name": "name",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "put": {
+        "operationId": "setScenarioState",
+        "summary": "Set the state of an individual scenario",
+        "tags": [
+          "Scenarios"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/scenarioState"
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully set state"
+          }
+        }
+      }
+    },
     "/__admin/scenarios/reset": {
       "post": {
         "operationId": "resetAllScenarios",

--- a/wiremock-core/src/main/resources/swagger/wiremock-admin-api.yaml
+++ b/wiremock-core/src/main/resources/swagger/wiremock-admin-api.yaml
@@ -560,6 +560,25 @@ paths:
                       $ref: "schemas/scenario.yaml"
           description: All scenarios
 
+  /__admin/scenarios/{name}/state:
+    parameters:
+      - description: The name of the scenario
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: setScenarioState
+      summary: Set the state of an individual scenario
+      tags:
+         - Scenarios
+      requestBody:
+        $ref: "#/components/requestBodies/scenarioState"
+      responses:
+        '200':
+          description: Successfully set state
+
   /__admin/scenarios/reset:
     post:
       operationId: resetAllScenarios


### PR DESCRIPTION
Closes #3319.

## Summary
- add the missing `/__admin/scenarios/{name}/state` PUT path to the admin OpenAPI spec
- keep the JSON and YAML spec resources aligned for the embedded docs endpoint
- extend `AdminApiTest` so the served swagger document covers this route

## Verification
- `./gradlew.bat :test --tests com.github.tomakehurst.wiremock.AdminApiTest`