### PR TITLE
Honor the configured HTTPS trust store type

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/HttpsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpsAcceptanceTest.java
@@ -32,11 +32,15 @@ import com.github.tomakehurst.wiremock.http.client.apache5.ApacheHttpClientFacto
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.SocketException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.util.Collections;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
@@ -60,6 +64,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class HttpsAcceptanceTest {
 
@@ -112,7 +119,8 @@ class HttpsAcceptanceTest {
         exception
             .getMessage()
             .contains(
-                "Not listening on HTTP port. Either HTTP is not enabled or the WireMock server is stopped."));
+                "Not listening on HTTP port. Either HTTP is not enabled or the WireMock server is"
+                    + " stopped."));
   }
 
   @Test
@@ -259,6 +267,41 @@ class HttpsAcceptanceTest {
 
     assertThat(
         secureContentFor(url("/https-test"), testClientCertPath, TRUST_STORE_PASSWORD),
+        is("HTTPS content"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void acceptsClientCertificateWithDifferentKeyAndTrustStoreTypes(
+      boolean http2TlsDisabled, @TempDir Path tempDir) throws Exception {
+    KeyStore clientStore = readKeyStore(TRUST_STORE_PATH, TRUST_STORE_PASSWORD);
+    KeyStore trustStore = KeyStore.getInstance("JCEKS");
+    trustStore.load(null, TRUST_STORE_PASSWORD.toCharArray());
+    for (String alias : Collections.list(clientStore.aliases())) {
+      trustStore.setCertificateEntry(alias, clientStore.getCertificate(alias));
+    }
+    Path trustStorePath = tempDir.resolve("truststore.jceks");
+    try (OutputStream output = Files.newOutputStream(trustStorePath)) {
+      trustStore.store(output, TRUST_STORE_PASSWORD.toCharArray());
+    }
+
+    wireMockServer =
+        new WireMockServer(
+            wireMockConfig()
+                .dynamicPort()
+                .dynamicHttpsPort()
+                .http2TlsDisabled(http2TlsDisabled)
+                .keystorePath(KEY_STORE_PATH)
+                .keystoreType("JKS")
+                .trustStorePath(trustStorePath.toString())
+                .trustStorePassword(TRUST_STORE_PASSWORD)
+                .trustStoreType("JCEKS")
+                .needClientAuth(true));
+    wireMockServer.start();
+    wireMockServer.stubFor(get("/https-test").willReturn(ok("HTTPS content")));
+
+    assertThat(
+        secureContentFor(url("/https-test"), TRUST_STORE_PATH, TRUST_STORE_PASSWORD),
         is("HTTPS content"));
   }
 

--- a/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/ssl/SslContexts.java
+++ b/wiremock-jetty/src/main/java/com/github/tomakehurst/wiremock/jetty/ssl/SslContexts.java
@@ -68,6 +68,7 @@ public class SslContexts {
     if (httpsSettings.hasTrustStore()) {
       sslContextFactory.setTrustStorePath(httpsSettings.trustStorePath());
       sslContextFactory.setTrustStorePassword(httpsSettings.trustStorePassword());
+      sslContextFactory.setTrustStoreType(httpsSettings.trustStoreType());
     }
     sslContextFactory.setNeedClientAuth(httpsSettings.needClientAuth());
   }


### PR DESCRIPTION
Fixes #1484.

When HTTPS client authentication uses different key-store and trust-store formats, WireMock can fail to start with an invalid key-store format error. `HttpsSettings` carries `trustStoreType`, but the Jetty SSL context only receives the trust-store path and password, leaving Jetty to fall back to the key-store type.

Pass the configured trust-store type through the shared client-authentication setup used by the HTTP/1.1, HTTP/2 and browser-proxy SSL contexts. The acceptance test uses a JKS key store and generates a JCEKS trust store from the existing client certificates, then makes an authenticated HTTPS request with HTTP/2 enabled and disabled. JCEKS makes the missing type reproducible even with JDKs that auto-detect JKS and PKCS12.

Both new cases fail before the production change with `Invalid keystore format` during server startup.

Validation on Windows / Temurin 25: 29 tests, 0 failures, 27 passed and 2 skipped (the existing platform-specific socket-reset test and disabled unused-method rule). Command:

```
./gradlew :test --tests '*HttpsAcceptanceTest' --tests '*HttpsBrowserProxyClientAuthAcceptanceTest' --tests '*Http2DisabledAcceptanceTest'
```

The changed Java files pass Google Java Format 1.17.0, the version configured by the project. The formatter was invoked directly because Spotless cannot locate the Git repository in a linked worktree (and the build disables it there by default).
