### PR TITLE
Clear the request cache when request handling fails

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandlerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2011-2026 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.http;
+
+import static com.github.tomakehurst.wiremock.common.DataTruncationSettings.NO_TRUNCATION;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.github.tomakehurst.wiremock.common.RequestCache;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AbstractRequestHandlerTest {
+
+  private final ResponseRenderer renderer = mock(ResponseRenderer.class);
+  private final HttpResponder responder = mock(HttpResponder.class);
+
+  @BeforeEach
+  void resetCache() {
+    RequestCache.onRequestEnd();
+    when(renderer.render(any(ServeEvent.class))).thenReturn(Response.response().status(200).build());
+  }
+
+  @AfterEach
+  void clearCache() {
+    RequestCache.onRequestEnd();
+  }
+
+  @Test
+  void clearsCacheAfterSuccessfulRequest() {
+    RequestCache cache = RequestCache.getCurrent();
+
+    handler().handle(mockRequest(), responder, null);
+
+    assertNotSame(cache, RequestCache.getCurrent());
+  }
+
+  @Test
+  void clearsCacheWhenRequestHandlingFails() {
+    RuntimeException failure = new RuntimeException("Request handling failed");
+    AbstractRequestHandler handler =
+        new AbstractRequestHandler(renderer, List.of(), List.of(), NO_TRUNCATION) {
+          @Override
+          protected ServeEvent handleRequest(ServeEvent serveEvent) {
+            RequestCache.getCurrent();
+            throw failure;
+          }
+        };
+    RequestCache cache = RequestCache.getCurrent();
+
+    assertSame(
+        failure,
+        assertThrows(RuntimeException.class, () -> handler.handle(mockRequest(), responder, null)));
+    assertNotSame(cache, RequestCache.getCurrent());
+  }
+
+  @Test
+  void clearsCacheWhenRenderingFails() {
+    RuntimeException failure = new RuntimeException("Rendering failed");
+    when(renderer.render(any(ServeEvent.class))).thenThrow(failure);
+    RequestCache cache = RequestCache.getCurrent();
+
+    assertSame(
+        failure,
+        assertThrows(
+            RuntimeException.class, () -> handler().handle(mockRequest(), responder, null)));
+    assertNotSame(cache, RequestCache.getCurrent());
+  }
+
+  @Test
+  void clearsCacheWhenSendingResponseFails() {
+    RuntimeException failure = new RuntimeException("Sending failed");
+    RequestCache cache = RequestCache.getCurrent();
+    HttpResponder failingResponder =
+        (request, response, attributes) -> {
+          assertSame(cache, RequestCache.getCurrent());
+          throw failure;
+        };
+
+    assertSame(
+        failure,
+        assertThrows(
+            RuntimeException.class, () -> handler().handle(mockRequest(), failingResponder, null)));
+    assertNotSame(cache, RequestCache.getCurrent());
+  }
+
+  @Test
+  void clearsCacheWhenAfterResponseCallbackFails() {
+    RuntimeException failure = new RuntimeException("Callback failed");
+    RequestCache cache = RequestCache.getCurrent();
+    AbstractRequestHandler handler =
+        new AbstractRequestHandler(renderer, List.of(), List.of(), NO_TRUNCATION) {
+          @Override
+          protected ServeEvent handleRequest(ServeEvent serveEvent) {
+            return serveEvent.withResponseDefinition(ResponseDefinition.ok());
+          }
+
+          @Override
+          protected void afterResponseSent(ServeEvent serveEvent, Response response) {
+            assertSame(cache, RequestCache.getCurrent());
+            throw failure;
+          }
+        };
+
+    assertSame(
+        failure,
+        assertThrows(RuntimeException.class, () -> handler.handle(mockRequest(), responder, null)));
+    assertNotSame(cache, RequestCache.getCurrent());
+  }
+
+  private AbstractRequestHandler handler() {
+    return new AbstractRequestHandler(renderer, List.of(), List.of(), NO_TRUNCATION) {
+      @Override
+      protected ServeEvent handleRequest(ServeEvent serveEvent) {
+        return serveEvent.withResponseDefinition(ResponseDefinition.ok());
+      }
+    };
+  }
+}

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
@@ -55,55 +55,57 @@ public abstract class AbstractRequestHandler implements RequestHandler, RequestE
 
   @Override
   public void handle(Request request, HttpResponder httpResponder, ServeEvent originalServeEvent) {
-    ServeEvent serveEvent = ServeEvent.of(request);
-    Request processedRequest = request;
+    try {
+      ServeEvent serveEvent = ServeEvent.of(request);
+      Request processedRequest = request;
 
-    if (filterProcessor.hasAnyFilters()) {
-      RequestFilterAction requestFilterAction = filterProcessor.processFilters(request, serveEvent);
+      if (filterProcessor.hasAnyFilters()) {
+        RequestFilterAction requestFilterAction = filterProcessor.processFilters(request, serveEvent);
 
-      if (requestFilterAction instanceof ContinueAction continueAction) {
-        processedRequest = continueAction.getRequest();
-        serveEvent = handleRequest(serveEvent.replaceRequest(processedRequest));
+        if (requestFilterAction instanceof ContinueAction continueAction) {
+          processedRequest = continueAction.getRequest();
+          serveEvent = handleRequest(serveEvent.replaceRequest(processedRequest));
+        } else {
+          serveEvent =
+              serveEvent.withResponseDefinition(
+                  ((StopAction) requestFilterAction).getResponseDefinition());
+        }
       } else {
-        serveEvent =
-            serveEvent.withResponseDefinition(
-                ((StopAction) requestFilterAction).getResponseDefinition());
+        serveEvent = handleRequest(serveEvent);
       }
-    } else {
-      serveEvent = handleRequest(serveEvent);
+
+      ResponseDefinition responseDefinition = serveEvent.getResponseDefinition();
+      Response response = responseRenderer.render(serveEvent);
+      response = Response.Builder.like(response).protocol(request.getProtocol()).build();
+      serveEvent = serveEvent.complete(response, dataTruncationSettings);
+
+      if (logRequests()) {
+        notifier()
+            .info(
+                "Request received:\n"
+                    + formatRequest(request)
+                    + "\n\nMatched response definition:\n"
+                    + responseDefinition
+                    + "\n\nResponse:\n"
+                    + response);
+      }
+
+      for (RequestListener listener : listeners) {
+        listener.requestReceived(request, response);
+      }
+
+      beforeResponseSent(serveEvent, response);
+
+      serveEvent.beforeSend();
+
+      Map<String, Object> attributes = Map.of(ORIGINAL_SERVE_EVENT_KEY, serveEvent);
+      httpResponder.respond(request, response, attributes);
+
+      serveEvent.afterSend();
+      afterResponseSent(serveEvent, response);
+    } finally {
+      RequestCache.onRequestEnd();
     }
-
-    ResponseDefinition responseDefinition = serveEvent.getResponseDefinition();
-    Response response = responseRenderer.render(serveEvent);
-    response = Response.Builder.like(response).protocol(request.getProtocol()).build();
-    serveEvent = serveEvent.complete(response, dataTruncationSettings);
-
-    if (logRequests()) {
-      notifier()
-          .info(
-              "Request received:\n"
-                  + formatRequest(request)
-                  + "\n\nMatched response definition:\n"
-                  + responseDefinition
-                  + "\n\nResponse:\n"
-                  + response);
-    }
-
-    for (RequestListener listener : listeners) {
-      listener.requestReceived(request, response);
-    }
-
-    beforeResponseSent(serveEvent, response);
-
-    serveEvent.beforeSend();
-
-    Map<String, Object> attributes = Map.of(ORIGINAL_SERVE_EVENT_KEY, serveEvent);
-    httpResponder.respond(request, response, attributes);
-
-    serveEvent.afterSend();
-    afterResponseSent(serveEvent, response);
-
-    RequestCache.onRequestEnd();
   }
 
   protected String formatRequest(Request request) {


### PR DESCRIPTION
## Problem

`AbstractRequestHandler.handle()` calls `RequestCache.onRequestEnd()` only when processing completes normally.

If request handling, response rendering, sending, or an after-response callback throws, cleanup is skipped. Since `RequestCache` uses a `ThreadLocal`, the cache remains attached to the worker thread. A subsequent request on that thread can reuse the previous cache, and cached objects remain referenced.

This was identified through code inspection, not a reported production incident.

## Change

Move cache cleanup into a `finally` block around the existing request lifecycle. This ensures cleanup happens on both success and failure while preserving processing order and allowing the original exception to propagate.

## Validation

Added five regression tests covering successful completion and failures during handling, rendering, sending, and the after-response callback.

The Java tests and formatting checks have **not been run**. Source comparison confirmed the existing processing logic is unchanged apart from the cleanup wrapper, and `git diff --check` passed.
