### PR TITLE
Fix additional proxy User-Agent headers

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
@@ -400,6 +400,28 @@ public class ProxyAcceptanceTest {
   }
 
   @Test
+  public void additionalProxyRequestUserAgentOverridesTheOriginalRequestUserAgent() {
+    initWithDefaultConfig();
+
+    target.register(
+        get(urlEqualTo("/additional-user-agent")).willReturn(aResponse().withStatus(200)));
+    proxy.register(
+        get(urlEqualTo("/additional-user-agent"))
+            .willReturn(
+                aResponse()
+                    .proxiedFrom(targetServiceBaseUrl)
+                    .withAdditionalRequestHeader("User-Agent", "mapping-user-agent")));
+
+    testClient.get("/additional-user-agent", withHeader("User-Agent", "original-user-agent"));
+
+    List<LoggedRequest> proxiedRequests =
+        target.find(getRequestedFor(urlEqualTo("/additional-user-agent")));
+    assertThat(proxiedRequests, hasSize(1));
+    assertThat(
+        proxiedRequests.get(0).header("User-Agent").values(), contains("mapping-user-agent"));
+  }
+
+  @Test
   public void proxiesPatchRequestsWithBody() {
     initWithDefaultConfig();
 

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -271,6 +271,7 @@ public class WireMockApp implements StubServer, Admin {
                 settingsStore,
                 options.getStubCorsEnabled(),
                 options.getSupportedProxyEncodings(),
+                options.shouldPreserveUserAgentProxyHeader(),
                 reverseProxyClient,
                 forwardProxyClient),
             List.copyOf(extensions.ofType(ResponseTransformer.class).values()),

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -41,6 +41,7 @@ public class ProxyResponseRenderer implements ResponseRenderer {
   private final SettingsStore settingsStore;
   private final boolean stubCorsEnabled;
   private final Set<String> supportedEncodings;
+  private final boolean preserveUserAgentProxyHeader;
 
   @SuppressWarnings("unused")
   public ProxyResponseRenderer(
@@ -57,6 +58,7 @@ public class ProxyResponseRenderer implements ResponseRenderer {
         settingsStore,
         stubCorsEnabled,
         null,
+        false,
         reverseProxyClient,
         forwardProxyClient);
   }
@@ -70,11 +72,33 @@ public class ProxyResponseRenderer implements ResponseRenderer {
       HttpClient reverseProxyClient,
       HttpClient forwardProxyClient) {
 
+    this(
+        preserveHostHeader,
+        hostHeaderValue,
+        settingsStore,
+        stubCorsEnabled,
+        supportedEncodings,
+        false,
+        reverseProxyClient,
+        forwardProxyClient);
+  }
+
+  public ProxyResponseRenderer(
+      boolean preserveHostHeader,
+      String hostHeaderValue,
+      SettingsStore settingsStore,
+      boolean stubCorsEnabled,
+      Set<String> supportedEncodings,
+      boolean preserveUserAgentProxyHeader,
+      HttpClient reverseProxyClient,
+      HttpClient forwardProxyClient) {
+
     this.settingsStore = settingsStore;
     this.preserveHostHeader = preserveHostHeader;
     this.hostHeaderValue = hostHeaderValue;
     this.stubCorsEnabled = stubCorsEnabled;
     this.supportedEncodings = supportedEncodings;
+    this.preserveUserAgentProxyHeader = preserveUserAgentProxyHeader;
 
     this.forwardProxyClient = forwardProxyClient;
     this.reverseProxyClient = reverseProxyClient;
@@ -224,6 +248,11 @@ public class ProxyResponseRenderer implements ResponseRenderer {
             requestBuilder, response, key, originalRequest);
         case HttpClient.ACCEPT_ENCODING_HEADER -> addAcceptEncodingHeader(
             requestBuilder, key, originalRequest);
+        case HttpClient.USER_AGENT -> {
+          if (preserveUserAgentProxyHeader) {
+            copyHeader(requestBuilder, key, originalRequest);
+          }
+        }
         default -> copyHeader(requestBuilder, key, originalRequest);
       }
     }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/client/HttpClient.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/http/client/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Thomas Akehurst
+ * Copyright (C) 2023-2026 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ public interface HttpClient {
   String CONNECTION = "connection";
   String UPGRADE = "upgrade";
   List<String> FORBIDDEN_REQUEST_HEADERS =
-      List.of(TRANSFER_ENCODING, CONTENT_LENGTH, CONNECTION, UPGRADE, USER_AGENT);
+      List.of(TRANSFER_ENCODING, CONTENT_LENGTH, CONNECTION, UPGRADE);
   String HOST_HEADER = "host";
   String ACCEPT_ENCODING_HEADER = "accept-encoding";
 

--- a/wiremock-httpclient-apache5/src/main/java/com/github/tomakehurst/wiremock/http/client/apache5/ApacheBackedHttpClient.java
+++ b/wiremock-httpclient-apache5/src/main/java/com/github/tomakehurst/wiremock/http/client/apache5/ApacheBackedHttpClient.java
@@ -46,22 +46,23 @@ import org.wiremock.url.AbsoluteUrl;
 public class ApacheBackedHttpClient implements HttpClient {
 
   private final CloseableHttpClient apacheHttpClient;
-  private final boolean preserveUserAgentProxyHeader;
+
+  public ApacheBackedHttpClient(CloseableHttpClient apacheHttpClient) {
+    this.apacheHttpClient = apacheHttpClient;
+  }
 
   public ApacheBackedHttpClient(
       CloseableHttpClient apacheHttpClient, boolean preserveUserAgentProxyHeader) {
-    this.apacheHttpClient = apacheHttpClient;
-    this.preserveUserAgentProxyHeader = preserveUserAgentProxyHeader;
+    this(apacheHttpClient);
   }
 
   @Override
   public Response execute(Request request) throws IOException {
-    ClassicHttpRequest apacheRequest = createApacheRequest(request, preserveUserAgentProxyHeader);
+    ClassicHttpRequest apacheRequest = createApacheRequest(request);
     return apacheHttpClient.execute(apacheRequest, ApacheBackedHttpClient::toWireMockHttpResponse);
   }
 
-  private static ClassicHttpRequest createApacheRequest(
-      Request request, boolean preserveUserAgentProxyHeader) {
+  private static ClassicHttpRequest createApacheRequest(Request request) {
     ContentType contentType =
         request.contentTypeHeader().isPresent()
             ? ContentType.parse(request.contentTypeHeader().firstValue())
@@ -76,9 +77,7 @@ public class ApacheBackedHttpClient implements HttpClient {
                     .filter(
                         header ->
                             !FORBIDDEN_REQUEST_HEADERS.contains(
-                                    header.key().toLowerCase(Locale.ROOT))
-                                || (preserveUserAgentProxyHeader
-                                    && header.key().equalsIgnoreCase(USER_AGENT)))
+                                header.key().toLowerCase(Locale.ROOT)))
                     .flatMap(
                         header ->
                             header.values().stream()

--- a/wiremock-httpclient-apache5/src/main/java/com/github/tomakehurst/wiremock/http/client/apache5/ApacheHttpClientFactory.java
+++ b/wiremock-httpclient-apache5/src/main/java/com/github/tomakehurst/wiremock/http/client/apache5/ApacheHttpClientFactory.java
@@ -49,7 +49,7 @@ public class ApacheHttpClientFactory implements HttpClientFactory {
             options.getDisableConnectionReuse(),
             null);
 
-    return new ApacheBackedHttpClient(apacheClient, options.shouldPreserveUserAgentProxyHeader());
+    return new ApacheBackedHttpClient(apacheClient);
   }
 
   public static CloseableHttpClient createClient() {


### PR DESCRIPTION
## Summary
- Preserve a mapping-configured `additionalProxyRequestHeaders.User-Agent` when proxying through the Apache HTTP client.
- Keep the default behavior unchanged: an original client `User-Agent` is forwarded only when `preserveUserAgentProxyHeader` is enabled.

Fixes #2690

## Verification
- `./gradlew :test --tests com.github.tomakehurst.wiremock.ProxyAcceptanceTest.additionalProxyRequestUserAgentOverridesTheOriginalRequestUserAgent --no-daemon --console=plain`
- `./gradlew :wiremock-httpclient-apache5:spotlessJavaCheck :wiremock-core:spotlessJavaCheck :spotlessJavaCheck --no-daemon --console=plain`