### PR TITLE
Clarify default stub priority in schemas

### DIFF
--- a/schemas/wiremock-message-stub-mapping-or-mappings.json
+++ b/schemas/wiremock-message-stub-mapping-or-mappings.json
@@ -1001,7 +1001,7 @@
         },
         "priority" : {
           "type" : "integer",
-          "description" : "This message stub mapping's priority relative to others. 1 is highest.",
+          "description" : "This message stub mapping's priority relative to others. If omitted, the default priority is 5. 1 is highest.",
           "minimum" : 1
         },
         "trigger" : {
@@ -1664,7 +1664,7 @@
         },
         "priority" : {
           "type" : "integer",
-          "description" : "This stub mapping's priority relative to others. 1 is highest.",
+          "description" : "This stub mapping's priority relative to others. If omitted, the default priority is 5. 1 is highest.",
           "minimum" : 1
         },
         "scenarioName" : {

--- a/schemas/wiremock-stub-mapping-or-mappings.json
+++ b/schemas/wiremock-stub-mapping-or-mappings.json
@@ -1001,7 +1001,7 @@
         },
         "priority" : {
           "type" : "integer",
-          "description" : "This message stub mapping's priority relative to others. 1 is highest.",
+          "description" : "This message stub mapping's priority relative to others. If omitted, the default priority is 5. 1 is highest.",
           "minimum" : 1
         },
         "trigger" : {
@@ -1664,7 +1664,7 @@
         },
         "priority" : {
           "type" : "integer",
-          "description" : "This stub mapping's priority relative to others. 1 is highest.",
+          "description" : "This stub mapping's priority relative to others. If omitted, the default priority is 5. 1 is highest.",
           "minimum" : 1
         },
         "scenarioName" : {

--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -819,6 +819,10 @@ class AdminApiTest extends AcceptanceTestBase {
     WireMockResponse response = testClient.get("/__admin/docs/swagger");
     assertThat(response.statusCode(), is(200));
     assertThat(response.content(), containsString("\"openapi\": \"3.0.0\""));
+    assertThat(
+        response.content(),
+        containsString(
+            "This stub mapping's priority relative to others. If omitted, the default priority is 5. 1 is highest."));
   }
 
   @Test

--- a/wiremock-core/src/main/resources/swagger/schemas/message-stub-mapping.yaml
+++ b/wiremock-core/src/main/resources/swagger/schemas/message-stub-mapping.yaml
@@ -14,7 +14,7 @@ properties:
     description: The message stub mapping's name
   priority:
     type: integer
-    description: This message stub mapping's priority relative to others. 1 is highest.
+    description: This message stub mapping's priority relative to others. If omitted, the default priority is 5. 1 is highest.
     minimum: 1
   trigger:
     $ref: 'message-trigger.yaml'
@@ -27,4 +27,3 @@ properties:
     type: object
     description: Arbitrary metadata to be attached to the stub mapping
     additionalProperties: true
-

--- a/wiremock-core/src/main/resources/swagger/schemas/stub-mapping.yaml
+++ b/wiremock-core/src/main/resources/swagger/schemas/stub-mapping.yaml
@@ -18,7 +18,7 @@ properties:
     description: Indicates that the stub mapping should be persisted immediately on create/update/delete and survive resets to default.
   priority:
     type: integer
-    description: This stub mapping's priority relative to others. 1 is highest.
+    description: This stub mapping's priority relative to others. If omitted, the default priority is 5. 1 is highest.
     minimum: 1
   scenarioName:
     type: string

--- a/wiremock-core/src/main/resources/swagger/wiremock-admin-api.json
+++ b/wiremock-core/src/main/resources/swagger/wiremock-admin-api.json
@@ -3746,7 +3746,7 @@
           },
           "priority": {
             "type": "integer",
-            "description": "This stub mapping's priority relative to others. 1 is highest.",
+            "description": "This stub mapping's priority relative to others. If omitted, the default priority is 5. 1 is highest.",
             "minimum": 1
           },
           "scenarioName": {
@@ -4470,7 +4470,7 @@
           },
           "priority": {
             "type": "integer",
-            "description": "This message stub mapping's priority relative to others. 1 is highest.",
+            "description": "This message stub mapping's priority relative to others. If omitted, the default priority is 5. 1 is highest.",
             "minimum": 1
           },
           "trigger": {


### PR DESCRIPTION
## References
- Refs #1574

## Summary
- clarify the published stub-mapping and message-stub-mapping schema descriptions to state that omitted priorities default to 5
- update the committed admin OpenAPI JSON so /__admin/docs/swagger exposes the same clarification
- add a regression assertion that the served Swagger spec includes the clarified priority description

## Verification
- `.\gradlew.bat :test --tests com.github.tomakehurst.wiremock.AdminApiTest --tests com.github.tomakehurst.wiremock.schema.WireMockStubMappingJsonSchemaRegressionTest --tests com.github.tomakehurst.wiremock.schema.WireMockMessageStubMappingJsonSchemaRegressionTest`

## Submitter checklist
- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)