### PR TITLE
Fix toJson helper returning empty string for null values

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ToJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ToJsonHelperTest.java
@@ -43,7 +43,7 @@ public class ToJsonHelperTest extends HandlebarsHelperTestBase {
     ResponseDefinition responseDefinition =
         transform(transformer, mockRequest(), aResponse().withBody(responseTemplate));
 
-    assertThat(responseDefinition.getBody(), is(""));
+    assertThat(responseDefinition.getBody(), is("null"));
   }
 
   @Test

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ToJsonHelper.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ToJsonHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Thomas Akehurst
+ * Copyright (C) 2024-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ class ToJsonHelper extends HandlebarsHelper<Object> {
   @Override
   public String apply(Object obj, Options options) {
     if (obj == null) {
-      return "";
+      return "null";
     } else {
       return Json.write(obj);
     }


### PR DESCRIPTION
## Summary
`toJson` was returning an empty string for null inputs, which produces invalid JSON when the helper is embedded in a templated response body.

This change returns the JSON literal `null` instead, matching common JSON serializers and keeping generated responses valid.

## Changes
- `ToJsonHelper.apply(...)`: return `"null"` when the value is null
- Update `ToJsonHelperTest.convertNullToJson` to expect `null`
- Existing non-null cases (array, string, map, boolean, number) remain covered by the same test class

Fixes #3282

## Test plan
- [ ] `ToJsonHelperTest` passes, including null → `null`
- [ ] Non-null `toJson` outputs are unchanged