### PR TITLE
Fix equalToXml matching with NamespaceAwareness.NONE

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -703,6 +703,31 @@ public class EqualToXmlPatternTest {
     EqualToXmlPattern pattern =
         new EqualToXmlPattern("<body><!-- Comment --><entry/><entry/></body>", false, true);
     MatchResult result = pattern.match("<body><entry/><entry/><!-- A different comment --></body>");
+    assertTrue(result.isExactMatch());
+  }
+
+  @Test
+  void noNamespaceAwarenessMatchesDifferentlyNamedSiblingElementsRegardlessOfOrder() {
+    String expected = "<root><a>1</a><b>2</b></root>";
+    EqualToXmlPattern pattern = equalToXml(expected, EqualToXmlPattern.NamespaceAwareness.NONE);
+
+    assertTrue(pattern.match(expected).isExactMatch());
+    assertTrue(pattern.match("<root><b>2</b><a>1</a></root>").isExactMatch());
+  }
+
+  @Test
+  void noNamespaceAwarenessIgnoresOrderOfSameNamedSiblingElements() {
+    EqualToXmlPattern pattern =
+        equalToXml(
+            "<root><item>1</item><item>2</item></root>",
+            false,
+            null,
+            null,
+            true,
+            EqualToXmlPattern.NamespaceAwareness.NONE);
+
+    MatchResult result = pattern.match("<root><item>2</item><item>1</item></root>");
+
     assertTrue(result.isExactMatch());
   }
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPattern.java
@@ -342,11 +342,17 @@ public class EqualToXmlPattern extends StringValuePattern {
           .collect(Collectors.toList());
     }
 
+    private static String getNameForComparison(Node node) {
+      String localName = node.getLocalName();
+      return localName != null ? localName : node.getNodeName();
+    }
+
     private Comparator<Node> getComparator() {
       if (Objects.nonNull(secondaryOrderByTextContent) && secondaryOrderByTextContent) {
-        return Comparator.comparing(Node::getLocalName).thenComparing(Node::getTextContent);
+        return Comparator.comparing(OrderInvariantNodeMatcher::getNameForComparison)
+            .thenComparing(Node::getTextContent);
       } else {
-        return Comparator.comparing(Node::getLocalName);
+        return Comparator.comparing(OrderInvariantNodeMatcher::getNameForComparison);
       }
     }
   }


### PR DESCRIPTION
## Description

With `NamespaceAwareness.NONE`, DOM nodes have no local name. The order-invariant matcher sorted sibling elements by `Node#getLocalName()`, which caused comparison to fail as soon as two siblings were sorted.

Use the full node name only when the local name is unavailable. This preserves the existing namespace-aware behavior and gives namespace-unaware elements the name used by their comparison mode.

Fixes #3508

## Verification

- The two focused regression cases fail on current `master` and pass with this change.
- Full `./gradlew test`
- `spotlessJavaCheck`
