### PR TITLE
fix: inject Notifier into AbstractRequestHandler to support custom HttpServerFactory logging

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/jetty/JettyHttpServerTest.java
@@ -25,6 +25,7 @@ import com.github.tomakehurst.wiremock.admin.AdminRoutes;
 import com.github.tomakehurst.wiremock.common.DataTruncationSettings;
 import com.github.tomakehurst.wiremock.common.FatalStartupException;
 import com.github.tomakehurst.wiremock.common.Limit;
+import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.core.StubServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -77,7 +78,17 @@ public class JettyHttpServerTest {
             false,
             Collections.emptyList(),
             Collections.emptyList(),
-            NO_TRUNCATION);
+            NO_TRUNCATION,
+            new Notifier() {
+              @Override
+              public void info(String message) {}
+
+              @Override
+              public void error(String message) {}
+
+              @Override
+              public void error(String message, Throwable t) {}
+            });
     stubRequestHandler =
         new StubRequestHandler(
             Mockito.mock(StubServer.class),
@@ -90,7 +101,17 @@ public class JettyHttpServerTest {
             Collections.emptyList(),
             false,
             NO_TRUNCATION,
-            new PlainTextStubNotMatchedRenderer(Extensions.NONE));
+            new PlainTextStubNotMatchedRenderer(Extensions.NONE),
+            new Notifier() {
+              @Override
+              public void info(String message) {}
+
+              @Override
+              public void error(String message) {}
+
+              @Override
+              public void error(String message, Throwable t) {}
+            });
     messageStubRequestHandler =
         new MessageStubRequestHandler(
             messageStubMappings,

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import com.github.tomakehurst.wiremock.admin.AdminRoutes;
 import com.github.tomakehurst.wiremock.common.DataTruncationSettings;
 import com.github.tomakehurst.wiremock.common.Limit;
+import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
 import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
@@ -64,7 +65,17 @@ public class AdminRequestHandlerTest {
             false,
             Collections.emptyList(),
             Collections.emptyList(),
-            new DataTruncationSettings(Limit.UNLIMITED));
+            new DataTruncationSettings(Limit.UNLIMITED),
+            new Notifier() {
+              @Override
+              public void info(String message) {}
+
+              @Override
+              public void error(String message) {}
+
+              @Override
+              public void error(String message, Throwable t) {}
+            });
   }
 
   @Test

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -236,7 +236,8 @@ public class WireMockApp implements StubServer, Admin {
         options.getHttpsRequiredForAdminApi(),
         getAdminRequestFilters(),
         getV2AdminRequestFilters(),
-        options.getDataTruncationSettings());
+        options.getDataTruncationSettings(),
+        options.notifier());
   }
 
   public StubRequestHandler buildStubRequestHandler() {
@@ -284,7 +285,8 @@ public class WireMockApp implements StubServer, Admin {
         getV2StubRequestFilters(),
         options.getStubRequestLoggingDisabled(),
         options.getDataTruncationSettings(),
-        options.getNotMatchedRendererFactory().apply(extensions));
+        options.getNotMatchedRendererFactory().apply(extensions),
+        options.notifier());
   }
 
   public MessageStubRequestHandler buildMessageStubRequestHandler() {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
@@ -15,10 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static com.github.tomakehurst.wiremock.stubbing.ServeEvent.ORIGINAL_SERVE_EVENT_KEY;
 
 import com.github.tomakehurst.wiremock.common.DataTruncationSettings;
+import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.common.RequestCache;
 import com.github.tomakehurst.wiremock.extension.requestfilter.*;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
@@ -33,15 +33,18 @@ public abstract class AbstractRequestHandler implements RequestHandler, RequestE
   protected final FilterProcessor filterProcessor;
 
   private final DataTruncationSettings dataTruncationSettings;
+  protected final Notifier notifier;
 
   public AbstractRequestHandler(
       ResponseRenderer responseRenderer,
       List<RequestFilter> requestFilters,
       List<RequestFilterV2> v2RequestFilters,
-      DataTruncationSettings dataTruncationSettings) {
+      DataTruncationSettings dataTruncationSettings,
+      Notifier notifier) {
     this.responseRenderer = responseRenderer;
     this.filterProcessor = new FilterProcessor(requestFilters, v2RequestFilters);
     this.dataTruncationSettings = dataTruncationSettings;
+    this.notifier = notifier;
   }
 
   @Override
@@ -79,14 +82,13 @@ public abstract class AbstractRequestHandler implements RequestHandler, RequestE
     serveEvent = serveEvent.complete(response, dataTruncationSettings);
 
     if (logRequests()) {
-      notifier()
-          .info(
-              "Request received:\n"
-                  + formatRequest(request)
-                  + "\n\nMatched response definition:\n"
-                  + responseDefinition
-                  + "\n\nResponse:\n"
-                  + response);
+      notifier.info(
+          "Request received:\n"
+              + formatRequest(request)
+              + "\n\nMatched response definition:\n"
+              + responseDefinition
+              + "\n\nResponse:\n"
+              + response);
     }
 
     for (RequestListener listener : listeners) {

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandler.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandler.java
@@ -15,7 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static com.github.tomakehurst.wiremock.core.WireMockApp.ADMIN_CONTEXT_ROOT_SEGMENT;
 import static org.wiremock.url.SchemeRegistry.https;
 
@@ -48,8 +47,9 @@ public class AdminRequestHandler extends AbstractRequestHandler {
       boolean requireHttps,
       List<RequestFilter> requestFilters,
       List<RequestFilterV2> v2RequestFilters,
-      DataTruncationSettings dataTruncationSettings) {
-    super(responseRenderer, requestFilters, v2RequestFilters, dataTruncationSettings);
+      DataTruncationSettings dataTruncationSettings,
+      Notifier notifier) {
+    super(responseRenderer, requestFilters, v2RequestFilters, dataTruncationSettings, notifier);
     this.adminRoutes = adminRoutes;
     this.admin = admin;
     this.authenticator = authenticator;
@@ -63,22 +63,21 @@ public class AdminRequestHandler extends AbstractRequestHandler {
     final boolean isRequestHttps = request.getTypedAbsoluteUrl().getScheme().equals(https);
 
     if (requireHttps && !isRequestHttps) {
-      notifier().info("HTTPS is required for admin requests, sending upgrade redirect");
+      notifier.info("HTTPS is required for admin requests, sending upgrade redirect");
       return initialServeEvent.withResponseDefinition(
           ResponseDefinition.notPermitted("HTTPS is required for accessing the admin API"));
     }
 
     if (!authenticator.authenticate(request)) {
-      notifier()
-          .info(
-              "Authentication failed for "
+      notifier.info(
+          "Authentication failed for "
                   + request.getMethod()
                   + " "
                   + request.getPathAndQueryWithoutPrefix());
       return initialServeEvent.withResponseDefinition(ResponseDefinition.notAuthorised());
     }
 
-    notifier().info("Admin request received:\n" + formatRequest(request));
+    notifier.info("Admin request received:\n" + formatRequest(request));
     Path path = withoutAdminRoot(request.getPathAndQueryWithoutPrefix().getPath());
 
     try {
@@ -104,7 +103,7 @@ public class AdminRequestHandler extends AbstractRequestHandler {
     } catch (ConflictException ce) {
       return initialServeEvent.withResponseDefinition(ResponseDefinition.conflict(ce.getErrors()));
     } catch (Throwable t) {
-      notifier().error("Unrecoverable error handling admin request", t);
+      notifier.error("Unrecoverable error handling admin request", t);
       throw t;
     }
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/StubRequestHandler.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/StubRequestHandler.java
@@ -15,11 +15,11 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static com.github.tomakehurst.wiremock.extension.ServeEventListener.RequestPhase.*;
 import static com.github.tomakehurst.wiremock.extension.ServeEventListenerUtils.triggerListeners;
 
 import com.github.tomakehurst.wiremock.common.DataTruncationSettings;
+import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.common.url.PathParams;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.core.StubServer;
@@ -56,8 +56,9 @@ public class StubRequestHandler extends AbstractRequestHandler {
       List<RequestFilterV2> v2RequestFilters,
       boolean loggingDisabled,
       DataTruncationSettings dataTruncationSettings,
-      NotMatchedRenderer notMatchedRenderer) {
-    super(responseRenderer, requestFilters, v2RequestFilters, dataTruncationSettings);
+      NotMatchedRenderer notMatchedRenderer,
+      Notifier notifier) {
+    super(responseRenderer, requestFilters, v2RequestFilters, dataTruncationSettings, notifier);
     this.stubServer = stubServer;
     this.admin = admin;
     this.postServeActions = postServeActions;
@@ -127,7 +128,7 @@ public class StubRequestHandler extends AbstractRequestHandler {
         Parameters parameters = postServeActionDef.getParameters();
         action.doAction(serveEvent, admin, parameters);
       } else {
-        notifier().error("No extension was found named \"" + postServeActionDef.getName() + "\"");
+        notifier.error("No extension was found named \"" + postServeActionDef.getName() + "\"");
       }
     }
   }


### PR DESCRIPTION
## Summary

When using a custom `HttpServerFactory`, the `Notifier` (set via `.notifier(ConsoleNotifier(...))`) silently doesn't take effect — only the default Jetty log line appears.

## Root Cause

`AbstractRequestHandler.handle()` and `AdminRequestHandler.handleRequest()` call `LocalNotifier.notifier()`, which reads a thread-local set by `WireMockHandlerDispatchingServlet.service()`. Custom `HttpServerFactory` implementations never call `LocalNotifier.set()`, so the thread-local defaults to `NullNotifier`.

## Fix

Inject a `Notifier` instance into `AbstractRequestHandler` via constructor, replacing the `LocalNotifier.notifier()` static call. The change flows through:

1. **`AbstractRequestHandler`** — Added `Notifier notifier` field, constructor parameter, and replaced `notifier()` calls with `notifier`.
2. **`StubRequestHandler`** — Added `Notifier` constructor parameter, passed to super.
3. **`AdminRequestHandler`** — Added `Notifier` constructor parameter, passed to super, replaced `notifier()` calls.
4. **`WireMockApp`** — Passes `options.notifier()` to both handler constructors.

The Jetty servlet's `LocalNotifier.set()` call is retained for backward compatibility with other code that still uses the thread-local pattern.

## Testing

- All existing tests pass (AdminRequestHandlerTest, JettyHttpServerTest)
- `./gradlew :wiremock-core:compileJava` — BUILD SUCCESSFUL

Fixes #3285