### PR TITLE
fix: handle Bazel sandbox symlinks in assertFilePathIsUnderRoot [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/common/SingleRootFileSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/SingleRootFileSourceTest.java
@@ -18,13 +18,16 @@ package com.github.tomakehurst.wiremock.common;
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.filePath;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.fileNamed;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.hasExactlyIgnoringOrder;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.github.tomakehurst.wiremock.security.NotAuthorisedException;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -230,5 +233,29 @@ public class SingleRootFileSourceTest {
           SingleRootFileSource fileSource = new SingleRootFileSource(EXIST_FILES_ROOT_PATH);
           fileSource.getBinaryFileNamed("non-existent-file").getStream();
         });
+  }
+
+  @Test
+  void allowsReadingFileViaSymlinkInsideRootWhenCanonicalPathIsOutsideRoot(
+      @TempDir Path rootDir, @TempDir Path externalDir) throws IOException {
+    // Simulates Bazel's sandboxed runfiles, where the root directory contains symlinks
+    // to files that physically reside outside of it. The canonical path of such a file
+    // resolves outside the root, but access to it is legitimate (see #2964).
+    File externalFile = externalDir.resolve("external.xml").toFile();
+    Files.write(externalFile.toPath(), "<root/>".getBytes(UTF_8));
+
+    Path symlink = rootDir.resolve("aliased.xml");
+    try {
+      Files.createSymbolicLink(symlink, externalFile.toPath());
+    } catch (IOException | UnsupportedOperationException e) {
+      // Symbolic links may not be supported on this platform (e.g. Windows without privileges)
+      assumeTrue(false, "Symbolic links not supported on this platform");
+      return;
+    }
+
+    SingleRootFileSource fileSource = new SingleRootFileSource(rootDir.toFile());
+
+    // Must NOT throw NotAuthorisedException
+    fileSource.getBinaryFileNamed("aliased.xml");
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
@@ -160,14 +160,25 @@ public abstract class AbstractFileSource implements FileSource {
   private void assertFilePathIsUnderRoot(String path) {
     try {
       String rootPath = rootDirectory.getCanonicalPath();
+      String rootAbsolutePath = rootDirectory.getAbsolutePath();
 
       File file = new File(path);
       String filePath =
           file.isAbsolute()
               ? new File(path).getCanonicalPath()
               : new File(rootDirectory, path).getCanonicalPath();
+      String fileAbsolutePath =
+          file.isAbsolute()
+              ? new File(path).getAbsolutePath()
+              : new File(rootDirectory, path).getAbsolutePath();
 
-      if (!Paths.get(filePath).normalize().startsWith(rootPath)) {
+      // Check both the canonical path (which resolves symlinks) and the absolute path.
+      // The canonical path check catches path traversal attacks. The absolute path
+      // fallback handles filesystems where the root directory contains symlinks to
+      // files outside of it (e.g. Bazel's sandboxed runfiles), where the canonical
+      // path of a contained file legitimately resolves outside the root directory.
+      if (!Paths.get(filePath).normalize().startsWith(rootPath)
+          && !Paths.get(fileAbsolutePath).normalize().startsWith(rootAbsolutePath)) {
         throw new NotAuthorisedException(
             "Access to file "
                 + path


### PR DESCRIPTION
### What

Fix `AbstractFileSource.assertFilePathIsUnderRoot()` to handle filesystems where the root directory contains symlinks to files outside of it, such as Bazel's sandboxed runfiles.

### Why (context)

Under Bazel's sandbox, the root directory (e.g., `.../sandbox/NNN/execroot/.../wiremock`) is a real directory, but the files inside it are symlinks to the source tree. When `getCanonicalPath()` is called on such a file, it resolves the symlink to the real source path (e.g., `/home/user/Work/.../features.xml`), which is outside the root directory. This causes the security check to incorrectly throw `NotAuthorisedException`.

See issue #2964 for full reproduction details.

### How

The fix adds a fallback check using the **absolute path** (which does not resolve symlinks). The method now checks both:

1. The **canonical path** (with symlinks resolved) — catches path traversal attacks like `../../../etc/passwd`
2. The **absolute path** (without resolving symlinks) — allows access through symlinks that are legitimately inside the root directory, such as Bazel's sandboxed runfiles

A file is only rejected when **both** checks fail, ensuring backwards compatibility and security.

### Testing

- All existing tests continue to pass
- Added a new test `allowsReadingFileViaSymlinkInsideRootWhenCanonicalPathIsOutsideRoot` that creates a symlink inside the root pointing to a file outside of it, and verifies that reading the file via the symlink does not throw `NotAuthorisedException`

Closes #2964
