### PR TITLE
Fix NPE when scenario name generated from a request URL matcher that is not URL or URL path

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
@@ -60,7 +60,7 @@ public class SnapshotDslAcceptanceTest extends AcceptanceTestBase {
         new WireMockServer(
             wireMockConfig()
                 .dynamicPort()
-                .extensions(new TestParameterisedTransformer())
+                .extensions(new TestParameterisedTransformer(), new UrlPathTemplateTransformer())
                 .withRootDirectory(setupTempFileRoot().getAbsolutePath()));
     proxyingService.start();
     proxyingService.stubFor(proxyAllTo("http://localhost:" + wireMockServer.port()));
@@ -288,6 +288,21 @@ public class SnapshotDslAcceptanceTest extends AcceptanceTestBase {
   }
 
   @Test
+  public void
+      buildsAScenarioForRepeatedRequestsWhenTransformerChangesUrlPatternToUrlPathTemplate() {
+    targetService.stubFor(get("/stateful/1").willReturn(ok("One")));
+    client.get("/stateful/1");
+
+    targetService.stubFor(get("/stateful/2").willReturn(ok("Two")));
+    client.get("/stateful/2");
+
+    List<StubMapping> mappings =
+        snapshotRecord(recordSpec().transformers("url-path-template-transformer"));
+
+    assertThat(mappings, everyItem(WireMatchers.isInAScenario()));
+  }
+
+  @Test
   public void appliesTransformerWithParameters() {
     client.get("/transform-this");
 
@@ -436,6 +451,31 @@ public class SnapshotDslAcceptanceTest extends AcceptanceTestBase {
     @Override
     public String getName() {
       return "test-transformer";
+    }
+  }
+
+  public static class UrlPathTemplateTransformer extends StubMappingTransformer {
+
+    @Override
+    public StubMapping transform(StubMapping stubMapping, FileSource files, Parameters parameters) {
+      String urlPath = stubMapping.getRequest().getUrl();
+      String pathTemplate = urlPath.replaceAll("/[^/]+$", "/{state_id}");
+      return stubMapping.transform(
+          b ->
+              b.setRequest(
+                  stubMapping
+                      .getRequest()
+                      .transform(rb -> rb.setUrl(WireMock.urlPathTemplate(pathTemplate)))));
+    }
+
+    @Override
+    public boolean applyGlobally() {
+      return false;
+    }
+
+    @Override
+    public String getName() {
+      return "url-path-template-transformer";
     }
   }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
@@ -15,6 +15,12 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathTemplate;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -103,5 +109,42 @@ public class UrlsTest {
     Map<String, QueryParameter> query =
         Urls.toQueryParameterMap(Url.parse("/a/b/").getQueryOrEmpty());
     assertThat(query.isEmpty(), is(true));
+  }
+
+  @Test
+  public void urlPatternToPathPartsHandlesUrlEqualTo() {
+    assertThat(Urls.urlPatternToPathParts(urlEqualTo("/stateful/1")), is("stateful-1"));
+  }
+
+  @Test
+  public void urlPatternToPathPartsHandlesUrlPathEqualTo() {
+    assertThat(Urls.urlPatternToPathParts(urlPathEqualTo("/stateful/1")), is("stateful-1"));
+  }
+
+  @Test
+  public void urlPatternToPathPartsHandlesUrlMatching() {
+    assertThat(Urls.urlPatternToPathParts(urlMatching("/stateful/.*")), is("stateful-.*"));
+  }
+
+  @Test
+  public void urlPatternToPathPartsHandlesUrlPathMatching() {
+    assertThat(Urls.urlPatternToPathParts(urlPathMatching("/stateful/.*")), is("stateful-.*"));
+  }
+
+  @Test
+  public void urlPatternToPathPartsHandlesUrlPathTemplate() {
+    assertThat(
+        Urls.urlPatternToPathParts(urlPathTemplate("/stateful/{state_id}")),
+        is("stateful-{state_id}"));
+  }
+
+  @Test
+  public void urlPatternToPathPartsHandlesUrlEqualToWithQueryString() {
+    assertThat(Urls.urlPatternToPathParts(urlEqualTo("/stateful/1?foo=bar")), is("stateful-1"));
+  }
+
+  @Test
+  public void urlPatternToPathPartsHandlesAnyUrl() {
+    assertThat(Urls.urlPatternToPathParts(anyUrl()), is(""));
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/Urls.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/Urls.java
@@ -16,6 +16,8 @@
 package com.github.tomakehurst.wiremock.common;
 
 import com.github.tomakehurst.wiremock.http.QueryParameter;
+import com.github.tomakehurst.wiremock.matching.UrlPattern;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -43,5 +45,41 @@ public class Urls {
     int nodeCount = uriPathNodes.size();
 
     return nodeCount > 0 ? String.join("-", uriPathNodes) : "";
+  }
+
+  /**
+   * Normalises the value matched by any kind of {@link UrlPattern} (e.g. one created via {@code
+   * urlEqualTo}, {@code urlMatching}, {@code urlPathEqualTo}, {@code urlPathMatching} or {@code
+   * urlPathTemplate}) into its path segments.
+   *
+   * <p>This works generically across all current and future {@link UrlPattern} subtypes by parsing
+   * the matcher's own {@code toString()} description, rather than switching on specific pattern
+   * classes.
+   */
+  public static List<String> urlPatternToPathSegments(UrlPattern urlPattern) {
+    String description = urlPattern.toString();
+    String withoutScopePrefix =
+        description.startsWith("path and query ")
+            ? description.substring("path and query ".length())
+            : description.startsWith("path ")
+                ? description.substring("path ".length())
+                : description;
+
+    int firstSpaceIndex = withoutScopePrefix.indexOf(' ');
+    String matchedValue =
+        firstSpaceIndex >= 0 ? withoutScopePrefix.substring(firstSpaceIndex + 1) : "";
+    String pathOnly = matchedValue.split("\\?", 2)[0];
+
+    return Arrays.stream(pathOnly.split("/")).filter(part -> !part.isEmpty()).toList();
+  }
+
+  /**
+   * Normalises the value matched by any kind of {@link UrlPattern} into a set of dash-joined path
+   * parts, e.g. for use in a human-readable name.
+   *
+   * @see #urlPatternToPathSegments(UrlPattern)
+   */
+  public static String urlPatternToPathParts(UrlPattern urlPattern) {
+    return String.join("-", urlPatternToPathSegments(urlPattern));
   }
 }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
@@ -15,7 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.recording;
 
-import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
@@ -27,7 +26,6 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.wiremock.url.PathAndQuery;
 
 class ScenarioProcessor {
 
@@ -75,11 +73,7 @@ class ScenarioProcessor {
         "scenario-"
             + scenarioIndex
             + "-"
-            + Urls.urlToPathParts(
-                PathAndQuery.parse(
-                    getFirstNonNull(
-                        firstScenario.getRequest().getUrl(),
-                        firstScenario.getRequest().getUrlPath())));
+            + Urls.urlPatternToPathParts(firstScenario.getRequest().getUrlMatcher());
 
     return IntStream.range(1, stubMappings.size() + 1)
         .mapToObj(

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractor.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractor.java
@@ -15,14 +15,15 @@
  */
 package com.github.tomakehurst.wiremock.recording;
 
-import static com.github.tomakehurst.wiremock.common.ParameterUtils.getFirstNonNull;
-
 import com.github.tomakehurst.wiremock.common.*;
 import com.github.tomakehurst.wiremock.common.filemaker.FilenameMaker;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.store.BlobStore;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import java.util.List;
+import org.wiremock.url.Path;
 import org.wiremock.url.PathAndQuery;
+import org.wiremock.url.Segment;
 
 class SnapshotStubMappingBodyExtractor {
   private final BlobStore filesBlobStore;
@@ -40,10 +41,10 @@ class SnapshotStubMappingBodyExtractor {
   StubMapping extractInPlace(StubMapping stubMapping) {
     byte[] body = stubMapping.getResponse().getByteBody();
     HttpHeaders responseHeaders = stubMapping.getResponse().getHeaders();
-    PathAndQuery pathAndQuery =
-        PathAndQuery.parse(
-            getFirstNonNull(
-                stubMapping.getRequest().getUrl(), stubMapping.getRequest().getUrlPath()));
+    List<String> pathSegments =
+        Urls.urlPatternToPathSegments(stubMapping.getRequest().getUrlMatcher());
+    Path path = Path.of(pathSegments.stream().map(Segment::encode)).toAbsolutePath();
+    PathAndQuery pathAndQuery = PathAndQuery.of(path);
     String extension =
         ContentTypes.determineFileExtension(
             pathAndQuery, responseHeaders.getContentTypeHeader(), body);


### PR DESCRIPTION
ScenarioProcessor and SnapshotStubMappingBodyExtractor both derived a request's path via getUrl()/getUrlPath(), which only return a value for urlEqualTo/urlPathEqualTo matchers. Any other UrlPattern (e.g. one set by a recording StubMappingTransformer via urlPathTemplate, urlMatching, etc.) made both return null, causing an NPE during snapshot recording.

Urls.urlPatternToPathSegments() normalises any UrlPattern generically by parsing its own toString() description instead of switching on concrete matcher classes, so it keeps working if new UrlPattern subtypes are added.

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
