### PR TITLE
fix: allow response header values to be string arrays in OpenAPI schema

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionSchemaValidityTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionSchemaValidityTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.networknt.schema.Error;
+import com.networknt.schema.InputFormat;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.resource.ClasspathResourceLoader;
+import java.util.List;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ResponseDefinitionSchemaValidityTest {
+
+  static Schema schema;
+
+  @BeforeAll
+  static void init() {
+    SchemaRegistry schemaRegistry =
+        SchemaRegistry.withDefaultDialect(
+            WireMock.JsonSchemaVersion.V202012.toVersionFlag(),
+            builder ->
+                builder.resourceLoaders(
+                    loaders -> loaders.add(ClasspathResourceLoader.getInstance())));
+
+    schema =
+        schemaRegistry.getSchema(
+            SchemaLocation.of("classpath:/swagger/schemas/response-definition.yaml"));
+  }
+
+  @Test
+  void headersAcceptStringValues() {
+    String json = "{\"status\": 200, \"headers\": { \"Content-Type\": \"application/json\" }}";
+    assertThat(validate(json), empty());
+  }
+
+  @Test
+  void headersAcceptArrayValues() {
+    String json = "{\"status\": 200, \"headers\": { \"Set-Cookie\": [\"a=b\", \"c=d\"] }}";
+    assertThat(validate(json), empty());
+  }
+
+  @Test
+  void headersRejectNonStringArrayItems() {
+    String json = "{\"status\": 200, \"headers\": { \"Set-Cookie\": [1, 2] }}";
+    assertThat(validate(json), Matchers.not(empty()));
+  }
+
+  private static List<Error> validate(String json) {
+    return schema.validate(json, InputFormat.JSON);
+  }
+}

--- a/wiremock-core/src/main/resources/swagger/schemas/response-definition.yaml
+++ b/wiremock-core/src/main/resources/swagger/schemas/response-definition.yaml
@@ -12,7 +12,11 @@ allOf:
         type: object
         description: Map of response headers to send
         additionalProperties:
-          type: string
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
       additionalProxyRequestHeaders:
         type: object
         description: Extra request headers to send when proxying to another host.


### PR DESCRIPTION
## Summary
The admin OpenAPI `response-definition` schema only allowed header values to be strings, while the runtime deserializer and docs already accept string arrays (e.g. multi-valued `Set-Cookie`).

## Changes
- Update `response-definition.yaml` so `headers` additionalProperties are `string | string[]`
- Add schema validity tests for string, string-array, and invalid array item cases

Fixes #3185

## Test plan
- [x] `./gradlew :test --tests com.github.tomakehurst.wiremock.ResponseDefinitionSchemaValidityTest`