### PR TITLE
build: upgrade commons-fileupload 1.6.0 to commons-fileupload2 2.0.0-M5 for module path compatibility [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,7 +100,7 @@ handlebars = { module = "com.github.jknack:handlebars", version.ref = "handlebar
 handlebars-helpers = { module = "com.github.jknack:handlebars-helpers", version.ref = "handlebars" }
 
 # File upload
-commons-fileupload = { module = "commons-fileupload:commons-fileupload", version = "1.6.0" }
+commons-fileupload2 = { module = "org.apache.commons:commons-fileupload2", version = "2.0.0-M5" }
 
 # JSON Schema
 json-schema-validator = { module = "com.networknt:json-schema-validator", version = "2.0.1" }

--- a/wiremock-core/build.gradle.kts
+++ b/wiremock-core/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 apply(from = "buildSchema.gradle")
 
 dependencies {
-    api(libs.commons.fileupload)
+    api(libs.commons.fileupload2)
     api(libs.guava) {
         exclude(group = "com.google.code.findbugs", module = "jsr305")
     }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileItemPartAdapter.java
@@ -23,8 +23,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileItemHeaders;
+import org.apache.commons.fileupload2.FileItem;
+import org.apache.commons.fileupload2.FileItemHeaders;
 
 public class FileItemPartAdapter implements Request.Part {
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileUpload.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/multipart/FileUpload.java
@@ -27,30 +27,30 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileItemFactory;
-import org.apache.commons.fileupload.FileItemHeaders;
-import org.apache.commons.fileupload.FileItemIterator;
-import org.apache.commons.fileupload.FileItemStream;
-import org.apache.commons.fileupload.FileUploadBase;
-import org.apache.commons.fileupload.FileUploadBase.FileSizeLimitExceededException;
-import org.apache.commons.fileupload.FileUploadBase.FileUploadIOException;
-import org.apache.commons.fileupload.FileUploadBase.IOFileUploadException;
-import org.apache.commons.fileupload.FileUploadBase.InvalidContentTypeException;
-import org.apache.commons.fileupload.FileUploadBase.SizeLimitExceededException;
-import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.MultipartStream;
-import org.apache.commons.fileupload.ParameterParser;
-import org.apache.commons.fileupload.RequestContext;
-import org.apache.commons.fileupload.UploadContext;
-import org.apache.commons.fileupload.util.Closeable;
-import org.apache.commons.fileupload.util.FileItemHeadersImpl;
-import org.apache.commons.fileupload.util.LimitedInputStream;
-import org.apache.commons.fileupload.util.Streams;
+import org.apache.commons.fileupload2.FileItem;
+import org.apache.commons.fileupload2.FileItemFactory;
+import org.apache.commons.fileupload2.FileItemHeaders;
+import org.apache.commons.fileupload2.FileItemIterator;
+import org.apache.commons.fileupload2.FileItemStream;
+import org.apache.commons.fileupload2.FileUploadBase;
+import org.apache.commons.fileupload2.FileUploadBase.FileSizeLimitExceededException;
+import org.apache.commons.fileupload2.FileUploadBase.FileUploadIOException;
+import org.apache.commons.fileupload2.FileUploadBase.IOFileUploadException;
+import org.apache.commons.fileupload2.FileUploadBase.InvalidContentTypeException;
+import org.apache.commons.fileupload2.FileUploadBase.SizeLimitExceededException;
+import org.apache.commons.fileupload2.FileUploadException;
+import org.apache.commons.fileupload2.MultipartStream;
+import org.apache.commons.fileupload2.ParameterParser;
+import org.apache.commons.fileupload2.RequestContext;
+import org.apache.commons.fileupload2.UploadContext;
+import org.apache.commons.fileupload2.util.Closeable;
+import org.apache.commons.fileupload2.util.FileItemHeadersImpl;
+import org.apache.commons.fileupload2.util.LimitedInputStream;
+import org.apache.commons.fileupload2.util.Streams;
 
 /**
- * The implementation is largely ported from {@link org.apache.commons.fileupload.FileUpload} and
- * {@link org.apache.commons.fileupload.FileUploadBase} to support 'jakarta.servlet' instead of
+ * The implementation is largely ported from {@link org.apache.commons.fileupload2.FileUpload} and
+ * {@link org.apache.commons.fileupload2.FileUploadBase} to support 'jakarta.servlet' instead of
  * 'javax.servlet'. The standard support of multipart content type by Jetty in limited to
  * 'multipart/form-data', so 'multipart/mixed' and 'multipart/related' are not recognized and parsed
  * properly. To preserve backward compatibility and support wider range of multipart content,

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/multipart/PartParser.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/multipart/PartParser.java
@@ -28,11 +28,11 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileItemFactory;
-import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.UploadContext;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
+import org.apache.commons.fileupload2.FileItem;
+import org.apache.commons.fileupload2.FileItemFactory;
+import org.apache.commons.fileupload2.FileUploadException;
+import org.apache.commons.fileupload2.UploadContext;
+import org.apache.commons.fileupload2.disk.DiskFileItemFactory;
 
 public class PartParser {
 


### PR DESCRIPTION
## Description

Upgrades `commons-fileupload:1.6.0` to `commons-fileupload2:2.0.0-M5` to fix module path compatibility.

commons-fileupload 1.6 adds a `module-info.class` file that references retired Java EE module names (`javax.servlet`), making it impossible to use as a module on the module path. commons-fileupload2 resolves this by using the `jakarta.servlet` namespace.

### Changes

1. **`gradle/libs.versions.toml`**: Updated dependency from `commons-fileupload:commons-fileupload:1.6.0` to `org.apache.commons:commons-fileupload2:2.0.0-M5`
2. **`PartParser.java`, `FileItemPartAdapter.java`, `FileUpload.java`**: Updated all imports from `org.apache.commons.fileupload` to `org.apache.commons.fileupload2`

### Related issue

Fixes #3559
