### PR TITLE
Support trailing slash for admin docs

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -835,6 +835,13 @@ class AdminApiTest extends AcceptanceTestBase {
   }
 
   @Test
+  void servesDocIndexWithTrailingSlash() {
+    WireMockResponse response = testClient.get("/__admin/docs/");
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.content(), containsString("<html"));
+  }
+
+  @Test
   void deleteStubFile() {
     String fileName = "bar.txt";
     FileSource fileSource = wireMockServer.getOptions().filesRoot().child(FILES_ROOT);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/admin/AdminRoutes.java
@@ -115,6 +115,7 @@ public class AdminRoutes {
 
     router.add(GET, "/docs/swagger", new GetSwaggerSpecTask());
     router.add(GET, "/docs", new GetDocIndexTask());
+    router.add(GET, "/docs/", new GetDocIndexTask());
 
     router.add(GET, "/certs/wiremock-ca.crt", new GetCaCertTask());
 
@@ -166,11 +167,15 @@ public class AdminRoutes {
   }
 
   public AdminTask taskFor(final RequestMethod method, final Path path) {
+    return routes.get(requestSpecFor(method, path));
+  }
+
+  public RequestSpec requestSpecFor(final RequestMethod method, final Path path) {
     return routes.entrySet().stream()
-        .filter(entry -> entry.getKey().matches(method, path))
-        .map(Entry::getValue)
+        .map(Entry::getKey)
+        .filter(requestSpec -> requestSpec.matches(method, path))
         .findFirst()
-        .orElseGet(NotFoundAdminTask::new);
+        .orElseThrow(() -> new NotFoundException("No route matched " + method + " " + path));
   }
 
   public RequestSpec requestSpecForTask(final Class<? extends AdminTask> taskClass) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandler.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandler.java
@@ -82,10 +82,9 @@ public class AdminRequestHandler extends AbstractRequestHandler {
     Path path = withoutAdminRoot(request.getPathAndQueryWithoutPrefix().getPath());
 
     try {
+      var requestSpec = adminRoutes.requestSpecFor(request.getMethod(), path);
       AdminTask adminTask = adminRoutes.taskFor(request.getMethod(), path);
-
-      PathTemplate uriTemplate =
-          adminRoutes.requestSpecForTask(adminTask.getClass()).getUriTemplate();
+      PathTemplate uriTemplate = requestSpec.getUriTemplate();
       PathParams pathParams = uriTemplate.parse(path);
 
       return initialServeEvent.withResponseDefinition(


### PR DESCRIPTION
Closes #3332.

## Summary
- allow the documented `/__admin/docs/` path to resolve to the admin docs index
- look up the matched admin request spec by method and path so aliased routes can share a task class safely
- cover the trailing-slash admin docs URL in `AdminApiTest`

## Verification
- `./gradlew :test --tests com.github.tomakehurst.wiremock.AdminApiTest --tests com.github.tomakehurst.wiremock.stubbing.AdminRequestHandlerTest`