### PR TITLE
fix: handle boolean XPath results in matchesXPath (#3510) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
@@ -35,6 +35,62 @@ import org.skyscreamer.jsonassert.JSONAssert;
 public class MatchesXPathPatternTest {
 
   @Test
+  public void returnsNoExactMatchWhenBooleanXPathExpressionIsFalse() {
+    String mySolarSystemXML =
+        "<solar-system>"
+            + "<planet name='Earth' position='3' supportsLife='yes'/>"
+            + "<planet name='Venus' position='4'/></solar-system>";
+
+    StringValuePattern pattern = WireMock.matchingXPath("count(//planet) = 99");
+
+    MatchResult match = pattern.match(mySolarSystemXML);
+    assertFalse(match.isExactMatch(), "Expected XPath boolean-false to not match");
+    assertThat(match.getDistance(), is(1.0));
+  }
+
+  @Test
+  public void returnsExactMatchWhenBooleanXPathExpressionIsTrue() {
+    String mySolarSystemXML =
+        "<solar-system>"
+            + "<planet name='Earth' position='3' supportsLife='yes'/>"
+            + "<planet name='Venus' position='4'/></solar-system>";
+
+    StringValuePattern pattern = WireMock.matchingXPath("count(//planet) = 2");
+
+    MatchResult match = pattern.match(mySolarSystemXML);
+    assertTrue(match.isExactMatch(), "Expected XPath boolean-true to match");
+    assertThat(match.getDistance(), is(0.0));
+  }
+
+  @Test
+  public void returnsNoExactMatchWhenContainsExpressionIsFalse() {
+    String mySolarSystemXML =
+        "<solar-system>"
+            + "<planet name='Earth' position='3' supportsLife='yes'/>"
+            + "<planet name='Venus' position='4'/></solar-system>";
+
+    StringValuePattern pattern = WireMock.matchingXPath("contains('abc','z')");
+
+    MatchResult match = pattern.match(mySolarSystemXML);
+    assertFalse(match.isExactMatch(), "Expected contains false to not match");
+    assertThat(match.getDistance(), is(1.0));
+  }
+
+  @Test
+  public void returnsNoExactMatchWhenComparisonExpressionIsFalse() {
+    String mySolarSystemXML =
+        "<solar-system>"
+            + "<planet name='Earth' position='3' supportsLife='yes'/>"
+            + "<planet name='Venus' position='4'/></solar-system>";
+
+    StringValuePattern pattern = WireMock.matchingXPath("1 = 2");
+
+    MatchResult match = pattern.match(mySolarSystemXML);
+    assertFalse(match.isExactMatch(), "Expected 1=2 false to not match");
+    assertThat(match.getDistance(), is(1.0));
+  }
+
+  @Test
   public void returnsExactMatchWhenXPathMatches() {
     String mySolarSystemXML =
         "<solar-system>"

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/xml/XmlNode.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/xml/XmlNode.java
@@ -78,6 +78,11 @@ public abstract class XmlNode {
         nodes.forEach(node -> xmlNodes.add(new XmlDomNode(node)));
       }
       case NODE -> xmlNodes.add(new XmlDomNode((Node) evaluationResult.value()));
+      case BOOLEAN -> {
+        if (Boolean.TRUE.equals(evaluationResult.value())) {
+          xmlNodes.add(new XmlPrimitiveNode<>(evaluationResult.value()));
+        }
+      }
       default -> xmlNodes.add(new XmlPrimitiveNode<>(evaluationResult.value()));
     }
 


### PR DESCRIPTION
## What

Fixes #3510

`matchesXPath` with a boolean-valued expression (e.g. `count(//planet) = 99`, `1 = 2`, `contains('abc','z')`) always matches, even when the boolean is false. The root cause is in `XmlNode.toListOrSingle()`: the `default` branch wraps any non-node XPath evaluation result in a single `XmlPrimitiveNode`, making the node list always non-empty, which `isSimpleMatch` interprets as a match.

## Fix

Add an explicit `BOOLEAN` case in `toListOrSingle()` that only adds a node when the value is `true`. A false boolean produces an empty list, which correctly causes `isSimpleMatch` to return no match. `NUMBER` and `STRING` results still use the default wrapping for the Handlebars xPath helper and two-argument paths.

## Tests

- `returnsNoExactMatchWhenBooleanXPathExpressionIsFalse` — `count(//planet) = 99` should not match
- `returnsExactMatchWhenBooleanXPathExpressionIsTrue` — `count(//planet) = 2` should match
- `returnsNoExactMatchWhenContainsExpressionIsFalse` — `contains('abc','z')` should not match
- `returnsNoExactMatchWhenComparisonExpressionIsFalse` — `1 = 2` should not match

All existing tests continue to pass.