### PR TITLE
fix: handle null part name in multipart request to prevent DuplicateKeyException (Fixes #2995)

### DIFF
--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/TemplateEngine.java
@@ -208,27 +208,26 @@ public class TemplateEngine {
 
         return result;
       } else {
-        return request.getParts().stream()
-            .collect(
-                Collectors.toMap(
-                    Request.Part::getName,
-                    part ->
-                        new RequestPartTemplateModel(
-                            part.getName(),
-                            part.getHeaders().all().stream()
-                                .collect(
-                                    Collectors.toMap(
-                                        HttpHeader::key,
-                                        header -> ListOrSingle.of(header.values()),
-                                        (e1, e2) -> {
-                                          throw new IllegalStateException("Duplicate header name");
-                                        },
-                                        LinkedHashMap::new)),
-                            part.getBodyEntity()),
-                    (e1, e2) -> {
-                      throw new IllegalStateException("Duplicate request part name");
-                    },
-                    LinkedHashMap::new));
+        Map<String, RequestPartTemplateModel> result = new LinkedHashMap<>();
+        int partIndex = 0;
+        for (Request.Part part : request.getParts()) {
+          String key = part.getName() != null ? part.getName() : "part-" + partIndex++;
+          result.put(
+              key,
+              new RequestPartTemplateModel(
+                  key,
+                  part.getHeaders().all().stream()
+                      .collect(
+                          Collectors.toMap(
+                              HttpHeader::key,
+                              header -> ListOrSingle.of(header.values()),
+                              (e1, e2) -> {
+                                throw new IllegalStateException("Duplicate header name");
+                              },
+                              LinkedHashMap::new)),
+                  part.getBodyEntity()));
+        }
+        return result;
       }
     }
 


### PR DESCRIPTION
### What

When a multipart request contains parts without a `name` attribute in the Content-Disposition header, `Request.Part.getName()` returns null. The `Collectors.toMap()` call in `buildRequestPartModel()` then throws `IllegalStateException: Duplicate key null` when two or more parts have null names.

### Fix

Replace the `Collectors.toMap()` with an explicit loop that assigns a fallback key (`"part-" + index`) when `part.getName()` is null, matching the pattern already used in the `multipart/related` branch above.

### Example

A multipart/related request with parts like:
- JSON part (no name)
- Base64-encoded binary part (no name)

Both parts have null names, causing the stream `Collectors.toMap(Request.Part::getName, ...)` to throw `DuplicateKeyException`.

Fixes #2995