### PR TITLE
fix: replace Java 9 newDefaultInstance() with newInstance() for Android compatibility

### DIFF
--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/xml/Xml.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/common/xml/Xml.java
@@ -48,8 +48,8 @@ public class Xml {
 
   public static void optimizeFactoriesLoading() {
     try {
-      String transformerFactoryImpl = TransformerFactory.newDefaultInstance().getClass().getName();
-      String xPathFactoryImpl = XPathFactory.newDefaultInstance().getClass().getName();
+      String transformerFactoryImpl = TransformerFactory.newInstance().getClass().getName();
+      String xPathFactoryImpl = XPathFactory.newInstance().getClass().getName();
 
       System.setProperty(TransformerFactory.class.getName(), transformerFactoryImpl);
       System.setProperty(
@@ -97,7 +97,7 @@ public class Xml {
               .getDeclaredConstructor()
               .newInstance();
     } catch (Exception e) {
-      transformerFactory = TransformerFactory.newDefaultInstance();
+      transformerFactory = TransformerFactory.newInstance();
     }
     transformerFactory.setAttribute("indent-number", 2);
     transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
@@ -148,7 +148,7 @@ public class Xml {
           new BuilderPerThreadDocumentBuilderFactory(
               new SilentErrorDocumentBuilderFactory(
                   new SkipResolvingEntitiesDocumentBuilderFactory(
-                      DocumentBuilderFactory.newDefaultInstance())));
+                      DocumentBuilderFactory.newInstance())));
       dbf.setFeature("http://xml.org/sax/features/validation", false);
       dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false);
       dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelper.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/FormatXmlHelper.java
@@ -65,7 +65,7 @@ public class FormatXmlHelper extends AbstractFormattingHelper {
   private final TransformerFactory transformerFactory;
 
   public FormatXmlHelper() {
-    TransformerFactory factory = TransformerFactory.newDefaultInstance();
+    TransformerFactory factory = TransformerFactory.newInstance();
     factory.setAttribute("indent-number", 2);
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
     factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");


### PR DESCRIPTION
Fixes #3568

`DocumentBuilderFactory.newDefaultInstance()`, `TransformerFactory.newDefaultInstance()`, and `XPathFactory.newDefaultInstance()` are Java 9+ APIs. Android's libcore does not have these methods, causing a `NoSuchMethodError` at runtime.

Replace all `newDefaultInstance()` calls with `newInstance()`, which is available since Java 1.4 and on Android.

Changes:
- `Xml.java`: 4 replacements (DocumentBuilderFactory, TransformerFactory x2, XPathFactory)
- `FormatXmlHelper.java`: 1 replacement (TransformerFactory)