### PR TITLE
Fix response header array support in API schemas

### DIFF
--- a/schemas/wiremock-message-stub-mapping-or-mappings.json
+++ b/schemas/wiremock-message-stub-mapping-or-mappings.json
@@ -1475,7 +1475,14 @@
             "type" : "object",
             "description" : "Map of response headers to send",
             "additionalProperties" : {
-              "type" : "string"
+              "oneOf" : [ {
+                "type" : "string"
+              }, {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              } ]
             }
           },
           "additionalProxyRequestHeaders" : {

--- a/schemas/wiremock-stub-mapping-or-mappings.json
+++ b/schemas/wiremock-stub-mapping-or-mappings.json
@@ -1475,7 +1475,14 @@
             "type" : "object",
             "description" : "Map of response headers to send",
             "additionalProperties" : {
-              "type" : "string"
+              "oneOf" : [ {
+                "type" : "string"
+              }, {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              } ]
             }
           },
           "additionalProxyRequestHeaders" : {

--- a/src/test/java/com/github/tomakehurst/wiremock/schema/WireMockStubMappingJsonSchemaRegressionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/schema/WireMockStubMappingJsonSchemaRegressionTest.java
@@ -19,6 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -33,6 +34,8 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class WireMockStubMappingJsonSchemaRegressionTest {
 
@@ -79,6 +82,28 @@ class WireMockStubMappingJsonSchemaRegressionTest {
               + " has been updated - compare it with the previous version, and if you are happy with the changes commit them.");
       throw e;
     }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"\"text/plain\"", "[\"a=1\", \"b=2\"]", "[]"})
+  void acceptsStringAndArrayResponseHeaders(String headerValue) {
+    assertThat(responseHeaderSchema().validate(Json.node(headerValue)), is(empty()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"123", "true", "null", "{}", "[123]", "[\"a=1\", false]"})
+  void rejectsInvalidResponseHeaders(String headerValue) {
+    assertThat(responseHeaderSchema().validate(Json.node(headerValue)), is(not(empty())));
+  }
+
+  private Schema responseHeaderSchema() {
+    JsonNode schemaJson = Json.node(loadResourceAsString(SCHEMA_PATH));
+    JsonNode headerSchema =
+        schemaJson.at("/definitions/response-definition/allOf/0/properties/headers");
+    SpecificationVersion version =
+        SpecificationVersion.fromDialectId(schemaJson.get("$schema").textValue()).orElseThrow();
+    return SchemaRegistry.withDefaultDialect(version)
+        .getSchema(headerSchema.get("additionalProperties"));
   }
 
   private String loadResourceAsString(String resourcePath) {

--- a/wiremock-core/src/main/resources/swagger/schemas/response-definition.yaml
+++ b/wiremock-core/src/main/resources/swagger/schemas/response-definition.yaml
@@ -12,7 +12,11 @@ allOf:
         type: object
         description: Map of response headers to send
         additionalProperties:
-          type: string
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
       additionalProxyRequestHeaders:
         type: object
         description: Extra request headers to send when proxying to another host.

--- a/wiremock-core/src/main/resources/swagger/wiremock-admin-api.json
+++ b/wiremock-core/src/main/resources/swagger/wiremock-admin-api.json
@@ -3619,7 +3619,17 @@
                 "type": "object",
                 "description": "Map of response headers to send",
                 "additionalProperties": {
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
                 }
               },
               "additionalProxyRequestHeaders": {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
