### PR TITLE
fix: make RequestPattern hashCode consistent

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 Thomas Akehurst
+ * Copyright (C) 2016-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.matching;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
 import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
@@ -50,8 +51,10 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1143,6 +1146,49 @@ class RequestPatternTest {
     assertThat(pattern.getScheme(), is(""));
     assertThat(Json.write(pattern), jsonEquals("""
         {"method": "ANY", "scheme": ""}"""));
+  }
+
+  @Test
+  void equalRequestPatternsHaveEqualHashCodes() {
+    RequestPattern a = RequestPattern.ANYTHING;
+    RequestPattern b = newRequestPattern(RequestMethod.ANY, anyUrl()).build();
+
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+    assertEquals(b, a);
+    assertEquals(b.hashCode(), a.hashCode());
+  }
+
+  @Test
+  void equalRequestPatternsWithSameFieldsHaveEqualHashCodes() {
+    RequestPattern a =
+        newRequestPattern(GET, urlPathEqualTo("/my/url"))
+            .withHeader("Accept", equalTo("text/plain"))
+            .withQueryParam("search", containing("thing"))
+            .build();
+    RequestPattern b =
+        newRequestPattern(GET, urlPathEqualTo("/my/url"))
+            .withHeader("Accept", equalTo("text/plain"))
+            .withQueryParam("search", containing("thing"))
+            .build();
+    RequestPattern c = newRequestPattern(GET, urlPathEqualTo("/other")).build();
+
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+    assertNotEquals(a, c);
+    assertNotEquals(a.hashCode(), c.hashCode());
+  }
+
+  @Test
+  void requestPatternWorksAsHashMapKeyAcrossEqualInstances() {
+    Map<RequestPattern, String> byPattern = new HashMap<>();
+    RequestPattern first = newRequestPattern(PUT, urlEqualTo("/items/1")).build();
+    RequestPattern second = newRequestPattern(PUT, urlEqualTo("/items/1")).build();
+
+    byPattern.put(first, "stub-a");
+
+    assertThat(byPattern.get(second), is("stub-a"));
+    assertThat(byPattern.containsKey(second), is(true));
   }
 
   static Matcher<ContentPattern<?>> valuePattern(

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -69,7 +69,6 @@ public class RequestPattern implements NamedValueMatcher<Request> {
   @NonNull private final List<MultipartValuePattern> multipartPatterns;
 
   private final CustomMatcherDefinition customMatcherDefinition;
-  private final ValueMatcher<Request> matcher;
   private final ValueMatcher<Request> inlineCustomMatcher;
 
   @JsonCreator
@@ -146,55 +145,6 @@ public class RequestPattern implements NamedValueMatcher<Request> {
     this.customMatcherDefinition = customMatcherDefinition;
     this.multipartPatterns = multiPattern != null ? List.copyOf(multiPattern) : List.of();
     this.inlineCustomMatcher = customMatcher;
-
-    this.matcher =
-        new RequestMatcher() {
-          @Override
-          public MatchResult match(Request request) {
-            final List<WeightedMatchResult> requestPartMatchResults = new ArrayList<>(15);
-
-            requestPartMatchResults.add(weight(schemeMatches(request), 3.0));
-            requestPartMatchResults.add(weight(hostMatches(request), 10.0));
-            requestPartMatchResults.add(weight(portMatches(request), 10.0));
-            requestPartMatchResults.add(weight(clientIpMatches(request), 3.0));
-            requestPartMatchResults.add(
-                weight(
-                    RequestPattern.this.url.match(
-                        request.getPathAndQueryWithoutPrefix().toString()),
-                    10.0));
-            requestPartMatchResults.add(
-                weight(RequestPattern.this.method.match(request.getMethod()), 3.0));
-
-            MatchResult matchResult =
-                new MemoizingMatchResult(MatchResult.aggregateWeighted(requestPartMatchResults));
-
-            if (!matchResult.isExactMatch()) {
-              return matchResult;
-            }
-
-            requestPartMatchResults.add(weight(allPathParamsMatch(request)));
-            requestPartMatchResults.add(weight(allHeadersMatchResult(request)));
-            requestPartMatchResults.add(weight(allQueryParamsMatch(request)));
-            requestPartMatchResults.add(weight(allFormParamsMatch(request)));
-            requestPartMatchResults.add(weight(allCookiesMatch(request)));
-            requestPartMatchResults.add(weight(allBodyPatternsMatch(request)));
-            requestPartMatchResults.add(weight(allMultipartPatternsMatch(request)));
-
-            matchResult =
-                new MemoizingMatchResult(MatchResult.aggregateWeighted(requestPartMatchResults));
-            if (!matchResult.isExactMatch() || customMatcher == null) {
-              return matchResult;
-            }
-
-            requestPartMatchResults.add(weight(customMatcher.match(request)));
-            return new MemoizingMatchResult(MatchResult.aggregateWeighted(requestPartMatchResults));
-          }
-
-          @Override
-          public String getName() {
-            return "request-matcher";
-          }
-        };
   }
 
   public static final RequestPattern ANYTHING =
@@ -217,7 +167,7 @@ public class RequestPattern implements NamedValueMatcher<Request> {
 
   public MatchResult match(Request request, Map<String, RequestMatcherExtension> customMatchers) {
     request = RequestPathParamsDecorator.decorate(request, this);
-    final MatchResult standardMatchResult = matcher.match(request);
+    final MatchResult standardMatchResult = matchStandard(request);
     if (standardMatchResult.isExactMatch() && customMatcherDefinition != null) {
       RequestMatcherExtension requestMatcher =
           getFirstNonNull(customMatchers.get(customMatcherDefinition.getName()), NEVER);
@@ -229,6 +179,41 @@ public class RequestPattern implements NamedValueMatcher<Request> {
     }
 
     return standardMatchResult;
+  }
+
+  private MatchResult matchStandard(Request request) {
+    final List<WeightedMatchResult> requestPartMatchResults = new ArrayList<>(15);
+
+    requestPartMatchResults.add(weight(schemeMatches(request), 3.0));
+    requestPartMatchResults.add(weight(hostMatches(request), 10.0));
+    requestPartMatchResults.add(weight(portMatches(request), 10.0));
+    requestPartMatchResults.add(weight(clientIpMatches(request), 3.0));
+    requestPartMatchResults.add(
+        weight(url.match(request.getPathAndQueryWithoutPrefix().toString()), 10.0));
+    requestPartMatchResults.add(weight(method.match(request.getMethod()), 3.0));
+
+    MatchResult matchResult =
+        new MemoizingMatchResult(MatchResult.aggregateWeighted(requestPartMatchResults));
+
+    if (!matchResult.isExactMatch()) {
+      return matchResult;
+    }
+
+    requestPartMatchResults.add(weight(allPathParamsMatch(request)));
+    requestPartMatchResults.add(weight(allHeadersMatchResult(request)));
+    requestPartMatchResults.add(weight(allQueryParamsMatch(request)));
+    requestPartMatchResults.add(weight(allFormParamsMatch(request)));
+    requestPartMatchResults.add(weight(allCookiesMatch(request)));
+    requestPartMatchResults.add(weight(allBodyPatternsMatch(request)));
+    requestPartMatchResults.add(weight(allMultipartPatternsMatch(request)));
+
+    matchResult = new MemoizingMatchResult(MatchResult.aggregateWeighted(requestPartMatchResults));
+    if (!matchResult.isExactMatch() || inlineCustomMatcher == null) {
+      return matchResult;
+    }
+
+    requestPartMatchResults.add(weight(inlineCustomMatcher.match(request)));
+    return new MemoizingMatchResult(MatchResult.aggregateWeighted(requestPartMatchResults));
   }
 
   private MatchResult allCookiesMatch(final Request request) {


### PR DESCRIPTION
### Proposed changes

Fixes #3201 — `RequestPattern.hashCode()` could produce unstable values because the internal matching logic was stored as an anonymous `RequestMatcher` instance whose class-based `hashCode()` (and historically inclusion in `Objects.hash(...)`) is not stable across JVM runs / debug vs run.

This change:

- Removes the identity-bearing private `matcher` field (anonymous inner class)
- Moves the same matching logic into a private `matchStandard(Request)` method
- Keeps `equals` / `hashCode` based only on logical fields (`scheme`, `url`, headers, params, `inlineCustomMatcher`, etc.)
- Adds regression tests for equal instances and `HashMap` key lookup (used when grouping stubs by request pattern, e.g. scenario processing)

### Notes

- No public API change
- Matching behaviour is unchanged; only how the standard matcher is structured
- Prior open work: baezzys expressed interest on the issue but no PR was opened; one comment noted the Run/Debug discrepancy was no longer obvious after immutability work — this hardens the root cause and locks it with tests

### Verification

```bash
./gradlew :test \
  --tests 'com.github.tomakehurst.wiremock.matching.RequestPatternTest' \
  --tests 'com.github.tomakehurst.wiremock.matching.RequestPatternBuilderTest' \
  --tests 'com.github.tomakehurst.wiremock.recording.ScenarioProcessorTest'
```

All green (JDK 17).